### PR TITLE
Add AWS Lambda runtime support

### DIFF
--- a/bin/swaig-test
+++ b/bin/swaig-test
@@ -9,30 +9,264 @@
 #
 # swaig-test — CLI tool for testing SWAIG agent endpoints.
 #
-# Usage:
-#   swaig-test --url http://user:pass@host:port/route --dump-swml
-#   swaig-test --url http://user:pass@host:port/route --list-tools
-#   swaig-test --url http://user:pass@host:port/route --exec tool_name --param key=value
+# Two modes:
+#
+#   (1) URL mode — hit a live agent over HTTP:
+#
+#       swaig-test --url http://user:pass@host:port/route --dump-swml
+#       swaig-test --url http://user:pass@host:port/route --list-tools
+#       swaig-test --url http://user:pass@host:port/route --exec tool_name --param key=value
+#
+#   (2) File mode with serverless simulation — load an agent source file
+#       and route invocations through the platform adapter (no HTTP server):
+#
+#       swaig-test agent.rb --simulate-serverless lambda
+#       swaig-test agent.rb --simulate-serverless lambda --dump-swml
+#       swaig-test agent.rb --simulate-serverless lambda --exec tool_name --param key=value
+#
+#   Only platforms the SDK has actually implemented are accepted. Today
+#   that's `lambda` only; `gcf`, `cgi`, and `azure` are rejected with a
+#   pointer to the phase-9 gap.
 #
 
 require 'net/http'
 require 'uri'
 require 'json'
 require 'optparse'
+require 'base64'
 
 module SwaigTest
+  # Platforms the port has a Phase-9 handler adapter for. Anything else
+  # must be rejected with a clear error so users don't accidentally exercise
+  # the fall-through HTTP path and think the simulator worked.
+  IMPLEMENTED_SERVERLESS_PLATFORMS = %w[lambda].freeze
+
+  # All platforms the porting guide recognises, so the CLI can emit a
+  # helpful "recognised but not implemented" error rather than
+  # "unrecognised value" for the in-progress ones.
+  RECOGNISED_SERVERLESS_PLATFORMS = %w[lambda cgi gcf google_cloud_function azure azure_function].freeze
+
+  # Environment variables the simulator touches. Captured so the simulator
+  # can snapshot and restore them no matter what path the invocation took.
+  LAMBDA_SIMULATION_ENV_VARS = %w[
+    AWS_LAMBDA_FUNCTION_NAME
+    AWS_LAMBDA_FUNCTION_URL
+    AWS_REGION
+    LAMBDA_TASK_ROOT
+    _HANDLER
+    SWML_PROXY_URL_BASE
+  ].freeze
+
+  # Snapshot + restore the env vars a serverless simulation touches, so
+  # tests in the same process (and users who invoke the CLI repeatedly in
+  # a shell session) never inherit leaked state.
+  module RuntimeEnvIsolation
+    def self.snapshot(keys = LAMBDA_SIMULATION_ENV_VARS)
+      keys.each_with_object({}) { |k, h| h[k] = ENV[k] }
+    end
+
+    def self.restore(snapshot)
+      snapshot.each do |k, v|
+        if v.nil?
+          ENV.delete(k)
+        else
+          ENV[k] = v
+        end
+      end
+    end
+  end
+
+  # Serverless platform simulator. Responsible for:
+  #   * setting the mode-detection env vars for the target platform,
+  #   * clearing conflicting env vars (notably SWML_PROXY_URL_BASE),
+  #   * restoring the original environment on deactivate.
+  #
+  # Mirrors signalwire/cli/simulation/mock_env.py's ServerlessSimulator.
+  class ServerlessSimulator
+    LAMBDA_PRESETS = {
+      'AWS_LAMBDA_FUNCTION_NAME' => 'test-agent-function',
+      'LAMBDA_TASK_ROOT'         => '/var/task',
+      'AWS_REGION'               => 'us-east-1',
+      '_HANDLER'                 => 'lambda_function.handler'
+    }.freeze
+
+    attr_reader :platform, :overrides
+
+    def initialize(platform, overrides: {}, verbose: false, io: $stderr)
+      @platform  = platform
+      @overrides = overrides || {}
+      @verbose   = verbose
+      @io        = io
+      @snapshot  = nil
+      @active    = false
+    end
+
+    def activate
+      return if @active
+
+      @snapshot = RuntimeEnvIsolation.snapshot
+
+      # Clear conflicting env vars BEFORE applying presets so that a
+      # SWML_PROXY_URL_BASE set in the outer shell can't override the
+      # platform-derived base URL during the simulation.
+      ENV.delete('SWML_PROXY_URL_BASE')
+
+      preset_for_platform.each { |k, v| ENV[k] = v }
+      @overrides.each { |k, v| ENV[k] = v }
+
+      # Match Python: warn if SWML_PROXY_URL_BASE somehow survived (e.g.
+      # an override re-set it). A live warning here is far cheaper than
+      # silently generating the wrong webhook URLs.
+      if ENV['SWML_PROXY_URL_BASE'] && !ENV['SWML_PROXY_URL_BASE'].empty?
+        @io.puts "WARNING: SWML_PROXY_URL_BASE still set after simulation clear: #{ENV['SWML_PROXY_URL_BASE'].inspect}"
+      end
+
+      @active = true
+
+      return unless @verbose
+
+      @io.puts "Activated #{@platform} environment simulation"
+      preset_for_platform.each_key do |k|
+        @io.puts "  #{k}: #{ENV[k]}"
+      end
+    end
+
+    def deactivate
+      return unless @active
+      RuntimeEnvIsolation.restore(@snapshot) if @snapshot
+      @snapshot = nil
+      @active   = false
+      @io.puts "Deactivated #{@platform} environment simulation" if @verbose
+    end
+
+    # Scope helper so callers can wrap a block in activate/deactivate
+    # without hand-rolling begin/ensure.
+    def with_simulation
+      activate
+      yield self
+    ensure
+      deactivate
+    end
+
+    private
+
+    def preset_for_platform
+      case @platform
+      when 'lambda' then LAMBDA_PRESETS
+      else {}  # unreachable — validated in CLI
+      end
+    end
+  end
+
+  # Dispatches synthetic Lambda Function URL events into a
+  # SignalWire::Serverless::LambdaHandler. Used by --simulate-serverless
+  # lambda to exercise the adapter instead of the HTTP server.
+  class LambdaAdapterDispatcher
+    def initialize(agent)
+      @agent   = agent
+      @handler = SignalWire::Serverless::LambdaHandler.for(agent)
+    end
+
+    # GET the agent's root route and return the response body as a
+    # parsed hash (the SWML document). Raises RuntimeError on non-2xx.
+    def dump_swml
+      route   = @agent.route == '/' ? '/' : @agent.route
+      event   = build_event('GET', route)
+      resp    = @handler.call(event, nil)
+      ensure_success!(resp, "dump-swml GET #{route}")
+      decode_body(resp)
+    end
+
+    # POST to <route>/swaig with a SWAIG invocation. Returns the
+    # response body parsed as a hash.
+    def exec_tool(func_name, params)
+      route = @agent.route == '/' ? '' : @agent.route
+      path  = "#{route}/swaig"
+      body  = JSON.generate(
+        'function' => func_name,
+        'argument' => { 'parsed' => [params || {}] }
+      )
+      auth  = basic_auth_header
+      headers = { 'content-type' => 'application/json' }
+      headers['authorization'] = auth if auth
+
+      event = build_event('POST', path, body: body, headers: headers)
+      resp  = @handler.call(event, nil)
+      ensure_success!(resp, "exec POST #{path}")
+      decode_body(resp)
+    end
+
+    private
+
+    def build_event(method, path, body: nil, headers: nil)
+      base_headers = {
+        'host' => ENV['AWS_LAMBDA_FUNCTION_URL']&.then { |u| URI.parse(u).host } ||
+                  "#{ENV['AWS_LAMBDA_FUNCTION_NAME']}.lambda-url.#{ENV['AWS_REGION']}.on.aws"
+      }
+      base_headers.merge!(headers) if headers
+
+      # Ensure auth is present for authenticated endpoints (SWML, swaig).
+      unless base_headers.key?('authorization') || path == '/health' || path == '/ready'
+        auth = basic_auth_header
+        base_headers['authorization'] = auth if auth
+      end
+
+      event = {
+        'version'        => '2.0',
+        'routeKey'       => '$default',
+        'rawPath'        => path,
+        'rawQueryString' => '',
+        'headers'        => base_headers,
+        'requestContext' => {
+          'http'  => { 'method' => method, 'path' => path, 'protocol' => 'HTTP/1.1' },
+          'stage' => '$default'
+        }
+      }
+      if body
+        event['body']            = body
+        event['isBase64Encoded'] = false
+      end
+      event
+    end
+
+    def basic_auth_header
+      # The agent auto-generates a random password at construction time;
+      # read it back via the public accessor so we can authenticate
+      # ourselves against it.
+      if @agent.respond_to?(:get_basic_auth_credentials)
+        user, pass = @agent.get_basic_auth_credentials
+        return "Basic " + ["#{user}:#{pass}"].pack('m0').chomp if user && pass
+      end
+      nil
+    end
+
+    def ensure_success!(resp, description)
+      status = resp['statusCode'].to_i
+      return if status >= 200 && status < 300
+      raise "Simulator: #{description} returned HTTP #{status}: #{resp['body']}"
+    end
+
+    def decode_body(resp)
+      body = resp['body'].to_s
+      body = Base64.decode64(body) if resp['isBase64Encoded']
+      JSON.parse(body)
+    end
+  end
+
   class CLI
     attr_reader :options
 
     def initialize(argv = ARGV)
       @options = {
-        url: nil,
-        dump_swml: false,
-        list_tools: false,
-        exec: nil,
-        params: {},
-        raw: false,
-        verbose: false
+        url:                 nil,
+        agent_file:          nil,
+        simulate_serverless: nil,
+        dump_swml:           false,
+        list_tools:          false,
+        exec:                nil,
+        params:              {},
+        raw:                 false,
+        verbose:             false
       }
       parse_options(argv)
     end
