### PR TITLE
Add PhoneCallHandler enum and typed phone-binding helpers

### DIFF
--- a/lib/signalwire/rest/namespaces/fabric.rb
+++ b/lib/signalwire/rest/namespaces/fabric.rb
@@ -15,6 +15,46 @@ module SignalWire
         self.update_method = 'PUT'
       end
 
+      # Fabric webhook resource that's normally auto-created by
+      # +phone_numbers.set_*_webhook+. Exposed for backwards compatibility.
+      #
+      # The binding model for these resources is on the phone number (see
+      # +phone_numbers.set_swml_webhook+ / +set_cxml_webhook+) -- setting
+      # +call_handler+ on a phone number auto-materializes the webhook
+      # Fabric resource. Calling +create+ directly here produces an orphan
+      # resource that isn't bound to any phone number.
+      class AutoMaterializedWebhook < FabricResource
+        # Subclasses override to advertise the correct helper in the warning.
+        AUTO_HELPER_NAME = 'phone_numbers.set_*_webhook'
+
+        # @deprecated Creating a webhook Fabric resource directly produces an
+        #   orphan that isn't bound to any phone number. Use the matching
+        #   +phone_numbers.set_*_webhook+ helper instead; it updates the
+        #   phone number and the server auto-materializes the resource.
+        #   See porting-sdk's +phone-binding.md+.
+        def create(**kwargs)
+          Kernel.warn(
+            "DEPRECATION: creating a webhook Fabric resource directly produces " \
+            "an orphan not bound to any phone number. Use " \
+            "#{self.class::AUTO_HELPER_NAME} instead; it updates the phone " \
+            "number and the server auto-materializes the resource. " \
+            "See porting-sdk's phone-binding.md.",
+            uplevel: 1
+          )
+          super
+        end
+      end
+
+      # SWML webhooks -- auto-materialized by +phone_numbers.set_swml_webhook+.
+      class SwmlWebhooksResource < AutoMaterializedWebhook
+        AUTO_HELPER_NAME = 'phone_numbers.set_swml_webhook(sid, url: ...)'
+      end
+
+      # cXML webhooks -- auto-materialized by +phone_numbers.set_cxml_webhook+.
+      class CxmlWebhooksResource < AutoMaterializedWebhook
+        AUTO_HELPER_NAME = 'phone_numbers.set_cxml_webhook(sid, url: ...)'
+      end
+
       # Call flows with version management.
       class CallFlowsResource < FabricResourcePUT
         def list_addresses(resource_id, **params)
@@ -89,7 +129,24 @@ module SignalWire
           @http.get(_path(resource_id, 'addresses'), params.empty? ? nil : params)
         end
 
+        # @deprecated For the common binding cases use +phone_numbers.set_*+ helpers.
+        #
+        # This endpoint (+POST /api/fabric/resources/{id}/phone_routes+) accepts
+        # only a narrow set of legacy resource types as the attach target. It
+        # *does not work* for +swml_webhook+ / +cxml_webhook+ / +ai_agent+
+        # bindings -- those are configured on the phone number and the Fabric
+        # resource is auto-materialized (see +phone_numbers.set_swml_webhook+
+        # etc.). The authoritative list of accepting resource types lives in
+        # the OpenAPI spec; routing here for those types returns 404 or 422.
         def assign_phone_route(resource_id, **kwargs)
+          Kernel.warn(
+            "DEPRECATION: assign_phone_route does not bind phone numbers to " \
+            "swml_webhook/cxml_webhook/ai_agent resources -- those are " \
+            "configured via phone_numbers.set_swml_webhook / set_cxml_webhook " \
+            "/ set_ai_agent. This method applies only to a narrow set of " \
+            "legacy resource types. See porting-sdk's phone-binding.md.",
+            uplevel: 1
+          )
           @http.post(_path(resource_id, 'phone_routes'), kwargs)
         end
 
@@ -159,10 +216,13 @@ module SignalWire
           @cxml_applications      = CxmlApplicationsResource.new(http, "#{base}/cxml_applications")
 
           # PATCH-update resources
-          @swml_webhooks = FabricResource.new(http, "#{base}/swml_webhooks")
+          # swml_webhooks and cxml_webhooks are normally auto-materialized by
+          # phone_numbers.set_swml_webhook / set_cxml_webhook. Direct create
+          # still works for backcompat but emits a deprecation warning.
+          @swml_webhooks = SwmlWebhooksResource.new(http, "#{base}/swml_webhooks")
           @ai_agents     = FabricResource.new(http, "#{base}/ai_agents")
           @sip_gateways  = FabricResource.new(http, "#{base}/sip_gateways")
-          @cxml_webhooks = FabricResource.new(http, "#{base}/cxml_webhooks")
+          @cxml_webhooks = CxmlWebhooksResource.new(http, "#{base}/cxml_webhooks")
 
           # Special resources
           @resources = GenericResources.new(http, base)

--- a/lib/signalwire/rest/namespaces/phone_numbers.rb
+++ b/lib/signalwire/rest/namespaces/phone_numbers.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
+require_relative '../phone_call_handler'
+
 module SignalWire
   module REST
     module Namespaces
       # Phone number management.
+      #
+      # Supports the standard CRUD surface plus typed helpers for binding an
+      # inbound call to a handler (SWML webhook, cXML webhook, AI agent, call
+      # flow, RELAY application/topic). The binding model is: set
+      # +call_handler+ and the handler-specific companion field on the phone
+      # number; the server auto-materializes the matching Fabric resource.
+      # See +SignalWire::REST::PhoneCallHandler+ for the enum, and the
+      # porting-sdk's +phone-binding.md+ for the full model.
       class PhoneNumbersResource < CrudResource
         self.update_method = 'PUT'
 
@@ -13,6 +23,100 @@ module SignalWire
 
         def search(**params)
           @http.get(_path('search'), params.empty? ? nil : params)
+        end
+
+        # -- Typed binding helpers -----------------------------------------
+        #
+        # Each helper is a one-line wrapper over +update+ with the right
+        # +call_handler+ value and companion field already set. Pass extra
+        # kwargs through for cases the helper doesn't name explicitly (e.g.
+        # +call_fallback_url+ on cXML webhooks).
+
+        # Route inbound calls to an SWML webhook URL.
+        #
+        # Your backend returns an SWML document per call. The server
+        # auto-creates a +swml_webhook+ Fabric resource keyed off this URL.
+        #
+        # @param sid [String] the phone number SID (e.g. +pn-...+)
+        # @param url [String] the SWML webhook URL
+        # @param extra [Hash] additional fields passed to +update+
+        # @return [Hash] the updated phone number representation
+        def set_swml_webhook(sid, url:, **extra)
+          update(
+            sid,
+            call_handler: PhoneCallHandler::RELAY_SCRIPT,
+            call_relay_script_url: url,
+            **extra
+          )
+        end
+
+        # Route inbound calls to a cXML (Twilio-compat / LAML) webhook.
+        #
+        # Despite the wire value +laml_webhooks+ being plural, this creates a
+        # single +cxml_webhook+ Fabric resource. +fallback_url+ is used when
+        # the primary URL fails; +status_callback_url+ receives call status
+        # updates.
+        def set_cxml_webhook(sid, url:, fallback_url: nil, status_callback_url: nil, **extra)
+          body = {
+            call_handler: PhoneCallHandler::LAML_WEBHOOKS,
+            call_request_url: url
+          }
+          body[:call_fallback_url]        = fallback_url        unless fallback_url.nil?
+          body[:call_status_callback_url] = status_callback_url unless status_callback_url.nil?
+          update(sid, **body, **extra)
+        end
+
+        # Route inbound calls to an existing cXML application by ID.
+        def set_cxml_application(sid, application_id:, **extra)
+          update(
+            sid,
+            call_handler: PhoneCallHandler::LAML_APPLICATION,
+            call_laml_application_id: application_id,
+            **extra
+          )
+        end
+
+        # Route inbound calls to an AI Agent Fabric resource by ID.
+        def set_ai_agent(sid, agent_id:, **extra)
+          update(
+            sid,
+            call_handler: PhoneCallHandler::AI_AGENT,
+            call_ai_agent_id: agent_id,
+            **extra
+          )
+        end
+
+        # Route inbound calls to a Call Flow by ID.
+        #
+        # +version+ accepts +"working_copy"+ or +"current_deployed"+ (server
+        # default when omitted).
+        def set_call_flow(sid, flow_id:, version: nil, **extra)
+          body = {
+            call_handler: PhoneCallHandler::CALL_FLOW,
+            call_flow_id: flow_id
+          }
+          body[:call_flow_version] = version unless version.nil?
+          update(sid, **body, **extra)
+        end
+
+        # Route inbound calls to a named RELAY application.
+        def set_relay_application(sid, name:, **extra)
+          update(
+            sid,
+            call_handler: PhoneCallHandler::RELAY_APPLICATION,
+            call_relay_application: name,
+            **extra
+          )
+        end
+
+        # Route inbound calls to a RELAY topic (client subscription).
+        def set_relay_topic(sid, topic:, status_callback_url: nil, **extra)
+          body = {
+            call_handler: PhoneCallHandler::RELAY_TOPIC,
+            call_relay_topic: topic
+          }
+          body[:call_relay_topic_status_callback_url] = status_callback_url unless status_callback_url.nil?
+          update(sid, **body, **extra)
         end
       end
     end

--- a/lib/signalwire/rest/phone_call_handler.rb
+++ b/lib/signalwire/rest/phone_call_handler.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module SignalWire
+  module REST
+    # PhoneCallHandler -- enum-like constants of the +call_handler+ values
+    # accepted by +phone_numbers.update+.
+    #
+    # Named +PhoneCallHandler+ (not +CallHandler+) to avoid colliding with
+    # the RELAY client's inbound-call-handler callback (+Relay::Client#on_call+).
+    #
+    # Setting a phone number's +call_handler+ together with the handler-specific
+    # companion field routes inbound calls and auto-materializes the matching
+    # Fabric resource on the server. See the high-level helpers on
+    # +SignalWire::REST::Namespaces::PhoneNumbersResource+.
+    #
+    # === Mapping
+    #
+    #   Constant          | Companion field (required)     | Auto-creates resource
+    #   ------------------+--------------------------------+----------------------
+    #   RELAY_SCRIPT      | call_relay_script_url          | swml_webhook
+    #   LAML_WEBHOOKS     | call_request_url               | cxml_webhook
+    #   LAML_APPLICATION  | call_laml_application_id       | cxml_application
+    #   AI_AGENT          | call_ai_agent_id               | ai_agent
+    #   CALL_FLOW         | call_flow_id                   | call_flow
+    #   RELAY_APPLICATION | call_relay_application         | relay_application
+    #   RELAY_TOPIC       | call_relay_topic               | (routes via RELAY)
+    #   RELAY_CONTEXT     | call_relay_context             | (legacy, prefer topic)
+    #   RELAY_CONNECTOR   | (connector config)             | (internal)
+    #   VIDEO_ROOM        | call_video_room_id             | (routes to Video API)
+    #   DIALOGFLOW        | call_dialogflow_agent_id       | (none)
+    #
+    # Note: +LAML_WEBHOOKS+ (wire value +laml_webhooks+) produces a *cXML*
+    # handler despite the plural name, not a generic webhook. For SWML, use
+    # +RELAY_SCRIPT+.
+    module PhoneCallHandler
+      RELAY_SCRIPT      = 'relay_script'
+      LAML_WEBHOOKS     = 'laml_webhooks'
+      LAML_APPLICATION  = 'laml_application'
+      AI_AGENT          = 'ai_agent'
+      CALL_FLOW         = 'call_flow'
+      RELAY_APPLICATION = 'relay_application'
+      RELAY_TOPIC       = 'relay_topic'
+      RELAY_CONTEXT     = 'relay_context'
+      RELAY_CONNECTOR   = 'relay_connector'
+      VIDEO_ROOM        = 'video_room'
+      DIALOGFLOW        = 'dialogflow'
+
+      # All supported wire values, in the same order as the constants.
+      ALL = [
+        RELAY_SCRIPT, LAML_WEBHOOKS, LAML_APPLICATION, AI_AGENT, CALL_FLOW,
+        RELAY_APPLICATION, RELAY_TOPIC, RELAY_CONTEXT, RELAY_CONNECTOR,
+        VIDEO_ROOM, DIALOGFLOW
+      ].freeze
+    end
+  end
+end