@@ -40,7 +274,9 @@ module SwaigTest
     def run
       validate_options!
 
-      if @options[:dump_swml]
+      if @options[:simulate_serverless]
+        run_simulated_serverless
+      elsif @options[:dump_swml]
         dump_swml
       elsif @options[:list_tools]
         list_tools
@@ -56,10 +292,15 @@ module SwaigTest
 
     def parse_options(argv)
       parser = OptionParser.new do |opts|
-        opts.banner = "Usage: swaig-test [options]"
+        opts.banner = "Usage: swaig-test [agent_file] [options]"
 
         opts.on("--url URL", "Agent URL with embedded auth (http://user:pass@host:port/route)") do |v|
           @options[:url] = v
+        end
+
+        opts.on("--simulate-serverless PLATFORM",
+                "Simulate the named serverless platform (loads agent file locally). Supported: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}") do |v|
+          @options[:simulate_serverless] = v
         end
 
         opts.on("--dump-swml", "GET SWML document and pretty-print it") do
@@ -77,7 +318,6 @@ module SwaigTest
         opts.on("--param KEY=VALUE", "Set a parameter (repeatable)") do |v|
           key, value = v.split('=', 2)
           if key && value
-            # Try to parse as JSON value (number, bool, etc.)
             @options[:params][key] = parse_param_value(value)
           else
             $stderr.puts "Warning: ignoring malformed --param '#{v}' (expected key=value)"
@@ -98,12 +338,28 @@ module SwaigTest
         end
       end
 
-      parser.parse!(argv)
+      remaining = parser.parse(argv)
+
+      # Any leftover positional argument is treated as an agent source
+      # file path. This is the only way to invoke file mode, so we keep
+      # it outside of validate_options! for clearer error messages.
+      if remaining.length > 1
+        $stderr.puts "Error: at most one positional agent file may be given; got #{remaining.inspect}"
+        exit 1
+      elsif remaining.length == 1
+        @options[:agent_file] = remaining.first
+      end
     end
 
     def validate_options!
+      if @options[:simulate_serverless]
+        validate_simulate_serverless_options!
+        return
+      end
+
+      # Classic URL mode from here down.
       unless @options[:url]
-        $stderr.puts "Error: --url is required"
+        $stderr.puts "Error: --url is required (or pass an agent file with --simulate-serverless PLATFORM)"
         exit 1
       end
 
@@ -113,6 +369,45 @@ module SwaigTest
         exit 1
       elsif actions > 1
         $stderr.puts "Error: specify only one of --dump-swml, --list-tools, or --exec NAME"
+        exit 1
+      end
+    end
+
+    def validate_simulate_serverless_options!
+      platform = @options[:simulate_serverless]
+
+      unless IMPLEMENTED_SERVERLESS_PLATFORMS.include?(platform)
+        if RECOGNISED_SERVERLESS_PLATFORMS.include?(platform)
+          $stderr.puts "Error: --simulate-serverless #{platform.inspect} is not implemented in this SDK yet."
+          $stderr.puts "       Phase 9 (serverless support) has only shipped for: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}."
+          $stderr.puts "       Add the #{platform} handler adapter before enabling it here."
+        else
+          $stderr.puts "Error: unknown serverless platform #{platform.inspect}."
+          $stderr.puts "       Supported: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}."
+        end
+        exit 1
+      end
+
+      unless @options[:agent_file]
+        $stderr.puts "Error: --simulate-serverless requires a positional agent file argument"
+        $stderr.puts "Usage: swaig-test AGENT_FILE --simulate-serverless #{platform} [--dump-swml | --exec NAME]"
+        exit 1
+      end
+
+      unless File.exist?(@options[:agent_file])
+        $stderr.puts "Error: agent file not found: #{@options[:agent_file]}"
+        exit 1
+      end
+
+      # Simulated mode cannot combine with --url (different dispatch paths).
+      if @options[:url]
+        $stderr.puts "Error: --simulate-serverless and --url are mutually exclusive"
+        exit 1
+      end
+
+      actions = [@options[:dump_swml], @options[:list_tools], !!@options[:exec]].count(true)
+      if actions > 1
+        $stderr.puts "Error: specify at most one of --dump-swml, --list-tools, or --exec NAME"
         exit 1
       end
     end
@@ -300,6 +595,81 @@ module SwaigTest
       end
 
       functions
+    end
+
+    # --------------------------------------------------------------
+    # --simulate-serverless ... dispatch
+    # --------------------------------------------------------------
+
+    def run_simulated_serverless
+      require 'signalwire'
+
+      simulator = ServerlessSimulator.new(
+        @options[:simulate_serverless],
+        verbose: @options[:verbose]
+      )
+
+      simulator.with_simulation do
+        agent = load_agent_file(@options[:agent_file])
+        unless agent
+          $stderr.puts "Error: agent file #{@options[:agent_file].inspect} did not expose an AGENT constant (expected SignalWire::AgentBase)."
+          exit 1
+        end
+
+        dispatcher = LambdaAdapterDispatcher.new(agent)
+
+        if @options[:dump_swml]
+          puts format_json(dispatcher.dump_swml)
+        elsif @options[:exec]
+          puts format_json(dispatcher.exec_tool(@options[:exec], @options[:params]))
+        elsif @options[:list_tools]
+          swml = dispatcher.dump_swml
+          render_functions_list(extract_functions(swml))
+        else
+          # No sub-action: render the SWML and print it (matches the porting-guide
+          # "render SWML and exit" default).
+          puts format_json(dispatcher.dump_swml)
+        end
+      end
+    end
+
+    def load_agent_file(path)
+      # Use load rather than require so repeated CLI invocations in the
+      # same process (tests) don't silently no-op.
+      absolute = File.expand_path(path)
+      load(absolute)
+
+      # Preferred convention: the agent file defines a top-level
+      # constant named AGENT. Fall back to any SignalWire::AgentBase
+      # instance at top-level for forgiveness.
+      if Object.const_defined?(:AGENT)
+        candidate = Object.const_get(:AGENT)
+        return candidate if candidate.is_a?(SignalWire::AgentBase)
+      end
+
+      Object.constants.each do |c|
+        next if c == :AGENT
+        value = Object.const_get(c)
+        return value if value.is_a?(SignalWire::AgentBase)
+      end
+
+      nil
+    end
+
+    def render_functions_list(functions)
+      if functions.empty?
+        puts "No SWAIG functions found."
+        return
+      end
+      puts "SWAIG Functions:"
+      puts "-" * 60
+      functions.each do |func|
+        name = func['function'] || '(unnamed)'
+        desc = func['description'] || '(no description)'
+        puts "  #{name}"
+        puts "    #{desc}"
+        puts ""
+      end
     end
   end
 end

--- a/examples/lambda_agent.rb
+++ b/examples/lambda_agent.rb
@@ -1,34 +1,48 @@
 # frozen_string_literal: true
 
-# Example: Serverless-style agent pattern.
+# Example: AWS Lambda-deployed agent.
 #
-# Shows how to create an agent whose Rack app can be exported for use
-# in serverless environments (AWS Lambda via lamby, Cloud Functions,
-# or any Rack-compatible host).
+# This file doubles as:
+#   * A local script you can run directly (`ruby lambda_agent.rb`) — it
+#     boots a WEBrick server the same way every other example does.
+#   * A Lambda deployment entrypoint — bundle the SDK into a Lambda zip,
+#     point the function handler at `lambda_agent.handler`, and AWS will
+#     invoke the bottom of this file.
 #
-# For local testing, simply run this file directly.
+# No code changes are required between the two modes: the SDK auto-detects
+# Lambda via `AWS_LAMBDA_FUNCTION_NAME` / `LAMBDA_TASK_ROOT`, and
+# `SignalWire::Serverless::LambdaHandler` adapts API Gateway / Function
+# URL events to the agent's Rack app.
+#
+# Webhook URLs are derived automatically in this priority order:
+#   1. `SWML_PROXY_URL_BASE`          (any custom domain / proxy)
+#   2. `AWS_LAMBDA_FUNCTION_URL`      (Function URLs, the usual case)
+#   3. `https://{AWS_LAMBDA_FUNCTION_NAME}.lambda-url.{AWS_REGION}.on.aws`
+#
+# In each case the agent's `route:` is appended, so deploying at a
+# non-root route (e.g. `/my-agent`) just works.
 
 require 'signalwire'
 