--- a/lib/signalwire/rest/rest_client.rb
+++ b/lib/signalwire/rest/rest_client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'http_client'
+require_relative 'phone_call_handler'
 require_relative 'namespaces/fabric'
 require_relative 'namespaces/calling'
 require_relative 'namespaces/phone_numbers'

--- a/rest/docs/fabric.md
+++ b/rest/docs/fabric.md
@@ -2,32 +2,50 @@
 
 The Fabric API (`/api/fabric`) manages all resource types in your SignalWire project. Every resource type supports CRUD operations and address listing.
 
+## Phone-number binding belongs on `phone_numbers`, not on Fabric
+
+Routing an inbound phone number to an SWML webhook, cXML app, AI agent, call flow, etc. is configured on the **phone number**, not on the Fabric resource. Fabric webhook / agent / flow resources are *derived* — the server materializes them automatically when you set `call_handler` + the handler-specific companion field on the phone number.
+
+Use the typed helpers on `client.phone_numbers`:
+
+```ruby
+client.phone_numbers.set_swml_webhook(pn_sid, url: 'https://example.com/swml')
+client.phone_numbers.set_cxml_webhook(pn_sid, url: 'https://example.com/voice.xml')
+client.phone_numbers.set_cxml_application(pn_sid, application_id: 'app-uuid')
+client.phone_numbers.set_ai_agent(pn_sid, agent_id: 'agent-uuid')
+client.phone_numbers.set_call_flow(pn_sid, flow_id: 'flow-uuid')
+client.phone_numbers.set_relay_application(pn_sid, name: 'my-relay-app')
+client.phone_numbers.set_relay_topic(pn_sid, topic: 'office')
+```
+
+See `rest/examples/rest_bind_phone_to_swml_webhook.rb` for the happy path. Calling `fabric.swml_webhooks.create`, `fabric.cxml_webhooks.create`, or `fabric.resources.assign_phone_route` to bind a phone number is **not** the right path — those produce orphans or 404/422 for the common handler types and emit deprecation warnings.
+
 ## Standard CRUD Pattern
 
-All 13 resource types share the same methods:
+All resource types share the same methods:
 
-```python
+```ruby
 # List all resources of this type
-items = client.fabric.ai_agents.list()
-items = client.fabric.ai_agents.list(page=2, page_size=10)
+items = client.fabric.ai_agents.list
+items = client.fabric.ai_agents.list(page: 2, page_size: 10)
 
 # Create a new resource
 agent = client.fabric.ai_agents.create(
-    name="Support Bot",
-    prompt={"text": "You are a helpful support agent."},
+  name:   'Support Bot',
+  prompt: { text: 'You are a helpful support agent.' }
 )
 
 # Get a resource by ID
-agent = client.fabric.ai_agents.get("agent-uuid")
+agent = client.fabric.ai_agents.get('agent-uuid')
 
 # Update a resource
-client.fabric.ai_agents.update("agent-uuid", name="Updated Name")
+client.fabric.ai_agents.update('agent-uuid', name: 'Updated Name')
 
 # Delete a resource
-client.fabric.ai_agents.delete("agent-uuid")
+client.fabric.ai_agents.delete('agent-uuid')
 
 # List addresses assigned to this resource
-addresses = client.fabric.ai_agents.list_addresses("agent-uuid")
+addresses = client.fabric.ai_agents.list_addresses('agent-uuid')
 ```
 
 ## Resource Types
@@ -59,56 +77,58 @@ These resources use `PATCH` for updates (partial update):
 | `fabric.sip_gateways` | `/api/fabric/resources/sip_gateways` |
 | `fabric.cxml_webhooks` | `/api/fabric/resources/cxml_webhooks` |
 
+**Note:** `fabric.swml_webhooks` and `fabric.cxml_webhooks` are normally auto-materialized by `phone_numbers.set_swml_webhook` / `set_cxml_webhook`. Calling `.create` directly still works for backcompat but emits a deprecation warning — the created resource is an orphan unless you subsequently bind it via the phone number.
+
 ## Call Flows -- Extra Methods
 
 Call flows support version management:
 
-```python
+```ruby
 # List all versions of a call flow
-versions = client.fabric.call_flows.list_versions("call-flow-uuid")
+versions = client.fabric.call_flows.list_versions('call-flow-uuid')
 
 # Deploy a new version
-client.fabric.call_flows.deploy_version("call-flow-uuid", document_version=3)
+client.fabric.call_flows.deploy_version('call-flow-uuid', document_version: 3)
 ```
 
 ## Subscribers -- SIP Endpoints
 
 Subscribers have nested SIP endpoint management:
 
-```python
+```ruby
 # List subscriber's SIP endpoints
-endpoints = client.fabric.subscribers.list_sip_endpoints("subscriber-uuid")
+endpoints = client.fabric.subscribers.list_sip_endpoints('subscriber-uuid')
 
 # Create a SIP endpoint for a subscriber
 endpoint = client.fabric.subscribers.create_sip_endpoint(
-    "subscriber-uuid",
-    username="user1",
-    password="secret",
-    caller_id="+15551234567",
+  'subscriber-uuid',
+  username:  'user1',
+  password:  'secret',
+  caller_id: '+15551234567'
 )
 
 # Get a specific SIP endpoint
-endpoint = client.fabric.subscribers.get_sip_endpoint("subscriber-uuid", "endpoint-uuid")
+endpoint = client.fabric.subscribers.get_sip_endpoint('subscriber-uuid', 'endpoint-uuid')
 
 # Update a SIP endpoint (uses PATCH)
 client.fabric.subscribers.update_sip_endpoint(
-    "subscriber-uuid", "endpoint-uuid",
-    caller_id="+15559876543",
+  'subscriber-uuid', 'endpoint-uuid',
+  caller_id: '+15559876543'
 )
 
 # Delete a SIP endpoint
-client.fabric.subscribers.delete_sip_endpoint("subscriber-uuid", "endpoint-uuid")
+client.fabric.subscribers.delete_sip_endpoint('subscriber-uuid', 'endpoint-uuid')
 ```
 
 ## cXML Applications
 
 cXML applications support list/get/update/delete but not create:
 
-```python
-apps = client.fabric.cxml_applications.list()
-app = client.fabric.cxml_applications.get("app-uuid")
-client.fabric.cxml_applications.update("app-uuid", voice_url="https://example.com/voice")
-client.fabric.cxml_applications.delete("app-uuid")
+```ruby
+apps = client.fabric.cxml_applications.list
+app  = client.fabric.cxml_applications.get('app-uuid')
+client.fabric.cxml_applications.update('app-uuid', voice_url: 'https://example.com/voice')
+client.fabric.cxml_applications.delete('app-uuid')
 
 # This raises NotImplementedError:
 # client.fabric.cxml_applications.create(...)
@@ -118,66 +138,72 @@ client.fabric.cxml_applications.delete("app-uuid")
 
 Operate on any resource type by ID:
 
-```python
+```ruby
 # List all resources across all types
-all_resources = client.fabric.resources.list()
+all_resources = client.fabric.resources.list
 
 # Get any resource by ID
-resource = client.fabric.resources.get("resource-uuid")
+resource = client.fabric.resources.get('resource-uuid')
 
 # Delete any resource
-client.fabric.resources.delete("resource-uuid")
+client.fabric.resources.delete('resource-uuid')
 
 # List addresses for any resource
-addresses = client.fabric.resources.list_addresses("resource-uuid")
-
-# Assign a resource to a phone route
-client.fabric.resources.assign_phone_route("resource-uuid", phone_route_id="route-uuid")
+addresses = client.fabric.resources.list_addresses('resource-uuid')
 
 # Assign a resource as a domain application handler
-client.fabric.resources.assign_domain_application("resource-uuid", domain_application_id="da-uuid")
+client.fabric.resources.assign_domain_application('resource-uuid', domain_application_id: 'da-uuid')
+```
+
+### Deprecated: `assign_phone_route`
+
+```ruby
+# Deprecated -- emits a warning. This endpoint applies only to a narrow set
+# of legacy resource types and does NOT work for swml_webhook / cxml_webhook
+# / ai_agent bindings. Use phone_numbers.set_* helpers instead.
+client.fabric.resources.assign_phone_route('resource-uuid', phone_number: '+15551234567')
 ```
 
 ## Fabric Addresses
 
 Read-only access to all fabric addresses:
 
-```python
+```ruby
 # List all addresses (filter by type or display_name)
-addresses = client.fabric.addresses.list(type="room")
+addresses = client.fabric.addresses.list(type: 'room')
 
 # Get a specific address
-address = client.fabric.addresses.get("address-uuid")
+address = client.fabric.addresses.get('address-uuid')
 ```
 
 ## Tokens
 
 Create tokens for subscribers, guests, invites, and embeds:
 
-```python
+```ruby
 # Subscriber token
 token = client.fabric.tokens.create_subscriber_token(
-    reference="user@example.com",
-    password="secret",
+  reference: 'user@example.com',
+  password:  'secret'
 )
 
 # Refresh a subscriber token
 refreshed = client.fabric.tokens.refresh_subscriber_token(
-    refresh_token="existing-refresh-token",
+  refresh_token: 'existing-refresh-token'
 )
 
 # Guest token
 token = client.fabric.tokens.create_guest_token(
-    allowed_addresses=["address-uuid-1", "address-uuid-2"],
-    expire_at="2025-12-31T23:59:59Z",
+  allowed_addresses: %w[address-uuid-1 address-uuid-2],
+  expire_at:         '2025-12-31T23:59:59Z'
 )
 
 # Subscriber invite token
 token = client.fabric.tokens.create_invite_token(
-    address_id="address-uuid",
-    expires_at="2025-12-31T23:59:59Z",
+  address_id: 'address-uuid',
+  expires_at: '2025-12-31T23:59:59Z'
 )
 
 # Click-to-call embed token
-token = client.fabric.tokens.create_embed_token(token="embed-source-token")
+token = client.fabric.tokens.create_embed_token(token: 'embed-source-token')
 ```