-agent = SignalWire::AgentBase.new(
+AGENT = SignalWire::AgentBase.new(
   name:  'lambda-agent',
   route: '/'
 )
 
-agent.add_language('name' => 'English', 'code' => 'en-US', 'voice' => 'elevenlabs.rachel')
+AGENT.add_language('name' => 'English', 'code' => 'en-US', 'voice' => 'elevenlabs.rachel')
 
-agent.prompt_add_section(
+AGENT.prompt_add_section(
   'Role',
   'You are a helpful AI assistant running in a serverless environment.'
 )
 
-agent.prompt_add_section('Instructions', nil, bullets: [
+AGENT.prompt_add_section('Instructions', nil, bullets: [
   'Greet users warmly and offer help.',
   'Use the greet_user function when asked to greet someone.',
   'Use the get_time function when asked about the current time.'
 ])
 
-agent.define_tool(
+AGENT.define_tool(
   name:        'greet_user',
   description: 'Greet a user by name',
   parameters:  {
@@ -39,7 +53,7 @@ agent.define_tool(
   SignalWire::Swaig::FunctionResult.new("Hello #{name}! I'm running in serverless mode!")
 end
 
-agent.define_tool(
+AGENT.define_tool(
   name:        'get_time',
   description: 'Get the current time',
   parameters:  {}
@@ -47,12 +61,21 @@ agent.define_tool(
   SignalWire::Swaig::FunctionResult.new("Current time: #{Time.now.iso8601}")
 end
 
-# In a real serverless deployment you would export the Rack app:
-#   APP = agent.rack_app
-# and point your handler at APP.
-#
-# For local testing:
+# ---------------------------------------------------------------------------
+# Lambda entrypoint. AWS invokes `handler(event:, context:)` at the top level
+# of this file. `LambdaHandler.for(agent)` builds a long-lived adapter that
+# translates API Gateway / Function URL events to Rack and back.
+# ---------------------------------------------------------------------------
+HANDLER = SignalWire::Serverless::LambdaHandler.for(AGENT)
+
+def handler(event:, context: nil)
+  HANDLER.call(event, context)
+end
+
+# ---------------------------------------------------------------------------
+# Local development fallback — only runs when this file is the main script.
+# ---------------------------------------------------------------------------
 if __FILE__ == $PROGRAM_NAME
-  puts "Starting lambda-style agent on port #{agent.port}..."
-  agent.run
+  puts "Starting lambda-style agent on port #{AGENT.port}..."
+  AGENT.run
 end

--- a/lib/signalwire.rb
+++ b/lib/signalwire.rb
@@ -2,6 +2,7 @@
 
 require_relative 'signalwire/version'
 require_relative 'signalwire/logging'
+require_relative 'signalwire/runtime'
 require_relative 'signalwire/swml/document'
 require_relative 'signalwire/swml/schema'
 require_relative 'signalwire/swml/service'
@@ -13,6 +14,7 @@ require_relative 'signalwire/skills/skill_base'
 require_relative 'signalwire/skills/skill_manager'
 require_relative 'signalwire/skills/skill_registry'
 require_relative 'signalwire/agent/agent_base'
+require_relative 'signalwire/serverless/lambda_handler'
 
 module SignalWire
   # Top-level convenience: re-export VERSION from version.rb

--- a/lib/signalwire/agent/agent_base.rb
+++ b/lib/signalwire/agent/agent_base.rb
@@ -11,6 +11,7 @@ require 'openssl'
 require 'rack'
 require 'uri'
 require_relative '../logging'
+require_relative '../runtime'
 require_relative '../swml/document'
 require_relative '../swml/schema'
 require_relative '../swml/service'
@@ -1207,12 +1208,49 @@ module SignalWire
       url
     end
 
-    # Compute the base URL (with auth embedded).
+    # Compute the base URL for webhook construction.
+    #
+    # Precedence (matches the Python SDK):
+    #   1. +SWML_PROXY_URL_BASE+ or a call to +manual_set_proxy_url+
+    #      (an explicit override always wins)
+    #   2. AWS Lambda-derived URL when execution mode is +:lambda+
+    #      (either +AWS_LAMBDA_FUNCTION_URL+ or the Function URL built
+    #      from +AWS_LAMBDA_FUNCTION_NAME+ + +AWS_REGION+)
+    #   3. +http://user:pass@host:port+ for local server mode
+    #
+    # This method intentionally returns only the *base* — the agent's
+    # +@route+ is appended by {#_build_webhook_url}. Never bake the
+    # route into the base here, or a non-root agent deployed behind a
+    # proxy will have its mount point silently dropped from webhook
+    # URLs.
     def _base_url
-      return @proxy_url_base if @proxy_url_base && !@proxy_url_base.empty?
+      return @proxy_url_base.chomp('/') if @proxy_url_base && !@proxy_url_base.empty?
+
+      if Runtime.lambda?
+        lambda_base = Runtime.lambda_base_url
+        if lambda_base
+          user, pass = @basic_auth
+          return _embed_auth(lambda_base, user, pass)
+        end
+      end
 
       user, pass = @basic_auth
       "http://#{user}:#{pass}@#{@host}:#{@port}"
+    end
+
+    # Embed basic-auth credentials into +base+ immediately after the
+    # scheme. Returns +base+ untouched when either credential is blank
+    # or the URL already contains an @-delimited userinfo component.
+    def _embed_auth(base, user, pass)
+      return base if user.nil? || user.empty? || pass.nil? || pass.empty?
+
+      uri = URI.parse(base)
+      return base if uri.userinfo && !uri.userinfo.empty?
+
+      uri.userinfo = "#{URI.encode_www_form_component(user)}:#{URI.encode_www_form_component(pass)}"
+      uri.to_s
+    rescue URI::InvalidURIError
+      base
     end
 
     # Normalise tool parameters into JSON-Schema form.

--- a/lib/signalwire/runtime.rb
+++ b/lib/signalwire/runtime.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 SignalWire
+#
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+
+module SignalWire
+  # Runtime environment detection.
+  #
+  # Detects the execution environment (plain server, AWS Lambda, CGI,
+  # Google Cloud Functions, Azure Functions) by inspecting well-known
+  # environment variables set by each platform.
+  #
+  # This is the Ruby counterpart to the Python SDK's
+  # +signalwire.core.logging_config.get_execution_mode+.
+  module Runtime
+    MODES = %i[server lambda cgi google_cloud_function azure_function unknown].freeze
+
+    # Determine the current execution mode.
+    #
+    # Returns one of:
+    # - +:cgi+   - running under a CGI gateway (GATEWAY_INTERFACE is set)
+    # - +:lambda+ - running under AWS Lambda
+    # - +:google_cloud_function+ - Google Cloud Functions / Cloud Run
+    # - +:azure_function+ - Azure Functions
+    # - +:server+ - long-running HTTP server (the default)
+    #
+    # Detection order matters: CGI is checked before Lambda because a
+    # Lambda function invoked through an emulator that also sets
+    # GATEWAY_INTERFACE should still be treated as CGI.
+    #
+    # @return [Symbol] one of the values in {MODES}
+    def self.execution_mode
+      # CGI environment (e.g. Apache mod_cgi)
+      return :cgi if ENV['GATEWAY_INTERFACE'] && !ENV['GATEWAY_INTERFACE'].empty?
+
+      # AWS Lambda
+      if (ENV['AWS_LAMBDA_FUNCTION_NAME'] && !ENV['AWS_LAMBDA_FUNCTION_NAME'].empty?) ||
+         (ENV['LAMBDA_TASK_ROOT'] && !ENV['LAMBDA_TASK_ROOT'].empty?)
+        return :lambda
+      end
+
+      # Google Cloud Functions / Cloud Run
+      if (ENV['FUNCTION_TARGET'] && !ENV['FUNCTION_TARGET'].empty?) ||
+         (ENV['K_SERVICE'] && !ENV['K_SERVICE'].empty?) ||
+         (ENV['GOOGLE_CLOUD_PROJECT'] && !ENV['GOOGLE_CLOUD_PROJECT'].empty?)
+        return :google_cloud_function
+      end
+
+      # Azure Functions
+      if (ENV['AZURE_FUNCTIONS_ENVIRONMENT'] && !ENV['AZURE_FUNCTIONS_ENVIRONMENT'].empty?) ||
+         (ENV['FUNCTIONS_WORKER_RUNTIME'] && !ENV['FUNCTIONS_WORKER_RUNTIME'].empty?) ||
+         (ENV['AzureWebJobsStorage'] && !ENV['AzureWebJobsStorage'].empty?)
+        return :azure_function
+      end
+
+      :server
+    end
+
+    # True when the SDK is running inside AWS Lambda.
+    # @return [Boolean]
+    def self.lambda?
+      execution_mode == :lambda
+    end
+
+    # True when the SDK is running inside any serverless platform.
+    # @return [Boolean]
+    def self.serverless?
+      mode = execution_mode
+      mode == :lambda || mode == :cgi ||
+        mode == :google_cloud_function || mode == :azure_function
+    end
+
+    # Construct the base URL for the current Lambda function.
+    #
+    # Prefers +AWS_LAMBDA_FUNCTION_URL+ when set; otherwise falls back to
+    # the standard Function URL shape built from +AWS_LAMBDA_FUNCTION_NAME+
+    # and +AWS_REGION+. Returns +nil+ when neither signal is present.
+    #
+    # The returned URL never has a trailing slash and never contains a
+    # path component, so callers must append the agent's route themselves.
+    #
+    # @return [String, nil]
+    def self.lambda_base_url
+      explicit = ENV['AWS_LAMBDA_FUNCTION_URL']
+      return explicit.chomp('/') if explicit && !explicit.empty?
+
+      function_name = ENV['AWS_LAMBDA_FUNCTION_NAME']
+      return nil if function_name.nil? || function_name.empty?
+
+      region = ENV['AWS_REGION']
+      region = 'us-east-1' if region.nil? || region.empty?
+
+      "https://#{function_name}.lambda-url.#{region}.on.aws"
+    end
+  end
+end

--- a/lib/signalwire/serverless/lambda_handler.rb
+++ b/lib/signalwire/serverless/lambda_handler.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 SignalWire
+#
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+
+require 'base64'
+require 'json'
+require 'stringio'
+require 'uri'
+
+module SignalWire
+  module Serverless
+    # Adapter that lets an AWS Lambda function invoke a Rack application.
+    #
+    # Typical usage from a Lambda entrypoint file:
+    #
+    #   require 'signalwire'
+    #
+    #   AGENT = SignalWire::AgentBase.new(name: 'my-agent', route: '/')
+    #   # ...configure AGENT...
+    #
+    #   HANDLER = SignalWire::Serverless::LambdaHandler.new(AGENT.rack_app)
+    #
+    #   def handler(event:, context:)
+    #     HANDLER.call(event, context)
+    #   end
+    #
+    # The adapter accepts events from either Lambda Function URLs / API
+    # Gateway HTTP API (payload format v2) or the classic API Gateway REST
+    # API (payload format v1) and returns a response in the matching
+    # shape. Any triple returned by the Rack app (status, headers, body)
+    # is translated into the +{statusCode:, headers:, body:}+ shape
+    # expected by Lambda.
+    #
+    # The adapter never reaches out to the network and has no gem
+    # dependencies beyond what the SignalWire SDK already requires, so it
+    # can be bundled directly into a Lambda zip.
+    class LambdaHandler
+      # @param app [#call] a Rack-compatible application
+      def initialize(app)
+        raise ArgumentError, 'app must respond to #call' unless app.respond_to?(:call)
+
+        @app = app
+      end
+
+      # Invoke the wrapped Rack application with a Lambda event.
+      #
+      # @param event   [Hash]   the Lambda invocation event
+      # @param _context [Object] the Lambda context (ignored)
+      # @return [Hash] a Lambda-shaped response hash
+      def call(event, _context = nil)
+        event ||= {}
+        env = build_env(event)
+
+        status, headers, body = @app.call(env)
+
+        build_response(event, status, headers, body)
+      ensure
+        body.close if body.respond_to?(:close)
+      end
+
+      # Class-level convenience so consumers can use
+      # +SignalWire::Serverless::LambdaHandler.for(agent)+ without
+      # duplicating +.rack_app+ at the call site.
+      #
+      # @param agent_or_app [Object] either an AgentBase (responds to
+      #   +rack_app+) or any Rack-compatible application
+      # @return [LambdaHandler]
+      def self.for(agent_or_app)
+        app = if agent_or_app.respond_to?(:rack_app)
+                agent_or_app.rack_app
+              else
+                agent_or_app
+              end
+        new(app)
+      end
+
+      private
+
+      # ------------------------------------------------------------------
+      # Request: Lambda event -> Rack env
+      # ------------------------------------------------------------------
+
+      def build_env(event)
+        version = detect_version(event)
+        method  = extract_method(event, version)
+        path    = extract_path(event, version)
+        query   = extract_query_string(event, version)
+        headers = extract_headers(event)
+        body_io, content_length = extract_body(event)
+
+        env = {
+          'REQUEST_METHOD'    => method,
+          'SCRIPT_NAME'       => '',
+          'PATH_INFO'         => path,
+          'QUERY_STRING'      => query,
+          'SERVER_NAME'       => headers['host'] || 'lambda',
+          'SERVER_PORT'       => (headers['x-forwarded-port'] || '443'),
+          'SERVER_PROTOCOL'   => 'HTTP/1.1',
+          'HTTP_VERSION'      => 'HTTP/1.1',
+          'rack.version'      => [1, 6],
+          'rack.url_scheme'   => headers['x-forwarded-proto'] || 'https',
+          'rack.input'        => body_io,
+          'rack.errors'       => $stderr,
+          'rack.multithread'  => false,
+          'rack.multiprocess' => false,
+          'rack.run_once'     => true,
+          'rack.hijack?'      => false,
+          'signalwire.lambda_event' => event
+        }
+        env['CONTENT_LENGTH'] = content_length.to_s if content_length
+        env['CONTENT_TYPE']   = headers['content-type'] if headers['content-type']
+
+        headers.each do |name, value|
+          next if name == 'content-type' || name == 'content-length'
+
+          env["HTTP_#{name.tr('-', '_').upcase}"] = value
+        end
+
+        env
+      end
+
+      def detect_version(event)
+        # API Gateway HTTP API / Function URLs use payload v2 and include
+        # a 'version' key of "2.0". Everything else (REST API, ALB, direct
+        # invoke) is treated as v1.
+        event['version'].to_s.start_with?('2') ? 2 : 1
+      end
+
+      def extract_method(event, version)
+        if version == 2
+          event.dig('requestContext', 'http', 'method') || event['httpMethod'] || 'GET'
+        else
+          event['httpMethod'] || 'GET'
+        end
+      end
+
+      def extract_path(event, _version)
+        raw =
+          event['rawPath'] ||
+          event['path'] ||
+          event.dig('requestContext', 'http', 'path') ||
+          '/'
+        raw = "/#{raw}" unless raw.start_with?('/')
+        raw
+      end
+
+      def extract_query_string(event, _version)
+        if event['rawQueryString'] && !event['rawQueryString'].empty?
+          return event['rawQueryString']
+        end
+
+        params = event['multiValueQueryStringParameters'] || event['queryStringParameters']
+        return '' if params.nil? || params.empty?
+
+        pairs = []
+        params.each do |k, v|
+          if v.is_a?(Array)
+            v.each { |vv| pairs << [k, vv] }
+          else
+            pairs << [k, v]
+          end
+        end
+        URI.encode_www_form(pairs)
+      end
+
+      def extract_headers(event)
+        raw = event['headers'] || {}
+        multi = event['multiValueHeaders'] || {}
+
+        merged = {}
+        raw.each { |k, v| merged[k.downcase] = v }
+        multi.each do |k, values|
+          key = k.downcase
+          merged[key] = Array(values).join(',') unless merged.key?(key)
+        end
+        merged
+      end
+
+      def extract_body(event)
+        body = event['body']
+        return [StringIO.new(''.b), nil] if body.nil? || body.empty?
+
+        decoded = event['isBase64Encoded'] ? Base64.decode64(body) : body.dup
+        decoded = decoded.b
+        [StringIO.new(decoded), decoded.bytesize]
+      end
+
+      # ------------------------------------------------------------------
+      # Response: Rack triple -> Lambda response hash
+      # ------------------------------------------------------------------
+
+      def build_response(event, status, headers, body)
+        payload  = collect_body(body)
+        encoded, is_base64 = maybe_base64(payload, headers)
+
+        flat_headers = {}
+        multi_headers = {}
+        (headers || {}).each do |name, value|
+          key = name.to_s
+          if value.is_a?(Array)
+            flat_headers[key]  = value.join(',')
+            multi_headers[key] = value
+          else
+            flat_headers[key] = value.to_s
+          end
+        end
+
+        if detect_version(event) == 2
+          response = {
+            'statusCode'      => status.to_i,
+            'headers'         => flat_headers,
+            'body'            => encoded,
+            'isBase64Encoded' => is_base64
+          }
+          response['cookies'] = multi_headers['set-cookie'] if multi_headers.key?('set-cookie')
+          response
+        else
+          {
+            'statusCode'        => status.to_i,
+            'headers'           => flat_headers,
+            'multiValueHeaders' => multi_headers,
+            'body'              => encoded,
+            'isBase64Encoded'   => is_base64
+          }
+        end
+      end
+
+      def collect_body(body)
+        return ''.b if body.nil?
+
+        parts = []
+        body.each { |chunk| parts << chunk.to_s }
+        parts.join.b
+      end
+
+      # Lambda requires the 'body' field to be a UTF-8 string; binary
+      # responses have to be base64 encoded and flagged as such. Any byte
+      # that isn't valid UTF-8 forces base64 encoding.
+      def maybe_base64(payload, _headers)
+        if payload.force_encoding(Encoding::UTF_8).valid_encoding?
+          [payload.to_s, false]
+        else
+          [Base64.strict_encode64(payload), true]
+        end
+      end
+    end
+  end
+end

--- a/tests/lambda_agent_test.rb
+++ b/tests/lambda_agent_test.rb
@@ -1,0 +1,330 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'rack/test'
+require 'json'
+
+ENV['SIGNALWIRE_LOG_MODE'] = 'off'
+
+require_relative '../lib/signalwire'
+require_relative 'runtime_test' # pull in RuntimeEnvIsolation
+
+# Helper that digs the default SWAIG webhook URL out of a rendered SWML
+# document. Every agent-webhook test here uses this, so it's centralised
+# to keep the tests focused on the URL assertions themselves.
+module SwmlWebhookUrlHelper
+  def default_swaig_url(agent)
+    swml = agent.render_swml
+    ai   = swml['sections']['main'].find { |v| v.key?('ai') }['ai']
+    ai['SWAIG']['defaults']['web_hook_url']
+  end
+end
+
+# ==========================================================================
+# URL generation under Lambda
+# ==========================================================================
+class LambdaWebhookUrlTest < Minitest::Test
+  include RuntimeEnvIsolation
+  include SwmlWebhookUrlHelper
+
+  def test_lambda_url_used_when_no_proxy_base_root_route
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'my-func'
+    ENV['AWS_REGION']               = 'us-east-1'
+
+    agent = SignalWire::AgentBase.new(basic_auth: ['u', 'p'], route: '/')
+    agent.define_tool(name: 'test', description: 'test') { |_, _| }
+
+    url = default_swaig_url(agent)
+
+    assert_includes url, 'my-func.lambda-url.us-east-1.on.aws'
+    assert_includes url, '/swaig'
+    # Auth credentials must still be embedded for the SignalWire platform
+    # to authenticate webhook callbacks.
+    assert_includes url, 'u:p@'
+  end
+
+  def test_lambda_url_used_when_no_proxy_base_non_root_route
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'my-func'
+    ENV['AWS_REGION']               = 'eu-west-2'
+
+    agent = SignalWire::AgentBase.new(basic_auth: ['u', 'p'], route: '/my-agent')
+    agent.define_tool(name: 'test', description: 'test') { |_, _| }
+
+    url = default_swaig_url(agent)
+
+    assert_includes url, 'my-func.lambda-url.eu-west-2.on.aws'
+    assert_includes url, '/my-agent/swaig',
+                    'non-root route must appear before the endpoint'
+  end
+
+  def test_aws_lambda_function_url_takes_precedence_over_derived
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'ignored'
+    ENV['AWS_LAMBDA_FUNCTION_URL']  = 'https://abc.lambda-url.us-west-2.on.aws'
+
+    agent = SignalWire::AgentBase.new(basic_auth: ['u', 'p'], route: '/')
+    agent.define_tool(name: 'test', description: 'test') { |_, _| }
+
+    url = default_swaig_url(agent)
+    assert_includes url, 'abc.lambda-url.us-west-2.on.aws'
+    refute_includes url, 'ignored'
+  end
+
+  def test_region_defaults_to_us_east_1_when_not_set
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'my-func'
+    # AWS_REGION intentionally unset
+
+    agent = SignalWire::AgentBase.new(basic_auth: ['u', 'p'], route: '/')
+    agent.define_tool(name: 'test', description: 'test') { |_, _| }
+
+    url = default_swaig_url(agent)
+    assert_includes url, 'my-func.lambda-url.us-east-1.on.aws'
+  end
+
+  def test_not_lambda_means_no_lambda_url
+    # No Lambda env vars set; must fall back to the local server URL.
+    agent = SignalWire::AgentBase.new(basic_auth: ['u', 'p'], route: '/')
+    agent.define_tool(name: 'test', description: 'test') { |_, _| }
+
+    url = default_swaig_url(agent)
+    refute_includes url, 'lambda-url'
+    assert_match %r{http://u:p@}, url
+  end
+end
+
+# ==========================================================================
+# Regression: proxy base + non-root route + Lambda env
+# ==========================================================================
+#
+# This is the load-bearing test for the bug called out in the task brief:
+# when SWML_PROXY_URL_BASE is set (e.g. because the function is fronted
+# by API Gateway or CloudFront) the agent's route MUST still be appended.
+# If _base_url ever swallows the route, this test will catch it.
+class LambdaProxyRouteRegressionTest < Minitest::Test
+  include RuntimeEnvIsolation
+  include SwmlWebhookUrlHelper
+
+  def test_proxy_base_with_non_root_route_on_lambda_preserves_route
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'my-func'
+    ENV['AWS_REGION']               = 'us-east-1'
+    ENV['SWML_PROXY_URL_BASE']      = 'https://xyz.lambda-url.us-east-1.on.aws'
+
+    agent = SignalWire::AgentBase.new(basic_auth: ['u', 'p'], route: '/my-agent')
+    agent.define_tool(name: 'test', description: 'test') { |_, _| }
+
+    url = default_swaig_url(agent)
+
+    # The fully-qualified webhook URL must include the route before the
+    # endpoint. If _base_url accidentally returns a URL with a path, or
+    # _build_webhook_url short-circuits on a proxy, the route vanishes.
+    assert_includes url, 'https://xyz.lambda-url.us-east-1.on.aws/my-agent/swaig',
+                    "expected route '/my-agent' to appear before '/swaig', got #{url.inspect}"
+    refute_includes url, 'xyz.lambda-url.us-east-1.on.aws/swaig',
+                    "the proxy base must not be joined directly to '/swaig' (route dropped!)"
+  end
+
+  def test_proxy_base_without_route_still_works
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'my-func'
+    ENV['SWML_PROXY_URL_BASE']      = 'https://proxy.example.com'
+
+    agent = SignalWire::AgentBase.new(basic_auth: ['u', 'p'], route: '/')
+    agent.define_tool(name: 'test', description: 'test') { |_, _| }
+
+    url = default_swaig_url(agent)
+    assert_includes url, 'https://proxy.example.com/swaig'
+  end
+
+  def test_proxy_base_with_trailing_slash_is_normalised
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'my-func'
+    ENV['SWML_PROXY_URL_BASE']      = 'https://proxy.example.com/'
+
+    agent = SignalWire::AgentBase.new(basic_auth: ['u', 'p'], route: '/my-agent')
+    agent.define_tool(name: 'test', description: 'test') { |_, _| }
+
+    url = default_swaig_url(agent)
+    assert_includes url, 'https://proxy.example.com/my-agent/swaig'
+    refute_includes url, '//my-agent', 'trailing slash on base must not produce a double slash'
+  end
+end
+
+# ==========================================================================
+# Integration: LambdaHandler invoking a real agent's Rack app
+# ==========================================================================
+class LambdaHandlerIntegrationTest < Minitest::Test
+  include RuntimeEnvIsolation
+
+  def setup
+    super
+    @agent = SignalWire::AgentBase.new(
+      name:       'lambda-agent',
+      route:      '/',
+      basic_auth: ['testuser', 'testpass']
+    )
+    @agent.set_prompt_text('Hello from Lambda')
+    @agent.define_tool(
+      name:        'echo',
+      description: 'Echo back a message',
+      parameters:  { 'message' => { 'type' => 'string' } }
+    ) do |args, _raw|
+      SignalWire::Swaig::FunctionResult.new("echo: #{args['message']}")
+    end
+    @handler = SignalWire::Serverless::LambdaHandler.new(@agent.rack_app)
+  end
+
+  # ------------ Function URL / API Gateway v2 payload -----------------
+
+  def function_url_event(method:, path:, body: nil, headers: {}, query: nil)
+    merged_headers = {
+      'authorization' => 'Basic ' + ['testuser:testpass'].pack('m0').chomp,
+      'content-type'  => 'application/json',
+      'host'          => 'abc.lambda-url.us-east-1.on.aws'
+    }.merge(headers)
+
+    event = {
+      'version'     => '2.0',
+      'routeKey'    => '$default',
+      'rawPath'     => path,
+      'rawQueryString' => query.to_s,
+      'headers'     => merged_headers,
+      'requestContext' => {
+        'http' => { 'method' => method, 'path' => path, 'protocol' => 'HTTP/1.1' },
+        'stage' => '$default'
+      }
+    }
+    if body
+      event['body']            = body
+      event['isBase64Encoded'] = false
+    end
+    event
+  end
+
+  def test_health_endpoint_does_not_require_auth
+    event = function_url_event(method: 'GET', path: '/health', headers: {})
+    event['headers'].delete('authorization')
+
+    resp = @handler.call(event, nil)
+
+    assert_equal 200, resp['statusCode']
+    assert_equal 'application/json', resp['headers']['content-type']
+    payload = JSON.parse(resp['body'])
+    assert_equal 'healthy', payload['status']
+    refute resp['isBase64Encoded'], 'plain JSON must not be base64 encoded'
+  end
+
+  def test_swml_endpoint_returns_document_in_v2_shape
+    event = function_url_event(method: 'GET', path: '/')
+
+    resp = @handler.call(event, nil)
+
+    assert_equal 200, resp['statusCode']
+    assert resp.key?('statusCode')
+    assert resp.key?('headers')
+    assert resp.key?('body')
+    assert resp.key?('isBase64Encoded')
+    payload = JSON.parse(resp['body'])
+    # The SWML document carries the agent's prompt — enough to prove the
+    # Rack pipeline ran end-to-end.
+    assert payload.key?('sections')
+    main = payload['sections']['main']
+    ai_verb = main.find { |v| v.key?('ai') }
+    assert ai_verb, "rendered SWML should include an 'ai' verb"
+  end
+
+  def test_swaig_dispatch_via_post
+    body = JSON.generate(
+      'function'  => 'echo',
+      'argument'  => { 'parsed' => [{ 'message' => 'from-lambda' }] }
+    )
+    event = function_url_event(method: 'POST', path: '/swaig', body: body)
+
+    resp = @handler.call(event, nil)
+
+    assert_equal 200, resp['statusCode']
+    payload = JSON.parse(resp['body'])
+    assert_equal 'echo: from-lambda', payload['response']
+  end
+
+  def test_unauthorized_swml_request_returns_401
+    event = function_url_event(method: 'GET', path: '/', headers: {})
+    event['headers'].delete('authorization')
+
+    resp = @handler.call(event, nil)
+    assert_equal 401, resp['statusCode']
+  end
+
+  # ----------------- API Gateway v1 (REST API) payload -----------------
+
+  def rest_event(method:, path:, body: nil)
+    {
+      'httpMethod' => method,
+      'path'       => path,
+      'headers'    => {
+        'Authorization' => 'Basic ' + ['testuser:testpass'].pack('m0').chomp,
+        'Content-Type'  => 'application/json',
+        'Host'          => 'api.example.com'
+      },
+      'body'             => body,
+      'isBase64Encoded'  => false
+    }
+  end
+
+  def test_v1_payload_shape_returns_v1_response_shape
+    event = rest_event(method: 'GET', path: '/health')
+
+    resp = @handler.call(event, nil)
+    assert_equal 200, resp['statusCode']
+    # v1 responses include multiValueHeaders; v2 responses do not.
+    assert resp.key?('multiValueHeaders'), 'v1 payload must produce v1 response shape'
+  end
+
+  # ----------------- Query string + base64 body ------------------------
+
+  def test_query_string_is_forwarded
+    event = function_url_event(method: 'GET', path: '/health', query: 'foo=bar&baz=quux')
+    event['headers'].delete('authorization')
+    resp = @handler.call(event, nil)
+    # Health endpoint doesn't care about the query string; we just
+    # exercise the encoding path to make sure it doesn't blow up.
+    assert_equal 200, resp['statusCode']
+  end
+
+  def test_base64_encoded_body_is_decoded
+    raw_body = JSON.generate(
+      'function'  => 'echo',
+      'argument'  => { 'parsed' => [{ 'message' => 'b64' }] }
+    )
+    event = function_url_event(method: 'POST', path: '/swaig', body: nil)
+    require 'base64'
+    event['body']            = Base64.strict_encode64(raw_body)
+    event['isBase64Encoded'] = true
+
+    resp = @handler.call(event, nil)
+
+    assert_equal 200, resp['statusCode']
+    payload = JSON.parse(resp['body'])
+    assert_equal 'echo: b64', payload['response']
+  end
+
+  # ----------------- Handler factory -----------------------------------
+
+  def test_for_factory_accepts_agent
+    handler = SignalWire::Serverless::LambdaHandler.for(@agent)
+    event = function_url_event(method: 'GET', path: '/health')
+    event['headers'].delete('authorization')
+
+    resp = handler.call(event, nil)
+    assert_equal 200, resp['statusCode']
+  end
+
+  def test_for_factory_accepts_rack_app
+    handler = SignalWire::Serverless::LambdaHandler.for(@agent.rack_app)
+    event = function_url_event(method: 'GET', path: '/health')
+    event['headers'].delete('authorization')
+
+    resp = handler.call(event, nil)
+    assert_equal 200, resp['statusCode']
+  end
+
+  def test_constructor_rejects_non_rack_app
+    assert_raises(ArgumentError) { SignalWire::Serverless::LambdaHandler.new('not a rack app') }
+  end
+end

--- a/tests/runtime_test.rb
+++ b/tests/runtime_test.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+ENV['SIGNALWIRE_LOG_MODE'] = 'off'
+
+require_relative '../lib/signalwire'
+
+# Env vars the Runtime module sniffs. We snapshot and restore them around
+# every test so nothing that ran before (e.g. the auth tests setting
+# SWML_BASIC_AUTH_*) can leak in, and so the plain `ENV[...] = ...` we do
+# inside the test body doesn't leak out to later test files.
+module RuntimeEnvIsolation
+  RUNTIME_ENV_VARS = %w[
+    GATEWAY_INTERFACE
+    AWS_LAMBDA_FUNCTION_NAME
+    AWS_LAMBDA_FUNCTION_URL
+    AWS_REGION
+    LAMBDA_TASK_ROOT
+    FUNCTION_TARGET
+    K_SERVICE
+    GOOGLE_CLOUD_PROJECT
+    AZURE_FUNCTIONS_ENVIRONMENT
+    FUNCTIONS_WORKER_RUNTIME
+    AzureWebJobsStorage
+    SWML_PROXY_URL_BASE
+  ].freeze
+
+  def setup
+    super
+    @saved_env = RUNTIME_ENV_VARS.each_with_object({}) { |k, h| h[k] = ENV[k] }
+    RUNTIME_ENV_VARS.each { |k| ENV.delete(k) }
+  end
+
+  def teardown
+    RUNTIME_ENV_VARS.each do |k|
+      if @saved_env[k].nil?
+        ENV.delete(k)
+      else
+        ENV[k] = @saved_env[k]
+      end
+    end
+    super
+  end
+end
+
+class RuntimeExecutionModeTest < Minitest::Test
+  include RuntimeEnvIsolation
+
+  def test_defaults_to_server
+    assert_equal :server, SignalWire::Runtime.execution_mode
+    refute SignalWire::Runtime.lambda?
+    refute SignalWire::Runtime.serverless?
+  end
+
+  def test_detects_lambda_via_function_name
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'my-func'
+    assert_equal :lambda, SignalWire::Runtime.execution_mode
+    assert SignalWire::Runtime.lambda?
+    assert SignalWire::Runtime.serverless?
+  end
+
+  def test_detects_lambda_via_task_root
+    ENV['LAMBDA_TASK_ROOT'] = '/var/task'
+    assert_equal :lambda, SignalWire::Runtime.execution_mode
+  end
+
+  def test_detects_cgi
+    ENV['GATEWAY_INTERFACE'] = 'CGI/1.1'
+    assert_equal :cgi, SignalWire::Runtime.execution_mode
+    refute SignalWire::Runtime.lambda?
+    assert SignalWire::Runtime.serverless?
+  end
+
+  def test_cgi_wins_over_lambda_when_both_set
+    # Emulators sometimes set GATEWAY_INTERFACE on top of AWS_LAMBDA_*
+    # We want to honor the stricter CGI contract in that case.
+    ENV['GATEWAY_INTERFACE']        = 'CGI/1.1'
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'my-func'
+    assert_equal :cgi, SignalWire::Runtime.execution_mode
+  end
+
+  def test_detects_google_cloud_function
+    ENV['K_SERVICE'] = 'my-service'
+    assert_equal :google_cloud_function, SignalWire::Runtime.execution_mode
+    assert SignalWire::Runtime.serverless?
+  end
+
+  def test_detects_google_cloud_function_via_function_target
+    ENV['FUNCTION_TARGET'] = 'entry_point'
+    assert_equal :google_cloud_function, SignalWire::Runtime.execution_mode
+  end
+
+  def test_detects_azure_function
+    ENV['FUNCTIONS_WORKER_RUNTIME'] = 'python'
+    assert_equal :azure_function, SignalWire::Runtime.execution_mode
+    assert SignalWire::Runtime.serverless?
+  end
+
+  def test_empty_env_var_is_treated_as_unset
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = ''
+    assert_equal :server, SignalWire::Runtime.execution_mode
+  end
+end
+
+class RuntimeLambdaBaseUrlTest < Minitest::Test
+  include RuntimeEnvIsolation
+
+  def test_nil_when_no_lambda_signal
+    assert_nil SignalWire::Runtime.lambda_base_url
+  end
+
+  def test_prefers_function_url_env
+    ENV['AWS_LAMBDA_FUNCTION_URL'] = 'https://custom.lambda-url.us-west-2.on.aws'
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'ignore-me'
+    ENV['AWS_REGION']               = 'ignore-me-too'
+    assert_equal 'https://custom.lambda-url.us-west-2.on.aws',
+                 SignalWire::Runtime.lambda_base_url
+  end
+
+  def test_strips_trailing_slash_from_function_url
+    ENV['AWS_LAMBDA_FUNCTION_URL'] = 'https://custom.lambda-url.us-west-2.on.aws/'
+    assert_equal 'https://custom.lambda-url.us-west-2.on.aws',
+                 SignalWire::Runtime.lambda_base_url
+  end
+
+  def test_falls_back_to_function_name_and_region
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'my-func'
+    ENV['AWS_REGION']               = 'eu-west-1'
+    assert_equal 'https://my-func.lambda-url.eu-west-1.on.aws',
+                 SignalWire::Runtime.lambda_base_url
+  end
+
+  def test_region_defaults_to_us_east_1
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'my-func'
+    assert_equal 'https://my-func.lambda-url.us-east-1.on.aws',
+                 SignalWire::Runtime.lambda_base_url
+  end
+end

--- a/tests/simulate_serverless_test.rb
+++ b/tests/simulate_serverless_test.rb
@@ -1,0 +1,414 @@
+# frozen_string_literal: true
+
+# Tests for `bin/swaig-test --simulate-serverless lambda`.
+#
+# These cover the non-negotiables from the porting-sdk checklist:
+#   - env vars set during invocation and restored after, both on the
+#     happy path and when the agent raises;
+#   - SWML_PROXY_URL_BASE is cleared during simulation so the Lambda
+#     base URL actually drives webhook construction;
+#   - non-root routes round-trip correctly through the adapter (the
+#     load-bearing regression the prior agent fixed);
+#   - unimplemented platforms (gcf, azure, cgi) are rejected with a
+#     clear error.
+
+require 'minitest/autorun'
+require 'json'
+require 'stringio'
+require 'tempfile'
+
+ENV['SIGNALWIRE_LOG_MODE'] = 'off'
+
+require_relative '../lib/signalwire'
+require_relative 'runtime_test' # pull in RuntimeEnvIsolation
+
+# Load the CLI (defines SwaigTest module)
+load File.expand_path('../bin/swaig-test', __dir__)
+
+module SimulateServerlessTestHelpers
+  # Write an agent source file that defines an `AGENT` top-level constant
+  # at the given route, plus one tool per entry in `tools`. Each tool is
+  # a hash: { name:, description:, block: ->(args, raw) { ... } }.
+  # Returns the Tempfile (caller is responsible for unlinking).
+  def write_agent_file(route:, auth: ['u', 'p'], tools: default_tools, extra: '')
+    file = Tempfile.new(['agent', '.rb'])
+    file.write(<<~RUBY)
+      require 'signalwire'
+
+      AGENT = SignalWire::AgentBase.new(
+        name:       'simtest',
+        route:      #{route.inspect},
+        basic_auth: #{auth.inspect}
+      )
+      AGENT.set_prompt_text('Hello from the simulator test')
+    RUBY
+    tools.each do |t|
+      file.write(<<~RUBY)
+
+        AGENT.define_tool(
+          name:        #{t[:name].inspect},
+          description: #{t[:description].inspect},
+          parameters:  #{t.fetch(:parameters, {}).inspect}
+        ) do |args, raw|
+          #{t.fetch(:body, "SignalWire::Swaig::FunctionResult.new('ok')")}
+        end
+      RUBY
+    end
+    file.write("\n#{extra}\n") if extra && !extra.empty?
+    file.flush
+    file
+  end
+
+  def default_tools
+    [
+      {
+        name: 'echo',
+        description: 'Echo back a message',
+        parameters: { 'message' => { 'type' => 'string' } },
+        body: "SignalWire::Swaig::FunctionResult.new(\"echo: \#{args['message']}\")"
+      }
+    ]
+  end
+
+  def run_cli(argv)
+    cli = SwaigTest::CLI.new(argv)
+    cli.run
+  end
+
+  def capture_cli(argv)
+    out = StringIO.new
+    err = StringIO.new
+    orig_out = $stdout
+    orig_err = $stderr
+    $stdout = out
+    $stderr = err
+    status = :ok
+    begin
+      run_cli(argv)
+    rescue SystemExit => e
+      status = e.status
+    ensure
+      $stdout = orig_out
+      $stderr = orig_err
+    end
+    # Purge the AGENT constant so subsequent tests can reload cleanly.
+    Object.send(:remove_const, :AGENT) if Object.const_defined?(:AGENT)
+    [out.string, err.string, status]
+  end
+
+  # Run an SwaigTest::ServerlessSimulator directly so we can assert on
+  # what it sets/clears WITHOUT shelling out to a subprocess.
+  def with_simulator(platform: 'lambda')
+    sim = SwaigTest::ServerlessSimulator.new(platform)
+    sim.activate
+    yield sim
+  ensure
+    sim&.deactivate
+  end
+end
+
+# ==========================================================================
+# Simulator env-var lifecycle
+# ==========================================================================
+class SimulatorEnvLifecycleTest < Minitest::Test
+  include RuntimeEnvIsolation
+  include SimulateServerlessTestHelpers
+
+  def test_activate_sets_lambda_env_vars
+    assert_nil ENV['AWS_LAMBDA_FUNCTION_NAME']
+
+    with_simulator do
+      refute_nil ENV['AWS_LAMBDA_FUNCTION_NAME'],
+                 'AWS_LAMBDA_FUNCTION_NAME should be set during simulation'
+      refute_nil ENV['LAMBDA_TASK_ROOT'],
+                 'LAMBDA_TASK_ROOT should be set during simulation'
+      refute_nil ENV['AWS_REGION'],
+                 'AWS_REGION should be set during simulation'
+      assert_equal :lambda, SignalWire::Runtime.execution_mode
+    end
+
+    # After deactivate, everything should be back to unset.
+    assert_nil ENV['AWS_LAMBDA_FUNCTION_NAME']
+    assert_nil ENV['LAMBDA_TASK_ROOT']
+    assert_nil ENV['AWS_REGION']
+    assert_equal :server, SignalWire::Runtime.execution_mode
+  end
+
+  def test_deactivate_restores_pre_existing_values
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'pre-existing'
+
+    with_simulator do
+      # Simulator replaces it with its preset
+      refute_equal 'pre-existing', ENV['AWS_LAMBDA_FUNCTION_NAME']
+    end
+
+    # And restores the caller's original value
+    assert_equal 'pre-existing', ENV['AWS_LAMBDA_FUNCTION_NAME']
+  end
+
+  def test_activate_clears_swml_proxy_url_base
+    ENV['SWML_PROXY_URL_BASE'] = 'https://proxy.example.com'
+
+    with_simulator do
+      assert_nil ENV['SWML_PROXY_URL_BASE'],
+                 'SWML_PROXY_URL_BASE must be cleared during simulation so Lambda URL takes effect'
+    end
+
+    # Outer value must come back afterwards
+    assert_equal 'https://proxy.example.com', ENV['SWML_PROXY_URL_BASE']
+  end
+
+  def test_env_restored_when_block_raises
+    ENV['AWS_LAMBDA_FUNCTION_NAME']   = 'outer-value'
+    ENV['SWML_PROXY_URL_BASE']        = 'https://outer.example.com'
+
+    assert_raises(RuntimeError) do
+      sim = SwaigTest::ServerlessSimulator.new('lambda')
+      sim.with_simulation do
+        # Simulator is active; sanity-check then raise
+        refute_equal 'outer-value', ENV['AWS_LAMBDA_FUNCTION_NAME']
+        assert_nil ENV['SWML_PROXY_URL_BASE']
+        raise 'boom'
+      end
+    end
+
+    # ensure-path restoration
+    assert_equal 'outer-value',               ENV['AWS_LAMBDA_FUNCTION_NAME']
+    assert_equal 'https://outer.example.com', ENV['SWML_PROXY_URL_BASE']
+  end
+end
+
+# ==========================================================================
+# --simulate-serverless lambda --dump-swml
+# ==========================================================================
+class SimulateLambdaDumpSwmlTest < Minitest::Test
+  include RuntimeEnvIsolation
+  include SimulateServerlessTestHelpers
+
+  def teardown
+    @agent_file&.close
+    @agent_file&.unlink
+    super
+  end
+
+  def test_dump_swml_on_root_route_uses_simulator_lambda_url
+    @agent_file = write_agent_file(route: '/')
+
+    out, err, status = capture_cli(
+      [@agent_file.path, '--simulate-serverless', 'lambda', '--dump-swml', '--raw']
+    )
+
+    assert_equal :ok, status, "CLI exited non-zero: #{err}"
+    swml = JSON.parse(out)
+    url = swml['sections']['main'].find { |v| v.key?('ai') }['ai']['SWAIG']['defaults']['web_hook_url']
+    assert_includes url, 'lambda-url.us-east-1.on.aws',
+                    'simulator must drive the Lambda base URL'
+    assert_includes url, '/swaig'
+  end
+
+  def test_dump_swml_on_non_root_route_preserves_route
+    # The load-bearing regression from the Lambda bug: the agent is
+    # mounted at a non-root route, so the webhook URL must contain
+    # /my-agent/swaig. If `_base_url` ever drops the route, this fails.
+    @agent_file = write_agent_file(route: '/my-agent')
+
+    out, err, status = capture_cli(
+      [@agent_file.path, '--simulate-serverless', 'lambda', '--dump-swml', '--raw']
+    )
+
+    assert_equal :ok, status, "CLI exited non-zero: #{err}"
+    swml = JSON.parse(out)
+    url = swml['sections']['main'].find { |v| v.key?('ai') }['ai']['SWAIG']['defaults']['web_hook_url']
+    assert_includes url, '/my-agent/swaig',
+                    "expected '/my-agent/swaig' in webhook URL, got #{url.inspect}"
+    refute_match %r{lambda-url\.[^/]+/swaig$}, url,
+                 "route must not be dropped between base URL and /swaig, got #{url.inspect}"
+  end
+
+  def test_simulator_clears_outer_swml_proxy_url_base
+    # This is the mock_env.py behavior: SWML_PROXY_URL_BASE is set in
+    # the outer shell, but once --simulate-serverless lambda is in
+    # effect the resulting SWML must use a Lambda-style URL.
+    ENV['SWML_PROXY_URL_BASE'] = 'https://outer-proxy.example.com'
+
+    @agent_file = write_agent_file(route: '/my-agent')
+
+    out, err, status = capture_cli(
+      [@agent_file.path, '--simulate-serverless', 'lambda', '--dump-swml', '--raw']
+    )
+
+    assert_equal :ok, status, "CLI exited non-zero: #{err}"
+    swml = JSON.parse(out)
+    url = swml['sections']['main'].find { |v| v.key?('ai') }['ai']['SWAIG']['defaults']['web_hook_url']
+
+    refute_includes url, 'outer-proxy.example.com',
+                    'outer SWML_PROXY_URL_BASE must not leak into simulated webhook URL'
+    assert_match %r{lambda-url\.[^/]+\.on\.aws/my-agent/swaig}, url,
+                 "expected Lambda-style URL with route, got #{url.inspect}"
+
+    # And the outer env var must be restored by the time the CLI exits.
+    assert_equal 'https://outer-proxy.example.com', ENV['SWML_PROXY_URL_BASE'],
+                 'outer SWML_PROXY_URL_BASE must be restored after CLI completes'
+  end
+
+  def test_dump_swml_without_subaction_renders_and_exits
+    # The porting-guide spec: `--simulate-serverless lambda` without
+    # --dump-swml / --exec still renders the SWML and exits.
+    @agent_file = write_agent_file(route: '/')
+
+    out, err, status = capture_cli(
+      [@agent_file.path, '--simulate-serverless', 'lambda', '--raw']
+    )
+
+    assert_equal :ok, status, "CLI exited non-zero: #{err}"
+    parsed = JSON.parse(out)
+    assert parsed['sections']['main'].any? { |v| v.key?('ai') },
+           'default render path should emit a SWML document with an ai verb'
+  end
+end
+
+# ==========================================================================
+# --simulate-serverless lambda --exec
+# ==========================================================================
+class SimulateLambdaExecTest < Minitest::Test
+  include RuntimeEnvIsolation
+  include SimulateServerlessTestHelpers
+
+  def teardown
+    @agent_file&.close
+    @agent_file&.unlink
+    super
+  end
+
+  def test_exec_dispatches_through_lambda_adapter
+    @agent_file = write_agent_file(route: '/')
+
+    out, err, status = capture_cli(
+      [@agent_file.path, '--simulate-serverless', 'lambda',
+       '--exec', 'echo', '--param', 'message=hello', '--raw']
+    )
+
+    assert_equal :ok, status, "CLI exited non-zero: #{err}"
+    result = JSON.parse(out)
+    assert_equal 'echo: hello', result['response']
+  end
+
+  def test_exec_on_non_root_route_still_works
+    @agent_file = write_agent_file(route: '/my-agent')
+
+    out, err, status = capture_cli(
+      [@agent_file.path, '--simulate-serverless', 'lambda',
+       '--exec', 'echo', '--param', 'message=routed', '--raw']
+    )
+
+    assert_equal :ok, status, "CLI exited non-zero: #{err}"
+    result = JSON.parse(out)
+    assert_equal 'echo: routed', result['response']
+  end
+
+  def test_env_restored_when_tool_raises
+    # A tool body that raises must still leave the env clean.
+    ENV['AWS_LAMBDA_FUNCTION_NAME'] = 'outer-func'
+    ENV['SWML_PROXY_URL_BASE']      = 'https://outer.example.com'
+
+    @agent_file = write_agent_file(
+      route: '/',
+      tools: [{
+        name:        'boom',
+        description: 'Always raises',
+        parameters:  {},
+        body:        "raise 'simulated tool failure'"
+      }]
+    )
+
+    # The CLI catches tool errors at the dispatcher level (which raises
+    # because the handler returns 500). We only care that the env is
+    # restored after the CLI exits.
+    _out, _err, _status = capture_cli(
+      [@agent_file.path, '--simulate-serverless', 'lambda',
+       '--exec', 'boom', '--raw']
+    )
+
+    assert_equal 'outer-func',                ENV['AWS_LAMBDA_FUNCTION_NAME']
+    assert_equal 'https://outer.example.com', ENV['SWML_PROXY_URL_BASE']
+  end
+end
+
+# ==========================================================================
+# Platform validation
+# ==========================================================================
+class SimulateServerlessPlatformValidationTest < Minitest::Test
+  include RuntimeEnvIsolation
+  include SimulateServerlessTestHelpers
+
+  def teardown
+    @agent_file&.close
+    @agent_file&.unlink
+    super
+  end
+
+  def test_gcf_is_rejected_with_clear_error
+    @agent_file = write_agent_file(route: '/')
+
+    out, err, status = capture_cli(
+      [@agent_file.path, '--simulate-serverless', 'gcf', '--dump-swml']
+    )
+
+    refute_equal :ok, status, 'gcf must not be accepted until Phase 9 ships for it'
+    assert_includes err, 'gcf'
+    assert_includes err, 'not implemented'
+  end
+
+  def test_azure_is_rejected_with_clear_error
+    @agent_file = write_agent_file(route: '/')
+
+    _out, err, status = capture_cli(
+      [@agent_file.path, '--simulate-serverless', 'azure', '--dump-swml']
+    )
+
+    refute_equal :ok, status
+    assert_includes err, 'azure'
+    assert_includes err, 'not implemented'
+  end
+
+  def test_cgi_is_rejected_with_clear_error
+    @agent_file = write_agent_file(route: '/')
+
+    _out, err, status = capture_cli(
+      [@agent_file.path, '--simulate-serverless', 'cgi', '--dump-swml']
+    )
+
+    refute_equal :ok, status
+    assert_includes err, 'cgi'
+    assert_includes err, 'not implemented'
+  end
+
+  def test_unknown_platform_is_rejected
+    @agent_file = write_agent_file(route: '/')
+
+    _out, err, status = capture_cli(
+      [@agent_file.path, '--simulate-serverless', 'jellybean', '--dump-swml']
+    )
+
+    refute_equal :ok, status
+    assert_includes err, 'jellybean'
+  end
+
+  def test_missing_agent_file_is_rejected
+    _out, err, status = capture_cli(
+      ['--simulate-serverless', 'lambda', '--dump-swml']
+    )
+
+    refute_equal :ok, status
+    assert_includes err, 'requires a positional agent file'
+  end
+
+  def test_agent_file_not_found_is_rejected
+    _out, err, status = capture_cli(
+      ['/nonexistent/path/agent.rb', '--simulate-serverless', 'lambda', '--dump-swml']
+    )
+
+    refute_equal :ok, status
+    assert_includes err, 'not found'
+  end
+end


### PR DESCRIPTION
## Summary

- Adds full Lambda runtime support: `SignalWire::Runtime` (mode detection + `lambda_base_url`) and a dependency-free `SignalWire::Serverless::LambdaHandler` that accepts API Gateway v1, v2, and Function URL events. `_base_url` falls through to Lambda-derived URLs when mode is `:lambda`, while `_build_webhook_url` keeps appending `@route` — preserves the route-preservation invariant that Python and TypeScript just regressed on.
- Adds `--simulate-serverless lambda` to `bin/swaig-test`. Snapshots + sets Lambda env vars, clears `SWML_PROXY_URL_BASE`, routes dump-swml/exec through `LambdaHandler` (not Rack), and restores env via `ensure` on success or exception.
- Follows the conditional-required structure now documented in the porting-sdk repo's § Serverless Support (Step 0–6) and Phase 10 CLI sections.
- Also makes true the README's long-standing "auto-detects Lambda" claim — which was aspirational until now.

## Test plan

- [x] \`bundle exec rake test\` — 956 runs, 2361 assertions, 0 failures, 0 errors, 0 skips
- [x] 46 new tests from Lambda support commit + 17 new tests from simulator commit
- [x] Route-preservation regression: non-root route + Lambda env + `SWML_PROXY_URL_BASE` → URL contains \`/my-agent/swaig\` (not \`/swaig\`)
- [x] Env restore verified on both success and block-raises paths
- [x] LambdaHandler integration tests cover v2 + v1 payloads, base64 bodies, query strings, 401 challenge, health endpoint without auth
- [x] \`--simulate-serverless gcf|azure|cgi|unknown\` rejected with clear Phase-9 error

Commits:
- \`b74f405\` Add AWS Lambda runtime support with route-preserving URL generation
- \`29cbf1b\` Add --simulate-serverless lambda to swaig-test CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)