--- a/rest/examples/rest_bind_phone_to_swml_webhook.rb
+++ b/rest/examples/rest_bind_phone_to_swml_webhook.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Example: bind an inbound phone number to an SWML webhook (the happy path).
+#
+# This is the simplest way to route a SignalWire phone number to a backend
+# that returns an SWML document per inbound call. You set +call_handler+ on
+# the phone number; the server auto-materializes a +swml_webhook+ Fabric
+# resource pointing at your URL. You do *not* need to create the Fabric
+# webhook resource manually; you do *not* call +assign_phone_route+.
+#
+# Set these env vars (or pass them directly to RestClient.new):
+#   SIGNALWIRE_PROJECT_ID   - your SignalWire project ID
+#   SIGNALWIRE_API_TOKEN    - your SignalWire API token
+#   SIGNALWIRE_SPACE        - your SignalWire space (e.g. example.signalwire.com)
+#   PHONE_NUMBER_SID        - SID of a phone number you own (pn-...)
+#   SWML_WEBHOOK_URL        - your backend's SWML endpoint
+
+require 'signalwire'
+
+pn_sid      = ENV.fetch('PHONE_NUMBER_SID')
+webhook_url = ENV.fetch('SWML_WEBHOOK_URL')
+
+client = SignalWire::REST::RestClient.new
+
+# The typed helper -- one line:
+puts "Binding #{pn_sid} to #{webhook_url} ..."
+client.phone_numbers.set_swml_webhook(pn_sid, url: webhook_url)
+
+# The equivalent wire-level form (use this if you need unusual fields):
+#
+# client.phone_numbers.update(
+#   pn_sid,
+#   call_handler:          SignalWire::REST::PhoneCallHandler::RELAY_SCRIPT,
+#   call_relay_script_url: webhook_url
+# )
+
+# Verify: the server auto-created a swml_webhook Fabric resource.
+pn = client.phone_numbers.get(pn_sid)
+puts "  call_handler = #{pn['call_handler'].inspect}"
+puts "  call_relay_script_url = #{pn['call_relay_script_url'].inspect}"
+puts "  calling_handler_resource_id (server-derived) = " \
+     "#{pn['calling_handler_resource_id'].inspect}"
+
+# To route to something other than an SWML webhook, use:
+#   client.phone_numbers.set_cxml_webhook(sid, url: ...)        # LAML / Twilio-compat
+#   client.phone_numbers.set_ai_agent(sid, agent_id: ...)       # AI Agent
+#   client.phone_numbers.set_call_flow(sid, flow_id: ...)       # Call Flow
+#   client.phone_numbers.set_relay_application(sid, name: ...)  # Named RELAY app
+#   client.phone_numbers.set_relay_topic(sid, topic: ...)       # RELAY topic

--- a/rest/examples/rest_fabric_conferences_and_routing.rb
+++ b/rest/examples/rest_fabric_conferences_and_routing.rb
@@ -46,44 +46,35 @@ cxml = client.fabric.cxml_scripts.create(
 cxml_id = cxml['id']
 puts "  Created cXML script: #{cxml_id}"
 
-# 4. Create a cXML webhook
-puts "\nCreating cXML webhook..."
-cxml_wh = client.fabric.cxml_webhooks.create(
-  name:                'External cXML Handler',
-  primary_request_url: 'https://example.com/cxml-handler'
-)
-cxml_wh_id = cxml_wh['id']
-puts "  Created cXML webhook: #{cxml_wh_id}"
-
-# 5. Create a relay application
+# 4. Create a relay application
 puts "\nCreating relay application..."
 relay_app = client.fabric.relay_applications.create(name: 'Inbound Handler', topic: 'office')
 relay_id = relay_app['id']
 puts "  Created relay application: #{relay_id}"
 
-# 6. Generic resources: list all
+# 5. Generic resources: list all
 puts "\nListing all fabric resources..."
 resources = client.fabric.resources.list
 (resources['data'] || []).first(5).each do |r|
   puts "  - #{r.fetch('type', 'unknown')}: #{r.fetch('display_name', r.fetch('id', 'unknown'))}"
 end
 
-# 7. Get a specific generic resource
+# 6. Get a specific generic resource
 first = (resources['data'] || [{}]).first
 if first && first['id']
   detail = client.fabric.resources.get(first['id'])
   puts "  Resource detail: #{detail.fetch('display_name', 'N/A')} (#{detail.fetch('type', 'N/A')})"
 end
 
-# 8. Assign a phone route to a resource (demo)
-puts "\nAssigning phone route (demo)..."
-safe('Phone route') { client.fabric.resources.assign_phone_route(relay_id, phone_number: '+15551234567') }
-
-# 9. Assign a domain application (demo)
+# 7. Assign a domain application (demo)
 puts "\nAssigning domain application (demo)..."
 safe('Domain app') { client.fabric.resources.assign_domain_application(relay_id, domain: 'app.example.com') }
 
-# 10. Generate tokens
+# NOTE: To bind a phone number to a webhook/agent/flow, set call_handler on
+# the phone number directly -- see rest_bind_phone_to_swml_webhook.rb.
+# assign_phone_route does NOT work for swml_webhook / cxml_webhook / ai_agent.
+
+# 8. Generate tokens
 puts "\nGenerating tokens..."
 safe('Guest token') do
   guest = client.fabric.tokens.create_guest_token(resource_id: relay_id)
@@ -98,12 +89,10 @@ safe('Embed token') do
   puts "  Embed token: #{embed.fetch('token', '')[0, 40]}..."
 end
 
-# 11. Clean up
+# 9. Clean up
 puts "\nCleaning up..."
 client.fabric.relay_applications.delete(relay_id)
 puts "  Deleted relay application #{relay_id}"
-client.fabric.cxml_webhooks.delete(cxml_wh_id)
-puts "  Deleted cXML webhook #{cxml_wh_id}"
 client.fabric.cxml_scripts.delete(cxml_id)
 puts "  Deleted cXML script #{cxml_id}"
 client.fabric.conference_rooms.delete(room_id)

--- a/tests/rest/fabric_test.rb
+++ b/tests/rest/fabric_test.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
+require 'stringio'
 require_relative '../../lib/signalwire/rest/rest_client'
+require_relative 'phone_numbers_test' # for RecordingHttpClient
 
 class RestFabricDetailedTest < Minitest::Test
   def test_fabric_sub_resources
@@ -33,5 +35,82 @@ class RestFabricDetailedTest < Minitest::Test
       http, '/api/fabric/resources/cxml_applications'
     )
     assert_raises(NotImplementedError) { resource.create(name: 'test') }
+  end
+
+  # --- Deprecation warnings --------------------------------------------
+  # The three code paths identified in the phone-binding post-mortem that
+  # users reached for but that don't bind a phone number must warn loudly.
+
+  def test_assign_phone_route_emits_deprecation_warning
+    http = RecordingHttpClient.new
+    resources = SignalWire::REST::Namespaces::GenericResources.new(
+      http, '/api/fabric/resources'
+    )
+    stderr = capture_warn { resources.assign_phone_route('r-1', phone_number: '+15551234567') }
+    assert_match(/DEPRECATION/, stderr)
+    assert_match(/phone_numbers\.set_swml_webhook/, stderr)
+    # But the method still works -- call actually went through.
+    assert_equal 'POST', http.last[:method]
+    assert_equal '/api/fabric/resources/r-1/phone_routes', http.last[:path]
+  end
+
+  def test_swml_webhooks_create_emits_deprecation_warning
+    http = RecordingHttpClient.new
+    webhook = SignalWire::REST::Namespaces::SwmlWebhooksResource.new(
+      http, '/api/fabric/resources/swml_webhooks'
+    )
+    stderr = capture_warn do
+      webhook.create(name: 'x', primary_request_url: 'https://example.com/swml')
+    end
+    assert_match(/DEPRECATION/, stderr)
+    assert_match(/phone_numbers\.set_swml_webhook/, stderr)
+    # Still works.
+    assert_equal 'POST', http.last[:method]
+    assert_equal '/api/fabric/resources/swml_webhooks', http.last[:path]
+  end
+
+  def test_cxml_webhooks_create_emits_deprecation_warning
+    http = RecordingHttpClient.new
+    webhook = SignalWire::REST::Namespaces::CxmlWebhooksResource.new(
+      http, '/api/fabric/resources/cxml_webhooks'
+    )
+    stderr = capture_warn do
+      webhook.create(name: 'x', primary_request_url: 'https://example.com/cxml')
+    end
+    assert_match(/DEPRECATION/, stderr)
+    assert_match(/phone_numbers\.set_cxml_webhook/, stderr)
+    assert_equal 'POST', http.last[:method]
+    assert_equal '/api/fabric/resources/cxml_webhooks', http.last[:path]
+  end
+
+  # List/get/update/delete on SwmlWebhooksResource should NOT warn -- only
+  # create is deprecated.
+  def test_swml_webhooks_list_does_not_warn
+    http = RecordingHttpClient.new
+    webhook = SignalWire::REST::Namespaces::SwmlWebhooksResource.new(
+      http, '/api/fabric/resources/swml_webhooks'
+    )
+    stderr = capture_warn { webhook.list }
+    assert_equal '', stderr
+  end
+
+  def test_swml_webhooks_delete_does_not_warn
+    http = RecordingHttpClient.new
+    webhook = SignalWire::REST::Namespaces::SwmlWebhooksResource.new(
+      http, '/api/fabric/resources/swml_webhooks'
+    )
+    stderr = capture_warn { webhook.delete('r-1') }
+    assert_equal '', stderr
+  end
+
+  private
+
+  def capture_warn
+    original_stderr = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = original_stderr
   end
 end

--- a/tests/rest/phone_numbers_test.rb
+++ b/tests/rest/phone_numbers_test.rb
@@ -1,0 +1,274 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../../lib/signalwire/rest/rest_client'
+
+# Mock HttpClient that records requests without hitting the network.
+class RecordingHttpClient
+  attr_reader :requests
+
+  def initialize
+    @requests = []
+  end
+
+  def get(path, params = nil)
+    @requests << { method: 'GET', path: path, body: nil, params: params }
+    {}
+  end
+
+  def post(path, body = nil, params: nil)
+    @requests << { method: 'POST', path: path, body: body, params: params }
+    {}
+  end
+
+  def put(path, body = nil)
+    @requests << { method: 'PUT', path: path, body: body, params: nil }
+    {}
+  end
+
+  def patch(path, body = nil)
+    @requests << { method: 'PATCH', path: path, body: body, params: nil }
+    {}
+  end
+
+  def delete(path)
+    @requests << { method: 'DELETE', path: path, body: nil, params: nil }
+    {}
+  end
+
+  def last
+    @requests.last
+  end
+end
+
+class RestPhoneNumbersBindingTest < Minitest::Test
+  BASE = '/api/relay/rest/phone_numbers'
+
+  def setup
+    @http = RecordingHttpClient.new
+    @phone_numbers = SignalWire::REST::Namespaces::PhoneNumbersResource.new(@http)
+  end
+
+  # --- CRUD baseline ---------------------------------------------------
+
+  def test_update_uses_put
+    @phone_numbers.update('pn-1', name: 'Main')
+    assert_equal 'PUT', @http.last[:method]
+    assert_equal "#{BASE}/pn-1", @http.last[:path]
+    assert_equal({ name: 'Main' }, @http.last[:body])
+  end
+
+  def test_search_builds_query_path
+    @phone_numbers.search(area_code: '512')
+    assert_equal 'GET', @http.last[:method]
+    assert_equal "#{BASE}/search", @http.last[:path]
+    assert_equal({ area_code: '512' }, @http.last[:params])
+  end
+
+  # --- PhoneCallHandler enum contract ----------------------------------
+
+  def test_phone_call_handler_has_all_11_wire_values
+    expected = %w[
+      relay_script laml_webhooks laml_application ai_agent call_flow
+      relay_application relay_topic relay_context relay_connector
+      video_room dialogflow
+    ].freeze
+    assert_equal expected.sort, SignalWire::REST::PhoneCallHandler::ALL.sort
+  end
+
+  def test_phone_call_handler_constants_match_wire_values
+    assert_equal 'relay_script',      SignalWire::REST::PhoneCallHandler::RELAY_SCRIPT
+    assert_equal 'laml_webhooks',     SignalWire::REST::PhoneCallHandler::LAML_WEBHOOKS
+    assert_equal 'laml_application',  SignalWire::REST::PhoneCallHandler::LAML_APPLICATION
+    assert_equal 'ai_agent',          SignalWire::REST::PhoneCallHandler::AI_AGENT
+    assert_equal 'call_flow',         SignalWire::REST::PhoneCallHandler::CALL_FLOW
+    assert_equal 'relay_application', SignalWire::REST::PhoneCallHandler::RELAY_APPLICATION
+    assert_equal 'relay_topic',       SignalWire::REST::PhoneCallHandler::RELAY_TOPIC
+    assert_equal 'relay_context',     SignalWire::REST::PhoneCallHandler::RELAY_CONTEXT
+    assert_equal 'relay_connector',   SignalWire::REST::PhoneCallHandler::RELAY_CONNECTOR
+    assert_equal 'video_room',        SignalWire::REST::PhoneCallHandler::VIDEO_ROOM
+    assert_equal 'dialogflow',        SignalWire::REST::PhoneCallHandler::DIALOGFLOW
+  end
+
+  def test_phone_call_handler_all_frozen
+    assert SignalWire::REST::PhoneCallHandler::ALL.frozen?
+  end
+
+  # --- set_swml_webhook ------------------------------------------------
+
+  def test_set_swml_webhook_wire_body
+    @phone_numbers.set_swml_webhook('pn-1', url: 'https://example.com/swml')
+    assert_equal 'PUT', @http.last[:method]
+    assert_equal "#{BASE}/pn-1", @http.last[:path]
+    assert_equal(
+      { call_handler: 'relay_script', call_relay_script_url: 'https://example.com/swml' },
+      @http.last[:body]
+    )
+  end
+
+  def test_set_swml_webhook_extra_kwargs_pass_through
+    @phone_numbers.set_swml_webhook('pn-1', url: 'https://example.com/swml', name: 'Support')
+    body = @http.last[:body]
+    assert_equal 'Support', body[:name]
+    assert_equal 'relay_script', body[:call_handler]
+    assert_equal 'https://example.com/swml', body[:call_relay_script_url]
+  end
+
+  # --- set_cxml_webhook ------------------------------------------------
+
+  def test_set_cxml_webhook_minimal
+    @phone_numbers.set_cxml_webhook('pn-1', url: 'https://example.com/voice.xml')
+    assert_equal(
+      { call_handler: 'laml_webhooks', call_request_url: 'https://example.com/voice.xml' },
+      @http.last[:body]
+    )
+  end
+
+  def test_set_cxml_webhook_with_fallback_and_status
+    @phone_numbers.set_cxml_webhook(
+      'pn-1',
+      url: 'https://example.com/voice.xml',
+      fallback_url: 'https://example.com/fallback.xml',
+      status_callback_url: 'https://example.com/status'
+    )
+    assert_equal(
+      {
+        call_handler: 'laml_webhooks',
+        call_request_url: 'https://example.com/voice.xml',
+        call_fallback_url: 'https://example.com/fallback.xml',
+        call_status_callback_url: 'https://example.com/status'
+      },
+      @http.last[:body]
+    )
+  end
+
+  # --- set_cxml_application --------------------------------------------
+
+  def test_set_cxml_application_wire_body
+    @phone_numbers.set_cxml_application('pn-1', application_id: 'app-1')
+    assert_equal(
+      { call_handler: 'laml_application', call_laml_application_id: 'app-1' },
+      @http.last[:body]
+    )
+  end
+
+  # --- set_ai_agent ----------------------------------------------------
+
+  def test_set_ai_agent_wire_body
+    @phone_numbers.set_ai_agent('pn-1', agent_id: 'agent-1')
+    assert_equal(
+      { call_handler: 'ai_agent', call_ai_agent_id: 'agent-1' },
+      @http.last[:body]
+    )
+  end
+
+  # --- set_call_flow ---------------------------------------------------
+
+  def test_set_call_flow_minimal
+    @phone_numbers.set_call_flow('pn-1', flow_id: 'cf-1')
+    assert_equal(
+      { call_handler: 'call_flow', call_flow_id: 'cf-1' },
+      @http.last[:body]
+    )
+  end
+
+  def test_set_call_flow_with_version
+    @phone_numbers.set_call_flow('pn-1', flow_id: 'cf-1', version: 'current_deployed')
+    assert_equal(
+      {
+        call_handler: 'call_flow',
+        call_flow_id: 'cf-1',
+        call_flow_version: 'current_deployed'
+      },
+      @http.last[:body]
+    )
+  end
+
+  # --- set_relay_application -------------------------------------------
+
+  def test_set_relay_application_wire_body
+    @phone_numbers.set_relay_application('pn-1', name: 'my-app')
+    assert_equal(
+      { call_handler: 'relay_application', call_relay_application: 'my-app' },
+      @http.last[:body]
+    )
+  end
+
+  # --- set_relay_topic -------------------------------------------------
+
+  def test_set_relay_topic_minimal
+    @phone_numbers.set_relay_topic('pn-1', topic: 'office')
+    assert_equal(
+      { call_handler: 'relay_topic', call_relay_topic: 'office' },
+      @http.last[:body]
+    )
+  end
+
+  def test_set_relay_topic_with_status_callback
+    @phone_numbers.set_relay_topic(
+      'pn-1',
+      topic: 'office',
+      status_callback_url: 'https://example.com/status'
+    )
+    assert_equal(
+      {
+        call_handler: 'relay_topic',
+        call_relay_topic: 'office',
+        call_relay_topic_status_callback_url: 'https://example.com/status'
+      },
+      @http.last[:body]
+    )
+  end
+
+  # --- Helper coverage -------------------------------------------------
+
+  def test_all_seven_typed_helpers_present
+    %i[
+      set_swml_webhook set_cxml_webhook set_cxml_application set_ai_agent
+      set_call_flow set_relay_application set_relay_topic
+    ].each do |name|
+      assert_respond_to @phone_numbers, name, "phone_numbers missing binding helper: #{name}"
+    end
+  end
+
+  # --- Post-mortem regression ------------------------------------------
+
+  # The phone-binding post-mortem identified two traps that cost a user hours:
+  #   1. fabric.swml_webhooks.create(...) -> produces an orphan resource.
+  #   2. fabric.resources.assign_phone_route(...) -> returns 404/422 for
+  #      swml_webhook / cxml_webhook / ai_agent.
+  # The correct path is entirely through phone_numbers.update (directly or via
+  # the typed helpers). This test pins that contract.
+  def test_swml_binding_is_single_put_to_phone_numbers
+    @phone_numbers.set_swml_webhook('pn-1', url: 'https://example.com/swml')
+
+    assert_equal 1, @http.requests.size, 'should make exactly one HTTP call'
+    req = @http.requests.first
+    assert_equal 'PUT', req[:method]
+    assert_equal "#{BASE}/pn-1", req[:path]
+    refute_includes req[:path], '/api/fabric/resources/swml_webhooks',
+                    'should not call fabric.swml_webhooks.create'
+    refute_includes req[:path], '/phone_routes',
+                    'should not call assign_phone_route'
+  end
+
+  def test_wire_level_form_works_without_enum
+    @phone_numbers.update(
+      'pn-1',
+      call_handler: 'relay_script',
+      call_relay_script_url: 'https://example.com/swml'
+    )
+    body = @http.last[:body]
+    assert_equal 'relay_script', body[:call_handler]
+    assert_equal 'https://example.com/swml', body[:call_relay_script_url]
+  end
+
+  def test_enum_constant_and_wire_string_serialize_identically
+    @phone_numbers.update(
+      'pn-1',
+      call_handler: SignalWire::REST::PhoneCallHandler::RELAY_SCRIPT,
+      call_relay_script_url: 'https://example.com/swml'
+    )
+    assert_equal 'relay_script', @http.last[:body][:call_handler]
+  end
+end


### PR DESCRIPTION
## Summary

Ships typed phone-binding helpers — the good path for routing an inbound number to an SWML webhook / cXML webhook / AI agent / call flow / RELAY app/topic. Driven by a user post-mortem documenting hours lost on the existing trap (`fabric.swml_webhooks.create` + `fabric.resources.assign_phone_route` looked canonical but always failed live). Matches Python reference PR signalwire/signalwire-python#4 and the porting-sdk spec at `phone-binding.md`. Also makes true the README's long-standing "auto-materializes" promise about `swml_webhook`/`cxml_webhook` that was never accurate.

- New `SignalWire::REST::PhoneCallHandler` module with all 11 frozen string constants + `ALL` array. Named to avoid collision with the existing `@on_call_handler` in `Relay::Client`.
- Seven typed helpers on `phone_numbers`: `set_swml_webhook`, `set_cxml_webhook`, `set_cxml_application`, `set_ai_agent`, `set_call_flow`, `set_relay_application`, `set_relay_topic`. Ruby keyword args + `**extra` passthrough.
- `Kernel.warn(..., uplevel: 1)` + YARD `@deprecated` on `GenericResources#assign_phone_route`. Method still POSTs.
- New `AutoMaterializedWebhook` parent class; `SwmlWebhooksResource` / `CxmlWebhooksResource` subclasses warn on `create`, list/get/update/delete unchanged.
- Fixed misleading demo in `rest/examples/rest_fabric_conferences_and_routing.rb`.
- New example `rest/examples/rest_bind_phone_to_swml_webhook.rb` and rewritten `rest/docs/fabric.md`.

## Test plan

- [x] `bundle exec rake test` — 981 runs, 2432 assertions, 0 failures, 0 errors, 0 skips (baseline 956, +25 new)
- [x] 20 new tests in `tests/rest/phone_numbers_test.rb`: enum contract (11 values), 7 helper wire-body assertions, regression test pinning the happy path (one PUT, no `/swml_webhooks` POST, no `/phone_routes`)
- [x] 5 new tests in `tests/rest/fabric_test.rb` capturing `$stderr` to assert deprecation warnings fire on `assign_phone_route`, `swml_webhooks.create`, `cxml_webhooks.create`, and do NOT fire on list/delete
- [x] No new dependencies

## Non-breaking

All previously-working paths still work. Only new signal is the deprecation warning with a concrete pointer to the right helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)