### PR TITLE
Add Layer B symbol-level surface audit

### DIFF
--- a/.github/workflows/surface-audit.yml
+++ b/.github/workflows/surface-audit.yml
@@ -1,0 +1,72 @@
+name: Surface Audit (Layer B)
+# Enforces symbol-level parity between this Ruby port and the Python
+# reference that lives in the porting-sdk repo. Any drift — a Python symbol
+# missing from the port without an entry in PORT_OMISSIONS.md, or a
+# port-only symbol without an entry in PORT_ADDITIONS.md — fails the job.
+#
+# See:
+#   - scripts/enumerate_surface.rb           (produces port_surface.json)
+#   - PORT_OMISSIONS.md / PORT_ADDITIONS.md  (deliberate deltas)
+#   - ../porting-sdk/scripts/diff_port_surface.py (the diff tool)
+#   - ../porting-sdk/python_surface.json     (the canonical reference)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Nightly at 06:30 UTC so we catch upstream python_surface.json drift
+    # within 24 hours.
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  surface-audit:
+    name: Verify symbol-level parity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout signalwire-ruby
+        uses: actions/checkout@v5
+
+      - name: Checkout porting-sdk alongside
+        uses: actions/checkout@v5
+        with:
+          repository: signalwire/porting-sdk
+          path: porting-sdk
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Set up Python (for the diff tool)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Regenerate port_surface.json
+        run: |
+          # Prefer bundle exec if the Gemfile loads; fall back to plain ruby.
+          if bundle check >/dev/null 2>&1; then
+            bundle exec ruby scripts/enumerate_surface.rb --output port_surface.json
+          else
+            ruby scripts/enumerate_surface.rb --output port_surface.json
+          fi
+
+      - name: Detect stale port_surface.json
+        run: |
+          if ! git diff --exit-code -- port_surface.json; then
+            echo "::error::port_surface.json is stale. Regenerate with:"
+            echo "::error::  ruby scripts/enumerate_surface.rb --output port_surface.json"
+            exit 1
+          fi
+
+      - name: Diff against python_surface.json
+        run: |
+          python3 porting-sdk/scripts/diff_port_surface.py \
+              --reference porting-sdk/python_surface.json \
+              --port-surface port_surface.json \
+              --omissions PORT_OMISSIONS.md \
+              --additions PORT_ADDITIONS.md

--- a/PORT_ADDITIONS.md
+++ b/PORT_ADDITIONS.md
@@ -1,0 +1,565 @@
+# PORT_ADDITIONS.md
+
+Symbols present in this Ruby port's `port_surface.json` but **not** in
+`python_surface.json`. Each line has the form:
+
+    <fully.qualified.symbol>: <one-sentence rationale>
+
+Lines starting with `#` are ignored by `diff_port_surface.py`. Blank lines
+are ignored too. Every addition needs a justification so reviewers can
+spot drift from the Python reference.
+
+## Category summary
+
+- **Runtime support**: `signalwire.runtime.Runtime` (added in
+  `feat/lambda-support`) with `execution_mode`, `lambda?`, `serverless?`,
+  and `lambda_base_url` — Ruby SDK needs to detect the serverless
+  environment at startup. Python has an equivalent buried inside
+  `signalwire.core.logging_config.get_execution_mode` (also omitted).
+- **Lambda runtime**: `signalwire.serverless.lambda_handler.LambdaHandler`
+  (added in `feat/lambda-support`) — Rack-compatible handler for AWS
+  Lambda. Python has no equivalent in its module structure.
+- **Mixin hoisting** (~56 methods under
+  `signalwire.core.agent_base.AgentBase.*`): Python distributes these
+  across `signalwire.core.mixins.*`; Ruby's single-inheritance + modules
+  model consolidates them on `AgentBase`. The corresponding mixin classes
+  are omitted in PORT_OMISSIONS.md.
+- **Ruby-idiomatic method naming**: `to_h` (vs `to_dict`), `to_json`,
+  `to_s`, `inspect`, `?`-suffixed predicates, `!`-suffixed bang methods.
+  Idiomatic Ruby equivalents of Python methods omitted in
+  PORT_OMISSIONS.md.
+- **attr_reader accessors**: Ruby exposes constructor state via
+  `attr_reader` methods (e.g. `AgentBase#name`, `Call#project_id`,
+  `ConciergeAgent#amenities`). Python exposes the same data as dataclass
+  fields or `@property` getters.
+- **REST namespace accessors** (`RestClient.addresses`, `RestClient.video`,
+  `FabricNamespace.swml_webhooks`, etc.): Ruby `attr_reader` methods on
+  namespace resources. Python uses `@property` for the same access.
+- **SWML consolidated classes**: `signalwire.swml.document.Document`,
+  `signalwire.swml.schema.Schema`, `signalwire.swml.service.Service` —
+  Ruby collapses the Python `SWMLBuilder`/`SwmlRenderer`/`SchemaUtils`/
+  `SWMLService` split into three cohesive classes under
+  `SignalWire::SWML::*`. The Python counterparts are omitted.
+- **Ruby-keyword workarounds**: `Call.pass_call` (Python `Call.pass_`),
+  `Call.tap_audio` (Python `Call.tap`), `CallingNamespace.end_call`
+  (Python `CallingNamespace.end`), `Message.on_event`/`on_completed`
+  (Python `Message.on`), `Action.is_done?`/`done?` (Python `is_done`).
+- **Module-level helpers**: `SignalWire::Logging`, `SignalWire::SWML`,
+  `SignalWire::Contexts`, `SignalWire::Runtime` module functions. These
+  mirror behaviour Python keeps inside classes or separate files.
+- **Relay event attr_readers** (~118 symbols under
+  `signalwire.relay.event.*Event.*`): Ruby exposes Python `@dataclass`
+  fields as explicit attr_readers. Every event class mirrors the Python
+  contract but with Ruby-style accessors.
+
+# Added symbols
+
+signalwire.agent_server.AgentServer.host: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.agent_server.AgentServer.port: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.agent_server.AgentServer.rack_app: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.contexts.Contexts: port-only: SignalWire::Contexts module with create_simple_context helper
+signalwire.contexts.Contexts.create_simple_context: port-only: Ruby counterpart of Python signalwire.core.contexts.create_simple_context (omitted)
+signalwire.core.agent_base.AgentBase.add_function_include: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.add_hint: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.add_hints: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.add_internal_filler: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.add_language: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.add_mcp_server: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.add_pattern_hint: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.add_pronunciation: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.add_skill: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.as_rack_app: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.contexts: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.define_contexts: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.define_tool: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.define_tools: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.enable_debug_events: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.enable_debug_routes: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.enable_mcp_server: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.extract_sip_username: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.extract_sip_username_from_request: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.get_basic_auth_credentials: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.get_prompt: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.has_skill?: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.host: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.list_skills: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.list_tool_names: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.logger: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.manual_set_proxy_url: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.name: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.on_function_call: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.port: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.prompt_add_section: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.prompt_add_subsection: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.prompt_add_to_section: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.prompt_has_section?: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.rack_app: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.register_swaig_function: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.remove_skill: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.render_swml: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.reset_contexts: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.route: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.run: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.serve: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_dynamic_config_callback: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_function_includes: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_global_data: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_internal_fillers: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_languages: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_native_functions: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_param: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_params: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_post_prompt: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_post_prompt_llm_params: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_prompt_llm_params: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_prompt_pom: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_prompt_text: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.set_pronunciations: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.agent_base.AgentBase.update_global_data: port-only: mixin method collapsed onto SignalWire::AgentBase (Ruby single-inheritance + modules model replaces Python multiple inheritance)
+signalwire.core.contexts.Context.name: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.core.contexts.Context.to_h: port-only: Ruby convention - to_h replaces Python to_dict
+signalwire.core.contexts.ContextBuilder.attach_agent: port-only: Ruby ContextBuilder attaches to an agent for method chaining
+signalwire.core.contexts.ContextBuilder.to_h: port-only: Ruby convention - to_h replaces Python to_dict
+signalwire.core.contexts.ContextBuilder.validate!: port-only: Ruby bang-convention validate! matching Python validate (omitted)
+signalwire.core.contexts.GatherInfo.completion_action: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.core.contexts.GatherInfo.output_key: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.core.contexts.GatherInfo.prompt: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.core.contexts.GatherInfo.questions: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.core.contexts.GatherInfo.to_h: port-only: Ruby convention - to_h replaces Python to_dict
+signalwire.core.contexts.GatherQuestion.confirm: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.core.contexts.GatherQuestion.functions: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.core.contexts.GatherQuestion.key: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.core.contexts.GatherQuestion.prompt: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.core.contexts.GatherQuestion.question: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.core.contexts.GatherQuestion.to_h: port-only: Ruby convention - to_h replaces Python to_dict
+signalwire.core.contexts.GatherQuestion.type: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.core.contexts.Step.name: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.core.contexts.Step.to_h: port-only: Ruby convention - to_h replaces Python to_dict
+signalwire.core.data_map.DataMap.create_expression_tool: port-only class method: moved from module-level function in Python
+signalwire.core.data_map.DataMap.create_simple_api_tool: port-only class method: moved from module-level function in Python
+signalwire.core.data_map.DataMap.function_name: port-only: attr_reader for function_name
+signalwire.core.function_result.FunctionResult.action: port-only: attr_reader for function-result action array
+signalwire.core.function_result.FunctionResult.post_process: port-only: attr_reader for post_process flag
+signalwire.core.function_result.FunctionResult.response: port-only: attr_reader for response text
+signalwire.core.function_result.FunctionResult.to_h: port-only: Ruby convention - to_h replaces to_dict
+signalwire.core.function_result.FunctionResult.to_json: port-only: Ruby convention - to_json serializer
+signalwire.core.security.session_manager.SessionManager.create_token: port-only: Ruby create_token name matches the Python generate_token/create_tool_token surface (both omitted)
+signalwire.core.skill_base.SkillBase.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.core.skill_base.SkillBase.get_param: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.core.skill_base.SkillBase.instance_key: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.core.skill_base.SkillBase.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.core.skill_base.SkillBase.params: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.core.skill_base.SkillBase.required_env_vars: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.core.skill_base.SkillBase.supports_multiple_instances?: port-only: Ruby predicate method (? suffix)
+signalwire.core.skill_base.SkillBase.version: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.core.skill_manager.SkillManager.clear: port-only: SkillManager#clear - no direct Python equivalent (Python unloads individually)
+signalwire.core.skill_manager.SkillManager.get: port-only: SkillManager#get - Ruby shortened name; see PORT_OMISSIONS for get_skill
+signalwire.core.skill_manager.SkillManager.load: port-only: SkillManager#load - Ruby shortened name; see PORT_OMISSIONS for load_skill
+signalwire.core.skill_manager.SkillManager.loaded?: port-only: SkillManager#loaded? predicate - Ruby shortened name; see PORT_OMISSIONS for has_skill
+signalwire.core.skill_manager.SkillManager.loaded_keys: port-only: SkillManager#loaded_keys - Ruby shortened name; see PORT_OMISSIONS for list_loaded_skills
+signalwire.core.skill_manager.SkillManager.size: port-only: SkillManager#size - count of loaded skills
+signalwire.core.skill_manager.SkillManager.unload: port-only: SkillManager#unload - Ruby shortened name; see PORT_OMISSIONS for unload_skill
+signalwire.logging.Logging: port-only: Ruby SignalWire::Logging module (Python splits this between core.logging_config and standard logging)
+signalwire.logging.Logging.global_level: port-only: module accessor for the current log level
+signalwire.logging.Logging.logger: port-only: module accessor for a named logger
+signalwire.logging.Logging.reset!: port-only: Ruby bang-convention - reset logging configuration (used in tests)
+signalwire.logging.Logging.suppressed?: port-only: Ruby predicate - check if logging is suppressed
+signalwire.prefabs.concierge.ConciergeAgent.amenities: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.concierge.ConciergeAgent.global_data: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.concierge.ConciergeAgent.handle_amenity_info: port-only: Ruby prefab handler method (Ruby naming differs from Python)
+signalwire.prefabs.concierge.ConciergeAgent.handle_service_info: port-only: Ruby prefab handler method (Ruby naming differs from Python)
+signalwire.prefabs.concierge.ConciergeAgent.name: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.concierge.ConciergeAgent.prompt_sections: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.concierge.ConciergeAgent.route: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.concierge.ConciergeAgent.services: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.concierge.ConciergeAgent.tools: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.concierge.ConciergeAgent.venue_name: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.faq_bot.FAQBotAgent.faqs: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.faq_bot.FAQBotAgent.global_data: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.faq_bot.FAQBotAgent.handle_search: port-only: Ruby prefab handler method (Ruby naming differs from Python)
+signalwire.prefabs.faq_bot.FAQBotAgent.name: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.faq_bot.FAQBotAgent.prompt_sections: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.faq_bot.FAQBotAgent.route: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.faq_bot.FAQBotAgent.tools: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.info_gatherer.InfoGathererAgent.global_data: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.info_gatherer.InfoGathererAgent.handle_start: port-only: Ruby prefab handler method (Ruby naming differs from Python)
+signalwire.prefabs.info_gatherer.InfoGathererAgent.handle_submit: port-only: Ruby prefab handler method (Ruby naming differs from Python)
+signalwire.prefabs.info_gatherer.InfoGathererAgent.name: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.info_gatherer.InfoGathererAgent.prompt_sections: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.info_gatherer.InfoGathererAgent.questions: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.info_gatherer.InfoGathererAgent.route: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.info_gatherer.InfoGathererAgent.tools: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.receptionist.ReceptionistAgent.departments: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.receptionist.ReceptionistAgent.global_data: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.receptionist.ReceptionistAgent.greeting: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.receptionist.ReceptionistAgent.handle_transfer: port-only: Ruby prefab handler method (Ruby naming differs from Python)
+signalwire.prefabs.receptionist.ReceptionistAgent.name: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.receptionist.ReceptionistAgent.prompt_sections: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.receptionist.ReceptionistAgent.route: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.receptionist.ReceptionistAgent.tools: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.survey.SurveyAgent.global_data: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.survey.SurveyAgent.handle_start: port-only: Ruby prefab handler method (Ruby naming differs from Python)
+signalwire.prefabs.survey.SurveyAgent.handle_submit: port-only: Ruby prefab handler method (Ruby naming differs from Python)
+signalwire.prefabs.survey.SurveyAgent.handle_summary: port-only: Ruby prefab handler method (Ruby naming differs from Python)
+signalwire.prefabs.survey.SurveyAgent.name: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.survey.SurveyAgent.prompt_sections: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.survey.SurveyAgent.questions: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.survey.SurveyAgent.route: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.survey.SurveyAgent.survey_name: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.prefabs.survey.SurveyAgent.tools: port-only: Ruby attr_reader on prefab (configuration state)
+signalwire.relay.call.Action.call: port-only: attr_reader for parent call
+signalwire.relay.call.Action.completed: port-only: attr_reader for action completed state
+signalwire.relay.call.Action.control_id: port-only: attr_reader for control_id
+signalwire.relay.call.Action.done?: port-only: Ruby predicate for done state
+signalwire.relay.call.Action.is_done?: port-only: Ruby predicate for done state (see PORT_OMISSIONS for Python is_done)
+signalwire.relay.call.Action.on_completed: port-only: block-style event handler (idiomatic Ruby)
+signalwire.relay.call.Action.result: port-only: attr_reader for action result
+signalwire.relay.call.Call.call_id: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.call.Call.context: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.call.Call.device: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.call.Call.direction: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.call.Call.ended?: port-only: Ruby predicate for ended state
+signalwire.relay.call.Call.inspect: port-only: Ruby Object#inspect override
+signalwire.relay.call.Call.node_id: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.call.Call.pass_call: port-only: Ruby Call#pass_call - see PORT_OMISSIONS for Python pass_ (Ruby keyword conflict)
+signalwire.relay.call.Call.project_id: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.call.Call.segment_id: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.call.Call.state: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.call.Call.tag: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.call.Call.tap_audio: port-only: Ruby Call#tap_audio - see PORT_OMISSIONS for Python tap (Ruby core method conflict)
+signalwire.relay.call.Call.to_s: port-only: Ruby Object#to_s override
+signalwire.relay.client.ActionTimeoutError: port-only: Ruby error class for action timeouts (Python uses asyncio.TimeoutError)
+signalwire.relay.client.RelayClient.project_id: port-only: attr_reader for project_id on Client
+signalwire.relay.client.RelayClient.protocol: port-only: Ruby Client#protocol - see PORT_OMISSIONS for Python relay_protocol equivalent
+signalwire.relay.client.RelayClient.stop: port-only: Ruby Client#stop - see PORT_OMISSIONS for Python disconnect equivalent
+signalwire.relay.client.RelayError.code: port-only: attr_reader for error code
+signalwire.relay.client.RelayError.error_message: port-only: attr_reader for error message
+signalwire.relay.event.CallReceiveEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallReceiveEvent.call_state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallReceiveEvent.context: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallReceiveEvent.device: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallReceiveEvent.direction: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallReceiveEvent.node_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallReceiveEvent.project_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallReceiveEvent.segment_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallReceiveEvent.tag: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallStateEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallStateEvent.call_state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallStateEvent.device: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallStateEvent.direction: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallStateEvent.end_reason: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallingErrorEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallingErrorEvent.code: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CallingErrorEvent.message: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CollectEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CollectEvent.control_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CollectEvent.final: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CollectEvent.result_data: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.CollectEvent.state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.ConferenceEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.ConferenceEvent.conference_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.ConferenceEvent.name: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.ConferenceEvent.status: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.ConnectEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.ConnectEvent.connect_state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.ConnectEvent.peer: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.DenoiseEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.DenoiseEvent.denoised: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.DetectEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.DetectEvent.control_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.DetectEvent.detect: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.DialEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.DialEvent.call_data: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.DialEvent.dial_state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.DialEvent.tag: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.EchoEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.EchoEvent.state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.FaxEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.FaxEvent.control_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.FaxEvent.fax: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.HoldEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.HoldEvent.state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageReceiveEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageReceiveEvent.body: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageReceiveEvent.context: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageReceiveEvent.direction: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageReceiveEvent.from_number: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageReceiveEvent.media: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageReceiveEvent.message_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageReceiveEvent.message_state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageReceiveEvent.segments: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageReceiveEvent.tags: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageReceiveEvent.to_number: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageStateEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageStateEvent.body: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageStateEvent.context: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageStateEvent.direction: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageStateEvent.from_number: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageStateEvent.media: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageStateEvent.message_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageStateEvent.message_state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageStateEvent.reason: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageStateEvent.segments: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageStateEvent.tags: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.MessageStateEvent.to_number: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.PayEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.PayEvent.control_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.PayEvent.state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.PlayEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.PlayEvent.control_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.PlayEvent.state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.QueueEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.QueueEvent.control_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.QueueEvent.position: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.QueueEvent.queue_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.QueueEvent.queue_name: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.QueueEvent.size: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.QueueEvent.status: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.RecordEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.RecordEvent.control_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.RecordEvent.duration: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.RecordEvent.record: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.RecordEvent.size: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.RecordEvent.state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.RecordEvent.url: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.ReferEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.ReferEvent.sip_notify_response_code: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.ReferEvent.sip_refer_response_code: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.ReferEvent.sip_refer_to: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.ReferEvent.state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.RelayEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.RelayEvent.call_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.RelayEvent.event_type: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.RelayEvent.params: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.RelayEvent.timestamp: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.SendDigitsEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.SendDigitsEvent.control_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.SendDigitsEvent.state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.StreamEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.StreamEvent.control_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.StreamEvent.name: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.StreamEvent.state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.StreamEvent.url: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.TapEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.TapEvent.control_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.TapEvent.device: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.TapEvent.state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.TapEvent.tap: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.TranscribeEvent.__init__: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.TranscribeEvent.control_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.TranscribeEvent.duration: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.TranscribeEvent.recording_id: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.TranscribeEvent.size: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.TranscribeEvent.state: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.event.TranscribeEvent.url: port-only: Ruby attr_reader on relay event (Python exposes same data as dataclass field)
+signalwire.relay.message.Message.body: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.message.Message.context: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.message.Message.direction: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.message.Message.done?: port-only: Ruby predicate for done state
+signalwire.relay.message.Message.from_number: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.message.Message.inspect: port-only: Ruby Object#inspect override
+signalwire.relay.message.Message.is_done?: port-only: Ruby predicate (see PORT_OMISSIONS for Python is_done)
+signalwire.relay.message.Message.media: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.message.Message.message_id: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.message.Message.on_completed: port-only: block-style completion handler
+signalwire.relay.message.Message.on_event: port-only: block-style event handler - Ruby name (see PORT_OMISSIONS for Python on)
+signalwire.relay.message.Message.reason: port-only: attr_reader for message failure reason
+signalwire.relay.message.Message.segments: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.message.Message.state: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.message.Message.tags: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.message.Message.to_number: port-only: Ruby attr_reader exposing constructor state (idiomatic Ruby; Python uses property decorators or public fields)
+signalwire.relay.message.Message.to_s: port-only: Ruby Object#to_s override
+signalwire.rest._base.CrudResource.update_method: port-only: per-resource override hook for PATCH vs PUT (default update verb)
+signalwire.rest._base.HttpClient.base_url: port-only: attr_reader for base_url
+signalwire.rest._base.SignalWireRestError.body: port-only: attr_reader for error body
+signalwire.rest._base.SignalWireRestError.method_name: port-only: attr_reader for originating HTTP method
+signalwire.rest._base.SignalWireRestError.status_code: port-only: attr_reader for HTTP status
+signalwire.rest._base.SignalWireRestError.url: port-only: attr_reader for failed URL
+signalwire.rest.client.RestClient.addresses: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.calling: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.chat: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.compat: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.datasphere: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.fabric: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.imported_numbers: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.logs: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.lookup: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.mfa: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.number_groups: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.phone_numbers: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.project: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.pubsub: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.queues: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.recordings: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.registry: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.short_codes: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.sip_profile: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.verified_callers: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.client.RestClient.video: port-only: attr_reader for REST namespace (Python exposes via @property)
+signalwire.rest.namespaces.calling.CallingNamespace.end_call: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.compat.CompatNamespace.accounts: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.compat.CompatNamespace.applications: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.compat.CompatNamespace.calls: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.compat.CompatNamespace.conferences: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.compat.CompatNamespace.faxes: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.compat.CompatNamespace.laml_bins: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.compat.CompatNamespace.messages: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.compat.CompatNamespace.phone_numbers: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.compat.CompatNamespace.queues: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.compat.CompatNamespace.recordings: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.compat.CompatNamespace.tokens: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.compat.CompatNamespace.transcriptions: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.datasphere.DatasphereNamespace.documents: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.addresses: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.ai_agents: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.call_flows: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.conference_rooms: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.cxml_applications: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.cxml_scripts: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.cxml_webhooks: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.freeswitch_connectors: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.relay_applications: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.resources: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.sip_endpoints: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.sip_gateways: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.subscribers: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.swml_scripts: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.swml_webhooks: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricNamespace.tokens: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.fabric.FabricResource.list_addresses: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.logs.LogsNamespace.conferences: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.logs.LogsNamespace.fax: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.logs.LogsNamespace.messages: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.logs.LogsNamespace.voice: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.project.ProjectNamespace.tokens: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.registry.RegistryNamespace.brands: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.registry.RegistryNamespace.campaigns: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.registry.RegistryNamespace.numbers: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.registry.RegistryNamespace.orders: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.video.VideoNamespace.conference_tokens: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.video.VideoNamespace.conferences: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.video.VideoNamespace.room_recordings: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.video.VideoNamespace.room_sessions: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.video.VideoNamespace.room_tokens: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.video.VideoNamespace.rooms: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.rest.namespaces.video.VideoNamespace.streams: port-only: attr_reader for sub-resource (Python uses @property)
+signalwire.runtime.Runtime: port-only: Ruby SDK runtime bootstrap (feat/lambda-support - not in Python module structure)
+signalwire.runtime.Runtime.execution_mode: port-only: detects lambda/cgi/google_cloud_function/azure_function/server runtime
+signalwire.runtime.Runtime.lambda?: port-only: Ruby predicate - true when inside AWS Lambda
+signalwire.runtime.Runtime.lambda_base_url: port-only: constructs the AWS Lambda Function URL from env
+signalwire.runtime.Runtime.serverless?: port-only: Ruby predicate - true inside any serverless platform
+signalwire.serverless.lambda_handler.LambdaHandler: port-only: Lambda runtime support added in feat/lambda-support; not in Python module structure
+signalwire.serverless.lambda_handler.LambdaHandler.__init__: port-only: Lambda runtime support
+signalwire.serverless.lambda_handler.LambdaHandler.call: port-only: Lambda runtime support (Rack-style #call entrypoint)
+signalwire.serverless.lambda_handler.LambdaHandler.for: port-only: LambdaHandler.for(agent) class-method factory
+signalwire.skills.api_ninjas_trivia.skill.ApiNinjasTriviaSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.api_ninjas_trivia.skill.ApiNinjasTriviaSkill.instance_key: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.api_ninjas_trivia.skill.ApiNinjasTriviaSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.api_ninjas_trivia.skill.ApiNinjasTriviaSkill.supports_multiple_instances?: port-only: Ruby predicate method (? suffix)
+signalwire.skills.builtin.custom_skills_skill.CustomSkillsSkill: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.builtin.custom_skills_skill.CustomSkillsSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.builtin.custom_skills_skill.CustomSkillsSkill.get_parameter_schema: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.builtin.custom_skills_skill.CustomSkillsSkill.instance_key: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.builtin.custom_skills_skill.CustomSkillsSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.builtin.custom_skills_skill.CustomSkillsSkill.register_tools: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.builtin.custom_skills_skill.CustomSkillsSkill.setup: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.builtin.custom_skills_skill.CustomSkillsSkill.supports_multiple_instances?: port-only: Ruby predicate method (? suffix)
+signalwire.skills.claude_skills.skill.ClaudeSkillsSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.claude_skills.skill.ClaudeSkillsSkill.get_prompt_sections: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.claude_skills.skill.ClaudeSkillsSkill.instance_key: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.claude_skills.skill.ClaudeSkillsSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.claude_skills.skill.ClaudeSkillsSkill.supports_multiple_instances?: port-only: Ruby predicate method (? suffix)
+signalwire.skills.datasphere.skill.DataSphereSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.datasphere.skill.DataSphereSkill.instance_key: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.datasphere.skill.DataSphereSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.datasphere.skill.DataSphereSkill.supports_multiple_instances?: port-only: Ruby predicate method (? suffix)
+signalwire.skills.datasphere_serverless.skill.DataSphereServerlessSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.datasphere_serverless.skill.DataSphereServerlessSkill.instance_key: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.datasphere_serverless.skill.DataSphereServerlessSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.datasphere_serverless.skill.DataSphereServerlessSkill.supports_multiple_instances?: port-only: Ruby predicate method (? suffix)
+signalwire.skills.datetime.skill.DateTimeSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.datetime.skill.DateTimeSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.google_maps.skill.GoogleMapsSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.google_maps.skill.GoogleMapsSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.info_gatherer.skill.InfoGathererSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.info_gatherer.skill.InfoGathererSkill.get_prompt_sections: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.info_gatherer.skill.InfoGathererSkill.instance_key: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.info_gatherer.skill.InfoGathererSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.info_gatherer.skill.InfoGathererSkill.supports_multiple_instances?: port-only: Ruby predicate method (? suffix)
+signalwire.skills.joke.skill.JokeSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.joke.skill.JokeSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.math.skill.MathSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.math.skill.MathSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.mcp_gateway.skill.MCPGatewaySkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.mcp_gateway.skill.MCPGatewaySkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.native_vector_search.skill.NativeVectorSearchSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.native_vector_search.skill.NativeVectorSearchSkill.instance_key: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.native_vector_search.skill.NativeVectorSearchSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.native_vector_search.skill.NativeVectorSearchSkill.supports_multiple_instances?: port-only: Ruby predicate method (? suffix)
+signalwire.skills.play_background_file.skill.PlayBackgroundFileSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.play_background_file.skill.PlayBackgroundFileSkill.instance_key: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.play_background_file.skill.PlayBackgroundFileSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.play_background_file.skill.PlayBackgroundFileSkill.supports_multiple_instances?: port-only: Ruby predicate method (? suffix)
+signalwire.skills.registry.SkillRegistry.get_factory: port-only: returns class-or-factory (see PORT_OMISSIONS for Python get_skill_class)
+signalwire.skills.registry.SkillRegistry.register: port-only: explicit registry registration (Ruby ships built-ins via register_builtins!)
+signalwire.skills.registry.SkillRegistry.register_builtins!: port-only: Ruby bang-convention to seed the registry with built-in skills
+signalwire.skills.registry.SkillRegistry.registered?: port-only: Ruby predicate - is_registered check
+signalwire.skills.registry.SkillRegistry.reset!: port-only: Ruby bang-convention to clear the registry (used in tests)
+signalwire.skills.spider.skill.SpiderSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.spider.skill.SpiderSkill.instance_key: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.spider.skill.SpiderSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.spider.skill.SpiderSkill.supports_multiple_instances?: port-only: Ruby predicate method (? suffix)
+signalwire.skills.swml_transfer.skill.SWMLTransferSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.swml_transfer.skill.SWMLTransferSkill.instance_key: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.swml_transfer.skill.SWMLTransferSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.swml_transfer.skill.SWMLTransferSkill.supports_multiple_instances?: port-only: Ruby predicate method (? suffix)
+signalwire.skills.weather_api.skill.WeatherApiSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.weather_api.skill.WeatherApiSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.web_search.skill.WebSearchSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.web_search.skill.WebSearchSkill.instance_key: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.web_search.skill.WebSearchSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.web_search.skill.WebSearchSkill.supports_multiple_instances?: port-only: Ruby predicate method (? suffix)
+signalwire.skills.web_search.skill.WebSearchSkill.version: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.wikipedia_search.skill.WikipediaSearchSkill.description: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.skills.wikipedia_search.skill.WikipediaSearchSkill.name: port-only: Ruby attr_reader on skill (matches Python __init__ stored attribute)
+signalwire.swml.SWML: port-only: SignalWire::SWML module with schema accessors
+signalwire.swml.SWML.reset_schema!: port-only: Ruby bang-convention - clears the cached SWML schema (used in tests)
+signalwire.swml.SWML.schema: port-only: module accessor for the shared SWML schema instance
+signalwire.swml.document.Document: port-only: Ruby consolidated SWML builder+document; maps to Python SWMLBuilder/swml_renderer
+signalwire.swml.document.Document.__init__: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.document.Document.add_section: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.document.Document.add_verb: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.document.Document.add_verb_to_section: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.document.Document.get_verbs: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.document.Document.has_section?: port-only: Ruby predicate method (? suffix)
+signalwire.swml.document.Document.render: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.document.Document.render_pretty: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.document.Document.reset: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.document.Document.sections: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.document.Document.to_h: port-only: Ruby convention - to_h replaces Python to_dict
+signalwire.swml.document.Document.version: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.schema.Schema: port-only: Ruby consolidated schema utils; maps to Python SchemaUtils
+signalwire.swml.schema.Schema.__init__: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.schema.Schema.get_verb: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.schema.Schema.valid_verb?: port-only: Ruby predicate method (? suffix)
+signalwire.swml.schema.Schema.verb_count: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.schema.Schema.verb_names: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.schema.Schema.verbs: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service: port-only: Ruby consolidated SWML service; maps to Python SWMLService
+signalwire.swml.service.Service.__init__: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.document: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.execute_verb: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.get_basic_auth_credentials: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.get_full_url: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.host: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.method_missing: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.name: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.on_request: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.port: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.rack_app: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.register_routing_callback: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.render: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.render_pretty: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.route: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.serve: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)
+signalwire.swml.service.Service.stop: port-only: consolidated Ruby SWML class (see signalwire.swml.document/schema/service class-level rationale)

--- a/PORT_OMISSIONS.md
+++ b/PORT_OMISSIONS.md
@@ -1,0 +1,740 @@
+# PORT_OMISSIONS.md
+
+Symbols present in `python_surface.json` (the Python SDK reference at
+`/home/devuser/src/porting-sdk/python_surface.json`) that this Ruby port
+deliberately does **not** implement. Each line has the form:
+
+    <fully.qualified.symbol>: <one-sentence rationale>
+
+Lines starting with `#` are ignored by `diff_port_surface.py`. Blank lines
+are ignored too. Don't rename or remove entries without also updating the
+port surface; the diff tool will fail the build on unexcused drift.
+
+## Category summary
+
+- **CLI subsystem** (~120 symbols under `signalwire.cli.*`): Ruby SDK does
+  not ship a standalone CLI tool. Python's `signalwire-agents` CLI is a
+  separate project.
+- **Search subsystem** (~60 symbols under `signalwire.search.*`,
+  `signalwire.skills.native_vector_search.*`,
+  `signalwire.skills.web_search.skill_improved.*`,
+  `signalwire.skills.web_search.skill_original.*`): vector search /
+  indexing omitted per porting-sdk Phase 7 "What to Skip".
+- **Bedrock** (9 symbols under `signalwire.agents.bedrock.*`): omitted.
+- **LiveKit shim** (~65 symbols under `signalwire.livewire.*`): deferred
+  per PORTING_GUIDE.md "LiveKit Compatibility Shim" — added once core
+  port stabilises.
+- **MCP gateway service** (~35 symbols under `signalwire.mcp_gateway.*`):
+  separate daemon; Ruby agents consume MCP via
+  `SignalWire::AgentBase#add_mcp_server`.
+- **Python mixins** (~66 symbols under `signalwire.core.mixins.*`): Python
+  multiple-inheritance pattern collapsed into `SignalWire::AgentBase` per
+  Ruby's single-inheritance + modules model. Every mixin method is
+  present on `AgentBase` (see PORT_ADDITIONS.md entries under
+  `signalwire.core.agent_base.AgentBase.*`).
+- **POM internals** (~24 symbols under `signalwire.pom.*` and
+  `signalwire.core.pom_builder.*`): POM prompt-object-model managed
+  inline by `SignalWire::AgentBase` prompt methods.
+- **SWML internals** (~47 symbols under `signalwire.core.swml_service.*`,
+  `signalwire.core.swml_builder.*`, `signalwire.core.swml_renderer.*`,
+  `signalwire.core.swml_handler.*`, `signalwire.utils.schema_utils.*`):
+  consolidated into `SignalWire::SWML::Service`, `::Document`, and
+  `::Schema` (see PORT_ADDITIONS.md entries under `signalwire.swml.*`).
+- **Auth/Config/Logging/Security config** (~34 symbols): Ruby uses
+  `SignalWire::AgentBase` middleware, `ENV` directly, and
+  `SignalWire::Logging` instead of standalone classes.
+- **Web service** (6 symbols under `signalwire.web.web_service.*`):
+  standalone WebService not ported; static files served from
+  `SignalWire::Server::AgentServer`.
+- **Python async-context-manager / dunder methods** on RelayClient and
+  Message (`__aenter__`, `__aexit__`, `__del__`, `__repr__`): Ruby uses
+  block-style constructors and `inspect`/`to_s` idioms.
+- **Ruby-keyword conflicts** (`Call.pass_`, `Call.tap`,
+  `CallingNamespace.end`, `Message.on`, `Action.is_done`,
+  `Message.is_done`, various `to_dict`/`validate` methods): Ruby provides
+  equivalents under different names (see matching PORT_ADDITIONS.md
+  entries).
+- **Renamed symbols on SessionManager, SkillManager, SkillRegistry,
+  RelayClient**: Ruby uses shortened idiomatic names (see PORT_ADDITIONS
+  entries for the Ruby counterparts).
+- **Per-skill `get_hints`/`get_parameter_schema`/`setup`/`cleanup` hooks**
+  (~20 symbols): not yet implemented on individual Ruby skills; Ruby
+  built-ins register tools inline via `register_tools`.
+
+Everything explicitly marked `not_yet_implemented:` is a deliberate
+deferral — track those for future work.
+
+# Omitted symbols
+
+signalwire.RestClient: Ruby exposes SignalWire::REST::RestClient - not re-exported at top level
+signalwire.add_skill_directory: not_yet_implemented: top-level skill directory registration; use SignalWire::Skills::SkillRegistry directly
+signalwire.agent_server.AgentServer.register_global_routing_callback: not_yet_implemented: global routing callback on AgentServer
+signalwire.agents.bedrock.BedrockAgent: Bedrock agent omitted - not core to the port
+signalwire.agents.bedrock.BedrockAgent.__init__: Bedrock agent omitted - not core to the port
+signalwire.agents.bedrock.BedrockAgent.__repr__: Bedrock agent omitted - not core to the port
+signalwire.agents.bedrock.BedrockAgent.set_inference_params: Bedrock agent omitted - not core to the port
+signalwire.agents.bedrock.BedrockAgent.set_llm_model: Bedrock agent omitted - not core to the port
+signalwire.agents.bedrock.BedrockAgent.set_llm_temperature: Bedrock agent omitted - not core to the port
+signalwire.agents.bedrock.BedrockAgent.set_post_prompt_llm_params: Bedrock agent omitted - not core to the port
+signalwire.agents.bedrock.BedrockAgent.set_prompt_llm_params: Bedrock agent omitted - not core to the port
+signalwire.agents.bedrock.BedrockAgent.set_voice: Bedrock agent omitted - not core to the port
+signalwire.cli.build_search.console_entry_point: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.build_search.main: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.build_search.migrate_command: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.build_search.remote_command: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.build_search.search_command: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.build_search.validate_command: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.agent_loader.discover_agents_in_file: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.agent_loader.discover_services_in_file: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.agent_loader.load_agent_from_file: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.agent_loader.load_service_from_file: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.argparse_helpers.CustomArgumentParser: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.argparse_helpers.CustomArgumentParser.__init__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.argparse_helpers.CustomArgumentParser.error: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.argparse_helpers.CustomArgumentParser.parse_args: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.argparse_helpers.CustomArgumentParser.print_usage: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.argparse_helpers.parse_function_arguments: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.dynamic_config.apply_dynamic_config: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.service_loader.ServiceCapture: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.service_loader.ServiceCapture.__init__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.service_loader.ServiceCapture.capture: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.service_loader.discover_agents_in_file: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.service_loader.load_agent_from_file: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.service_loader.load_and_simulate_service: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.core.service_loader.simulate_request_to_service: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.Colors: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.DokkuProjectGenerator: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.DokkuProjectGenerator.__init__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.DokkuProjectGenerator.generate: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.cmd_config: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.cmd_deploy: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.cmd_init: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.cmd_logs: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.cmd_scale: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.generate_password: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.main: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.print_error: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.print_header: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.print_step: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.print_success: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.print_warning: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.prompt: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.dokku.prompt_yes_no: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.execution.datamap_exec.execute_datamap_function: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.execution.datamap_exec.simple_template_expand: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.execution.webhook_exec.execute_external_webhook_function: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.Colors: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.ProjectGenerator: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.ProjectGenerator.__init__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.ProjectGenerator.generate: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.generate_password: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.get_agent_template: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.get_app_template: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.get_env_credentials: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.get_readme_template: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.get_test_template: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.get_web_index_template: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.main: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.mask_token: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.print_error: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.print_step: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.print_success: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.print_warning: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.prompt: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.prompt_multiselect: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.prompt_select: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.prompt_yes_no: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.run_interactive: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.init_project.run_quick: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.output.output_formatter.display_agent_tools: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.output.output_formatter.format_result: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.output.swml_dump.handle_dump_swml: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.output.swml_dump.setup_output_suppression: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.data_generation.adapt_for_call_type: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.data_generation.generate_comprehensive_post_data: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.data_generation.generate_fake_node_id: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.data_generation.generate_fake_sip_from: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.data_generation.generate_fake_sip_to: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.data_generation.generate_fake_swml_post_data: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.data_generation.generate_fake_uuid: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.data_generation.generate_minimal_post_data: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.data_overrides.apply_convenience_mappings: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.data_overrides.apply_overrides: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.data_overrides.parse_value: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.data_overrides.set_nested_value: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockHeaders: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockHeaders.__contains__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockHeaders.__getitem__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockHeaders.__init__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockHeaders.get: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockHeaders.items: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockHeaders.keys: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockHeaders.values: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockQueryParams: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockQueryParams.__contains__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockQueryParams.__getitem__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockQueryParams.__init__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockQueryParams.get: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockQueryParams.items: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockQueryParams.keys: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockQueryParams.values: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockRequest: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockRequest.__init__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockRequest.body: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockRequest.client: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockRequest.json: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockURL: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockURL.__init__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.MockURL.__str__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.ServerlessSimulator: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.ServerlessSimulator.__init__: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.ServerlessSimulator.activate: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.ServerlessSimulator.add_override: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.ServerlessSimulator.deactivate: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.ServerlessSimulator.get_current_env: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.create_mock_request: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.simulation.mock_env.load_env_file: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.swaig_test_wrapper.main: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.test_swaig.console_entry_point: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.test_swaig.main: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.test_swaig.print_help_examples: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.test_swaig.print_help_platforms: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.types.AgentInfo: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.types.CallData: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.types.DataMapConfig: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.types.FunctionInfo: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.types.PostData: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.cli.types.VarsData: Ruby SDK does not ship a CLI; Python CLI is a separate tool
+signalwire.core.agent.prompt.manager.PromptManager: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.__init__: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.define_contexts: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.get_contexts: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.get_post_prompt: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.get_prompt: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.get_raw_prompt: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.prompt_add_section: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.prompt_add_subsection: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.prompt_add_to_section: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.prompt_has_section: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.set_post_prompt: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.set_prompt_pom: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.prompt.manager.PromptManager.set_prompt_text: prompt management inlined in SignalWire::AgentBase; no standalone PromptManager
+signalwire.core.agent.tools.decorator.ToolDecorator: Ruby uses keyword-arg registration, not decorators; ToolDecorator has no equivalent
+signalwire.core.agent.tools.decorator.ToolDecorator.create_class_decorator: Ruby uses keyword-arg registration, not decorators; ToolDecorator has no equivalent
+signalwire.core.agent.tools.decorator.ToolDecorator.create_instance_decorator: Ruby uses keyword-arg registration, not decorators; ToolDecorator has no equivalent
+signalwire.core.agent.tools.registry.ToolRegistry: tool registry inlined in SignalWire::AgentBase; no standalone ToolRegistry
+signalwire.core.agent.tools.registry.ToolRegistry.__init__: tool registry inlined in SignalWire::AgentBase; no standalone ToolRegistry
+signalwire.core.agent.tools.registry.ToolRegistry.define_tool: tool registry inlined in SignalWire::AgentBase; no standalone ToolRegistry
+signalwire.core.agent.tools.registry.ToolRegistry.get_all_functions: tool registry inlined in SignalWire::AgentBase; no standalone ToolRegistry
+signalwire.core.agent.tools.registry.ToolRegistry.get_function: tool registry inlined in SignalWire::AgentBase; no standalone ToolRegistry
+signalwire.core.agent.tools.registry.ToolRegistry.has_function: tool registry inlined in SignalWire::AgentBase; no standalone ToolRegistry
+signalwire.core.agent.tools.registry.ToolRegistry.register_class_decorated_tools: tool registry inlined in SignalWire::AgentBase; no standalone ToolRegistry
+signalwire.core.agent.tools.registry.ToolRegistry.register_swaig_function: tool registry inlined in SignalWire::AgentBase; no standalone ToolRegistry
+signalwire.core.agent.tools.registry.ToolRegistry.remove_function: tool registry inlined in SignalWire::AgentBase; no standalone ToolRegistry
+signalwire.core.agent.tools.type_inference.create_typed_handler_wrapper: type inference for decorator-based tool registration; not applicable to Ruby
+signalwire.core.agent.tools.type_inference.infer_schema: type inference for decorator-based tool registration; not applicable to Ruby
+signalwire.core.agent_base.AgentBase.auto_map_sip_usernames: not_yet_implemented: auto-map SIP usernames helper
+signalwire.core.agent_base.AgentBase.get_full_url: Ruby uses attr_reader accessors (host/port/route) plus manual_set_proxy_url; no get_full_url helper
+signalwire.core.agent_base.AgentBase.get_name: Ruby exposes SignalWire::AgentBase#name (attr_reader) instead
+signalwire.core.auth_handler.AuthHandler: Ruby basic-auth in SignalWire::AgentBase directly (rack middleware); no flask/fastapi decorator class
+signalwire.core.auth_handler.AuthHandler.__init__: Ruby basic-auth in SignalWire::AgentBase directly (rack middleware); no flask/fastapi decorator class
+signalwire.core.auth_handler.AuthHandler.flask_decorator: Ruby basic-auth in SignalWire::AgentBase directly (rack middleware); no flask/fastapi decorator class
+signalwire.core.auth_handler.AuthHandler.get_auth_info: Ruby basic-auth in SignalWire::AgentBase directly (rack middleware); no flask/fastapi decorator class
+signalwire.core.auth_handler.AuthHandler.get_fastapi_dependency: Ruby basic-auth in SignalWire::AgentBase directly (rack middleware); no flask/fastapi decorator class
+signalwire.core.auth_handler.AuthHandler.verify_api_key: Ruby basic-auth in SignalWire::AgentBase directly (rack middleware); no flask/fastapi decorator class
+signalwire.core.auth_handler.AuthHandler.verify_basic_auth: Ruby basic-auth in SignalWire::AgentBase directly (rack middleware); no flask/fastapi decorator class
+signalwire.core.auth_handler.AuthHandler.verify_bearer_token: Ruby basic-auth in SignalWire::AgentBase directly (rack middleware); no flask/fastapi decorator class
+signalwire.core.config_loader.ConfigLoader: config loader not ported - Ruby uses ENV directly
+signalwire.core.config_loader.ConfigLoader.__init__: config loader not ported - Ruby uses ENV directly
+signalwire.core.config_loader.ConfigLoader.find_config_file: config loader not ported - Ruby uses ENV directly
+signalwire.core.config_loader.ConfigLoader.get: config loader not ported - Ruby uses ENV directly
+signalwire.core.config_loader.ConfigLoader.get_config: config loader not ported - Ruby uses ENV directly
+signalwire.core.config_loader.ConfigLoader.get_config_file: config loader not ported - Ruby uses ENV directly
+signalwire.core.config_loader.ConfigLoader.get_section: config loader not ported - Ruby uses ENV directly
+signalwire.core.config_loader.ConfigLoader.has_config: config loader not ported - Ruby uses ENV directly
+signalwire.core.config_loader.ConfigLoader.merge_with_env: config loader not ported - Ruby uses ENV directly
+signalwire.core.config_loader.ConfigLoader.substitute_vars: config loader not ported - Ruby uses ENV directly
+signalwire.core.contexts.Context.to_dict: Ruby convention: SignalWire::Contexts::Context#to_h replaces to_dict
+signalwire.core.contexts.ContextBuilder.to_dict: Ruby convention: to_h replaces to_dict
+signalwire.core.contexts.ContextBuilder.validate: Ruby convention: SignalWire::Contexts::ContextBuilder#validate! (bang) replaces validate
+signalwire.core.contexts.GatherInfo.to_dict: Ruby convention: to_h replaces to_dict
+signalwire.core.contexts.GatherQuestion.to_dict: Ruby convention: to_h replaces to_dict
+signalwire.core.contexts.Step.to_dict: Ruby convention: to_h replaces to_dict
+signalwire.core.contexts.create_simple_context: Ruby exposes SignalWire::Contexts.create_simple_context (module function) - emitted under signalwire.contexts.Contexts in port surface
+signalwire.core.data_map.create_expression_tool: Ruby exposes SignalWire::DataMap.create_expression_tool as a class method
+signalwire.core.data_map.create_simple_api_tool: Ruby exposes SignalWire::DataMap.create_simple_api_tool as a class method
+signalwire.core.function_result.FunctionResult.to_dict: Ruby convention: SignalWire::Swaig::FunctionResult#to_h replaces to_dict
+signalwire.core.logging_config.configure_logging: SignalWire::Logging exposes the same surface without a separate config class
+signalwire.core.logging_config.get_execution_mode: SignalWire::Logging exposes the same surface without a separate config class
+signalwire.core.logging_config.get_logger: SignalWire::Logging exposes the same surface without a separate config class
+signalwire.core.logging_config.reset_logging_configuration: SignalWire::Logging exposes the same surface without a separate config class
+signalwire.core.logging_config.strip_control_chars: SignalWire::Logging exposes the same surface without a separate config class
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.add_function_include: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.add_hint: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.add_hints: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.add_internal_filler: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.add_language: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.add_mcp_server: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.add_pattern_hint: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.add_pronunciation: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.enable_debug_events: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.enable_mcp_server: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.set_function_includes: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.set_global_data: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.set_internal_fillers: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.set_languages: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.set_native_functions: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.set_param: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.set_params: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.set_post_prompt_llm_params: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.set_prompt_llm_params: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.set_pronunciations: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.ai_config_mixin.AIConfigMixin.update_global_data: mixin class collapsed into SignalWire::AgentBase (Ruby single-inheritance + modules); methods present on AgentBase
+signalwire.core.mixins.auth_mixin.AuthMixin: mixin class collapsed into SignalWire::AgentBase; get_basic_auth_credentials lives on AgentBase
+signalwire.core.mixins.auth_mixin.AuthMixin.get_basic_auth_credentials: mixin class collapsed into SignalWire::AgentBase; get_basic_auth_credentials lives on AgentBase
+signalwire.core.mixins.auth_mixin.AuthMixin.validate_basic_auth: mixin class collapsed into SignalWire::AgentBase; get_basic_auth_credentials lives on AgentBase
+signalwire.core.mixins.mcp_server_mixin.MCPServerMixin: mixin class collapsed into SignalWire::AgentBase (add_mcp_server/enable_mcp_server)
+signalwire.core.mixins.prompt_mixin.PromptMixin: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.prompt_mixin.PromptMixin.contexts: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.prompt_mixin.PromptMixin.define_contexts: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.prompt_mixin.PromptMixin.get_post_prompt: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.prompt_mixin.PromptMixin.get_prompt: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.prompt_mixin.PromptMixin.prompt_add_section: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.prompt_mixin.PromptMixin.prompt_add_subsection: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.prompt_mixin.PromptMixin.prompt_add_to_section: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.prompt_mixin.PromptMixin.prompt_has_section: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.prompt_mixin.PromptMixin.reset_contexts: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.prompt_mixin.PromptMixin.set_post_prompt: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.prompt_mixin.PromptMixin.set_prompt_pom: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.prompt_mixin.PromptMixin.set_prompt_text: mixin class collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.mixins.serverless_mixin.ServerlessMixin: serverless handling in SignalWire::Serverless::LambdaHandler, not a mixin
+signalwire.core.mixins.serverless_mixin.ServerlessMixin.handle_serverless_request: serverless handling in SignalWire::Serverless::LambdaHandler, not a mixin
+signalwire.core.mixins.skill_mixin.SkillMixin: mixin class collapsed into SignalWire::AgentBase skill methods
+signalwire.core.mixins.skill_mixin.SkillMixin.add_skill: mixin class collapsed into SignalWire::AgentBase skill methods
+signalwire.core.mixins.skill_mixin.SkillMixin.has_skill: mixin class collapsed into SignalWire::AgentBase skill methods
+signalwire.core.mixins.skill_mixin.SkillMixin.list_skills: mixin class collapsed into SignalWire::AgentBase skill methods
+signalwire.core.mixins.skill_mixin.SkillMixin.remove_skill: mixin class collapsed into SignalWire::AgentBase skill methods
+signalwire.core.mixins.state_mixin.StateMixin: mixin class collapsed into SignalWire::AgentBase (validate_tool_token via SessionManager)
+signalwire.core.mixins.state_mixin.StateMixin.validate_tool_token: mixin class collapsed into SignalWire::AgentBase (validate_tool_token via SessionManager)
+signalwire.core.mixins.tool_mixin.ToolMixin: mixin class collapsed into SignalWire::AgentBase tool methods
+signalwire.core.mixins.tool_mixin.ToolMixin.define_tool: mixin class collapsed into SignalWire::AgentBase tool methods
+signalwire.core.mixins.tool_mixin.ToolMixin.define_tools: mixin class collapsed into SignalWire::AgentBase tool methods
+signalwire.core.mixins.tool_mixin.ToolMixin.on_function_call: mixin class collapsed into SignalWire::AgentBase tool methods
+signalwire.core.mixins.tool_mixin.ToolMixin.register_swaig_function: mixin class collapsed into SignalWire::AgentBase tool methods
+signalwire.core.mixins.tool_mixin.ToolMixin.tool: mixin class collapsed into SignalWire::AgentBase tool methods
+signalwire.core.mixins.web_mixin.WebMixin: mixin class collapsed into SignalWire::AgentBase HTTP methods
+signalwire.core.mixins.web_mixin.WebMixin.as_router: mixin class collapsed into SignalWire::AgentBase HTTP methods
+signalwire.core.mixins.web_mixin.WebMixin.enable_debug_routes: mixin class collapsed into SignalWire::AgentBase HTTP methods
+signalwire.core.mixins.web_mixin.WebMixin.get_app: mixin class collapsed into SignalWire::AgentBase HTTP methods
+signalwire.core.mixins.web_mixin.WebMixin.manual_set_proxy_url: mixin class collapsed into SignalWire::AgentBase HTTP methods
+signalwire.core.mixins.web_mixin.WebMixin.on_request: mixin class collapsed into SignalWire::AgentBase HTTP methods
+signalwire.core.mixins.web_mixin.WebMixin.on_swml_request: mixin class collapsed into SignalWire::AgentBase HTTP methods
+signalwire.core.mixins.web_mixin.WebMixin.register_routing_callback: mixin class collapsed into SignalWire::AgentBase HTTP methods
+signalwire.core.mixins.web_mixin.WebMixin.run: mixin class collapsed into SignalWire::AgentBase HTTP methods
+signalwire.core.mixins.web_mixin.WebMixin.serve: mixin class collapsed into SignalWire::AgentBase HTTP methods
+signalwire.core.mixins.web_mixin.WebMixin.set_dynamic_config_callback: mixin class collapsed into SignalWire::AgentBase HTTP methods
+signalwire.core.mixins.web_mixin.WebMixin.setup_graceful_shutdown: mixin class collapsed into SignalWire::AgentBase HTTP methods
+signalwire.core.pom_builder.PomBuilder: POM builder collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.pom_builder.PomBuilder.__init__: POM builder collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.pom_builder.PomBuilder.add_section: POM builder collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.pom_builder.PomBuilder.add_subsection: POM builder collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.pom_builder.PomBuilder.add_to_section: POM builder collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.pom_builder.PomBuilder.from_sections: POM builder collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.pom_builder.PomBuilder.get_section: POM builder collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.pom_builder.PomBuilder.has_section: POM builder collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.pom_builder.PomBuilder.render_markdown: POM builder collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.pom_builder.PomBuilder.render_xml: POM builder collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.pom_builder.PomBuilder.to_dict: POM builder collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.pom_builder.PomBuilder.to_json: POM builder collapsed into SignalWire::AgentBase prompt methods
+signalwire.core.security.session_manager.SessionManager.activate_session: not_yet_implemented: explicit activate_session lifecycle
+signalwire.core.security.session_manager.SessionManager.create_session: not_yet_implemented: explicit create_session (Ruby creates-on-generate_token)
+signalwire.core.security.session_manager.SessionManager.create_tool_token: Ruby SignalWire::Security::SessionManager#create_token covers this - different name
+signalwire.core.security.session_manager.SessionManager.debug_token: not_yet_implemented: debug_token introspection
+signalwire.core.security.session_manager.SessionManager.end_session: not_yet_implemented: explicit end_session lifecycle
+signalwire.core.security.session_manager.SessionManager.generate_token: Ruby SignalWire::Security::SessionManager#create_token covers this - different name
+signalwire.core.security.session_manager.SessionManager.get_session_metadata: not_yet_implemented: session metadata getter
+signalwire.core.security.session_manager.SessionManager.set_session_metadata: not_yet_implemented: session metadata setter
+signalwire.core.security.session_manager.SessionManager.validate_tool_token: Ruby SignalWire::Security::SessionManager#validate_token covers this - different name
+signalwire.core.security_config.SecurityConfig: security-config class not ported - settings live in SignalWire::AgentBase and middleware
+signalwire.core.security_config.SecurityConfig.__init__: security-config class not ported - settings live in SignalWire::AgentBase and middleware
+signalwire.core.security_config.SecurityConfig.get_basic_auth: security-config class not ported - settings live in SignalWire::AgentBase and middleware
+signalwire.core.security_config.SecurityConfig.get_cors_config: security-config class not ported - settings live in SignalWire::AgentBase and middleware
+signalwire.core.security_config.SecurityConfig.get_security_headers: security-config class not ported - settings live in SignalWire::AgentBase and middleware
+signalwire.core.security_config.SecurityConfig.get_ssl_context_kwargs: security-config class not ported - settings live in SignalWire::AgentBase and middleware
+signalwire.core.security_config.SecurityConfig.get_url_scheme: security-config class not ported - settings live in SignalWire::AgentBase and middleware
+signalwire.core.security_config.SecurityConfig.load_from_env: security-config class not ported - settings live in SignalWire::AgentBase and middleware
+signalwire.core.security_config.SecurityConfig.log_config: security-config class not ported - settings live in SignalWire::AgentBase and middleware
+signalwire.core.security_config.SecurityConfig.should_allow_host: security-config class not ported - settings live in SignalWire::AgentBase and middleware
+signalwire.core.security_config.SecurityConfig.validate_ssl_config: security-config class not ported - settings live in SignalWire::AgentBase and middleware
+signalwire.core.skill_base.SkillBase.define_tool: Ruby SignalWire::Skills::SkillBase#register_tools does this via SignalWire::AgentBase#define_tool
+signalwire.core.skill_base.SkillBase.get_instance_key: Ruby uses SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.core.skill_base.SkillBase.get_skill_data: not_yet_implemented: skill-data share helpers
+signalwire.core.skill_base.SkillBase.update_skill_data: not_yet_implemented: skill-data share helpers
+signalwire.core.skill_base.SkillBase.validate_env_vars: not_yet_implemented: env-var validation helper
+signalwire.core.skill_base.SkillBase.validate_packages: not_yet_implemented: package validation (Python-specific; gem ecosystem differs)
+signalwire.core.skill_manager.SkillManager.get_skill: Ruby SignalWire::Skills::SkillManager#get covers this - different name
+signalwire.core.skill_manager.SkillManager.has_skill: Ruby SignalWire::Skills::SkillManager#loaded? covers this - different name
+signalwire.core.skill_manager.SkillManager.list_loaded_skills: Ruby SignalWire::Skills::SkillManager#loaded_keys covers this - different name
+signalwire.core.skill_manager.SkillManager.load_skill: Ruby SignalWire::Skills::SkillManager#load covers this - different name
+signalwire.core.skill_manager.SkillManager.unload_skill: Ruby SignalWire::Skills::SkillManager#unload covers this - different name
+signalwire.core.swaig_function.SWAIGFunction: SWAIG functions registered as hashes in Ruby (SignalWire::AgentBase#register_swaig_function); no SWAIGFunction wrapper class
+signalwire.core.swaig_function.SWAIGFunction.__call__: SWAIG functions registered as hashes in Ruby (SignalWire::AgentBase#register_swaig_function); no SWAIGFunction wrapper class
+signalwire.core.swaig_function.SWAIGFunction.__init__: SWAIG functions registered as hashes in Ruby (SignalWire::AgentBase#register_swaig_function); no SWAIGFunction wrapper class
+signalwire.core.swaig_function.SWAIGFunction.execute: SWAIG functions registered as hashes in Ruby (SignalWire::AgentBase#register_swaig_function); no SWAIGFunction wrapper class
+signalwire.core.swaig_function.SWAIGFunction.to_swaig: SWAIG functions registered as hashes in Ruby (SignalWire::AgentBase#register_swaig_function); no SWAIGFunction wrapper class
+signalwire.core.swaig_function.SWAIGFunction.validate_args: SWAIG functions registered as hashes in Ruby (SignalWire::AgentBase#register_swaig_function); no SWAIGFunction wrapper class
+signalwire.core.swml_builder.SWMLBuilder: consolidated into SignalWire::SWML::Document - render/add_verb/add_section live there
+signalwire.core.swml_builder.SWMLBuilder.__getattr__: consolidated into SignalWire::SWML::Document - render/add_verb/add_section live there
+signalwire.core.swml_builder.SWMLBuilder.__init__: consolidated into SignalWire::SWML::Document - render/add_verb/add_section live there
+signalwire.core.swml_builder.SWMLBuilder.add_section: consolidated into SignalWire::SWML::Document - render/add_verb/add_section live there
+signalwire.core.swml_builder.SWMLBuilder.ai: consolidated into SignalWire::SWML::Document - render/add_verb/add_section live there
+signalwire.core.swml_builder.SWMLBuilder.answer: consolidated into SignalWire::SWML::Document - render/add_verb/add_section live there
+signalwire.core.swml_builder.SWMLBuilder.build: consolidated into SignalWire::SWML::Document - render/add_verb/add_section live there
+signalwire.core.swml_builder.SWMLBuilder.hangup: consolidated into SignalWire::SWML::Document - render/add_verb/add_section live there
+signalwire.core.swml_builder.SWMLBuilder.play: consolidated into SignalWire::SWML::Document - render/add_verb/add_section live there
+signalwire.core.swml_builder.SWMLBuilder.render: consolidated into SignalWire::SWML::Document - render/add_verb/add_section live there
+signalwire.core.swml_builder.SWMLBuilder.reset: consolidated into SignalWire::SWML::Document - render/add_verb/add_section live there
+signalwire.core.swml_builder.SWMLBuilder.say: consolidated into SignalWire::SWML::Document - render/add_verb/add_section live there
+signalwire.core.swml_handler.AIVerbHandler: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_handler.AIVerbHandler.build_config: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_handler.AIVerbHandler.get_verb_name: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_handler.AIVerbHandler.validate_config: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_handler.SWMLVerbHandler: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_handler.SWMLVerbHandler.build_config: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_handler.SWMLVerbHandler.get_verb_name: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_handler.SWMLVerbHandler.validate_config: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_handler.VerbHandlerRegistry: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_handler.VerbHandlerRegistry.__init__: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_handler.VerbHandlerRegistry.get_handler: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_handler.VerbHandlerRegistry.has_handler: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_handler.VerbHandlerRegistry.register_handler: SWML verb handlers are schema-driven in SignalWire::SWML::Schema/Service; no per-verb handler classes
+signalwire.core.swml_renderer.SwmlRenderer: consolidated into SignalWire::SWML::Document#render and SignalWire::Swaig::FunctionResult
+signalwire.core.swml_renderer.SwmlRenderer.render_function_response_swml: consolidated into SignalWire::SWML::Document#render and SignalWire::Swaig::FunctionResult
+signalwire.core.swml_renderer.SwmlRenderer.render_swml: consolidated into SignalWire::SWML::Document#render and SignalWire::Swaig::FunctionResult
+signalwire.core.swml_service.SWMLService: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.__getattr__: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.__init__: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.add_section: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.add_verb: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.add_verb_to_section: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.as_router: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.extract_sip_username: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.full_validation_enabled: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.get_basic_auth_credentials: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.get_document: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.manual_set_proxy_url: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.on_request: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.register_routing_callback: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.register_verb_handler: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.render_document: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.reset_document: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.serve: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.core.swml_service.SWMLService.stop: consolidated into SignalWire::SWML::Service - see port_surface.json signalwire.swml.service
+signalwire.list_skills: not_yet_implemented: top-level list_skills helper; use SignalWire::Skills::SkillRegistry#list_skills
+signalwire.list_skills_with_params: not_yet_implemented: top-level helper; use SignalWire::Skills::SkillRegistry discovery
+signalwire.livewire.Agent: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.Agent.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.Agent.llm_node: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.Agent.on_enter: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.Agent.on_exit: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.Agent.on_user_turn_completed: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.Agent.session: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.Agent.stt_node: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.Agent.tts_node: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.Agent.update_instructions: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.Agent.update_tools: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentHandoff: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentHandoff.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentServer: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentServer.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentServer.rtc_session: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentSession: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentSession.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentSession.generate_reply: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentSession.history: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentSession.interrupt: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentSession.say: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentSession.start: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentSession.update_agent: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.AgentSession.userdata: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.ChatContext: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.ChatContext.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.ChatContext.append: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.InferenceLLM: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.InferenceLLM.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.InferenceSTT: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.InferenceSTT.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.InferenceTTS: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.InferenceTTS.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.JobContext: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.JobContext.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.JobContext.connect: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.JobContext.wait_for_participant: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.JobProcess: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.JobProcess.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.Room: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.RunContext: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.RunContext.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.RunContext.userdata: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.StopResponse: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.ToolError: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.function_tool: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.plugins.CartesiaTTS: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.plugins.CartesiaTTS.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.plugins.DeepgramSTT: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.plugins.DeepgramSTT.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.plugins.ElevenLabsTTS: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.plugins.ElevenLabsTTS.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.plugins.OpenAILLM: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.plugins.OpenAILLM.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.plugins.SileroVAD: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.plugins.SileroVAD.__init__: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.plugins.SileroVAD.load: LiveKit compatibility shim - to be added once core port is stable
+signalwire.livewire.run_app: LiveKit compatibility shim - to be added once core port is stable
+signalwire.mcp_gateway.gateway_service.MCPGateway: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.gateway_service.MCPGateway.__init__: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.gateway_service.MCPGateway.run: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.gateway_service.MCPGateway.shutdown: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.gateway_service.main: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPClient: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPClient.__init__: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPClient.call_method: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPClient.call_tool: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPClient.get_tools: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPClient.start: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPClient.stop: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPManager: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPManager.__init__: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPManager.create_client: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPManager.get_service: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPManager.get_service_tools: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPManager.list_services: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPManager.shutdown: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPManager.validate_services: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPService: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPService.__hash__: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.mcp_manager.MCPService.__post_init__: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.session_manager.Session: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.session_manager.Session.is_alive: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.session_manager.Session.is_expired: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.session_manager.Session.touch: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.session_manager.SessionManager: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.session_manager.SessionManager.__init__: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.session_manager.SessionManager.close_session: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.session_manager.SessionManager.create_session: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.session_manager.SessionManager.get_service_session_count: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.session_manager.SessionManager.get_session: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.session_manager.SessionManager.list_sessions: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.mcp_gateway.session_manager.SessionManager.shutdown: MCP gateway service is a separate daemon; Ruby agents consume MCP via SignalWire::AgentBase#add_mcp_server
+signalwire.pom.pom.PromptObjectModel: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.PromptObjectModel.__init__: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.PromptObjectModel.add_pom_as_subsection: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.PromptObjectModel.add_section: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.PromptObjectModel.find_section: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.PromptObjectModel.from_json: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.PromptObjectModel.from_yaml: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.PromptObjectModel.render_markdown: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.PromptObjectModel.render_xml: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.PromptObjectModel.to_dict: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.PromptObjectModel.to_json: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.PromptObjectModel.to_yaml: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.Section: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.Section.__init__: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.Section.add_body: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.Section.add_bullets: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.Section.add_subsection: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.Section.render_markdown: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.Section.render_xml: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom.Section.to_dict: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom_tool.detect_file_format: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom_tool.load_pom: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom_tool.main: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.pom.pom_tool.render_pom: POM prompt-object-model managed inline by SignalWire::AgentBase/Contexts; no standalone POM class
+signalwire.prefabs.concierge.ConciergeAgent.check_availability: not_yet_implemented: concierge check_availability tool
+signalwire.prefabs.concierge.ConciergeAgent.get_directions: not_yet_implemented: concierge get_directions tool
+signalwire.prefabs.concierge.ConciergeAgent.on_summary: not_yet_implemented: concierge on_summary hook
+signalwire.prefabs.faq_bot.FAQBotAgent.on_summary: not_yet_implemented: FAQ-bot on_summary hook
+signalwire.prefabs.faq_bot.FAQBotAgent.search_faqs: Ruby uses SignalWire::Prefabs::FaqBot#handle_search - different name
+signalwire.prefabs.info_gatherer.InfoGathererAgent.on_swml_request: not_yet_implemented: InfoGatherer on_swml_request hook
+signalwire.prefabs.info_gatherer.InfoGathererAgent.set_question_callback: not_yet_implemented: question callback setter
+signalwire.prefabs.info_gatherer.InfoGathererAgent.start_questions: Ruby uses SignalWire::Prefabs::InfoGatherer#handle_start - different name
+signalwire.prefabs.info_gatherer.InfoGathererAgent.submit_answer: Ruby uses SignalWire::Prefabs::InfoGatherer#handle_submit - different name
+signalwire.prefabs.receptionist.ReceptionistAgent.on_summary: not_yet_implemented: receptionist on_summary hook
+signalwire.prefabs.survey.SurveyAgent.log_response: not_yet_implemented: survey log_response hook
+signalwire.prefabs.survey.SurveyAgent.on_summary: not_yet_implemented: survey on_summary hook
+signalwire.prefabs.survey.SurveyAgent.validate_response: not_yet_implemented: survey validate_response hook
+signalwire.register_skill: not_yet_implemented: top-level skill registration helper; use SignalWire::Skills::SkillRegistry directly
+signalwire.relay.call.Action.is_done: Ruby uses is_done? and done? (idiomatic Ruby predicates)
+signalwire.relay.call.Call.__repr__: Ruby uses inspect/to_s idioms
+signalwire.relay.call.Call.pass_: Ruby uses SignalWire::Relay::Call#pass_call - pass is a Ruby keyword
+signalwire.relay.call.Call.tap: Ruby uses SignalWire::Relay::Call#tap_audio - tap is a Ruby core method
+signalwire.relay.call.Call.wait_for: not_yet_implemented: Call#wait_for predicate wait helper
+signalwire.relay.client.RelayClient.__aenter__: Python async-context-manager protocol; Ruby uses block-style Client.new { |c| ... }
+signalwire.relay.client.RelayClient.__aexit__: Python async-context-manager protocol; Ruby uses block-style Client.new { |c| ... }
+signalwire.relay.client.RelayClient.__del__: Ruby finalizers differ; no explicit __del__ equivalent
+signalwire.relay.client.RelayClient.connect: Ruby auto-connects on Client.new (constructor); no separate connect method
+signalwire.relay.client.RelayClient.disconnect: Ruby SignalWire::Relay::Client#stop covers this - different name
+signalwire.relay.client.RelayClient.relay_protocol: Ruby SignalWire::Relay::Client#protocol covers this - different name
+signalwire.relay.message.Message.__repr__: Ruby uses inspect/to_s idioms
+signalwire.relay.message.Message.is_done: Ruby uses is_done? and done? predicates
+signalwire.relay.message.Message.on: Ruby uses SignalWire::Relay::Message#on_event and #on_completed - different name
+signalwire.rest._base.CrudWithAddresses: not_yet_implemented: CrudWithAddresses mixin (list_addresses helper)
+signalwire.rest._base.CrudWithAddresses.list_addresses: not_yet_implemented: list_addresses helper
+signalwire.rest._pagination.PaginatedIterator: not_yet_implemented: standalone PaginatedIterator class (Ruby returns Arrays from list)
+signalwire.rest._pagination.PaginatedIterator.__init__: not_yet_implemented: paginated iterator
+signalwire.rest._pagination.PaginatedIterator.__iter__: not_yet_implemented: paginated iterator
+signalwire.rest._pagination.PaginatedIterator.__next__: not_yet_implemented: paginated iterator
+signalwire.rest.call_handler.PhoneCallHandler: Ruby SignalWire::REST::PhoneCallHandler is an empty marker (matches Python - no methods on either)
+signalwire.rest.namespaces.calling.CallingNamespace.end: Ruby uses SignalWire::REST::Namespaces::CallingNamespace#end_call - end is a Ruby keyword
+signalwire.run_agent: Ruby agents use agent.serve directly; no top-level run_agent convenience
+signalwire.search.document_processor.DocumentProcessor: search subsystem omitted - vector search/indexing not ported
+signalwire.search.document_processor.DocumentProcessor.__init__: search subsystem omitted - vector search/indexing not ported
+signalwire.search.document_processor.DocumentProcessor.create_chunks: search subsystem omitted - vector search/indexing not ported
+signalwire.search.index_builder.IndexBuilder: search subsystem omitted - vector search/indexing not ported
+signalwire.search.index_builder.IndexBuilder.__init__: search subsystem omitted - vector search/indexing not ported
+signalwire.search.index_builder.IndexBuilder.build_index: search subsystem omitted - vector search/indexing not ported
+signalwire.search.index_builder.IndexBuilder.build_index_from_sources: search subsystem omitted - vector search/indexing not ported
+signalwire.search.index_builder.IndexBuilder.validate_index: search subsystem omitted - vector search/indexing not ported
+signalwire.search.migration.SearchIndexMigrator: search subsystem omitted - vector search/indexing not ported
+signalwire.search.migration.SearchIndexMigrator.__init__: search subsystem omitted - vector search/indexing not ported
+signalwire.search.migration.SearchIndexMigrator.get_index_info: search subsystem omitted - vector search/indexing not ported
+signalwire.search.migration.SearchIndexMigrator.migrate_pgvector_to_sqlite: search subsystem omitted - vector search/indexing not ported
+signalwire.search.migration.SearchIndexMigrator.migrate_sqlite_to_pgvector: search subsystem omitted - vector search/indexing not ported
+signalwire.search.models.resolve_model_alias: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorBackend: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorBackend.__init__: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorBackend.close: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorBackend.create_schema: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorBackend.delete_collection: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorBackend.get_stats: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorBackend.list_collections: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorBackend.store_chunks: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorSearchBackend: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorSearchBackend.__init__: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorSearchBackend.close: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorSearchBackend.fetch_candidates: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorSearchBackend.get_stats: search subsystem omitted - vector search/indexing not ported
+signalwire.search.pgvector_backend.PgVectorSearchBackend.search: search subsystem omitted - vector search/indexing not ported
+signalwire.search.query_processor.detect_language: search subsystem omitted - vector search/indexing not ported
+signalwire.search.query_processor.ensure_nltk_resources: search subsystem omitted - vector search/indexing not ported
+signalwire.search.query_processor.get_synonyms: search subsystem omitted - vector search/indexing not ported
+signalwire.search.query_processor.get_wordnet_pos: search subsystem omitted - vector search/indexing not ported
+signalwire.search.query_processor.load_spacy_model: search subsystem omitted - vector search/indexing not ported
+signalwire.search.query_processor.preprocess_document_content: search subsystem omitted - vector search/indexing not ported
+signalwire.search.query_processor.preprocess_query: search subsystem omitted - vector search/indexing not ported
+signalwire.search.query_processor.remove_duplicate_words: search subsystem omitted - vector search/indexing not ported
+signalwire.search.query_processor.set_global_model: search subsystem omitted - vector search/indexing not ported
+signalwire.search.query_processor.vectorize_query: search subsystem omitted - vector search/indexing not ported
+signalwire.search.search_engine.SearchEngine: search subsystem omitted - vector search/indexing not ported
+signalwire.search.search_engine.SearchEngine.__init__: search subsystem omitted - vector search/indexing not ported
+signalwire.search.search_engine.SearchEngine.get_stats: search subsystem omitted - vector search/indexing not ported
+signalwire.search.search_engine.SearchEngine.search: search subsystem omitted - vector search/indexing not ported
+signalwire.search.search_service.SearchService: search subsystem omitted - vector search/indexing not ported
+signalwire.search.search_service.SearchService.__init__: search subsystem omitted - vector search/indexing not ported
+signalwire.search.search_service.SearchService.search_direct: search subsystem omitted - vector search/indexing not ported
+signalwire.search.search_service.SearchService.start: search subsystem omitted - vector search/indexing not ported
+signalwire.search.search_service.SearchService.stop: search subsystem omitted - vector search/indexing not ported
+signalwire.skills.api_ninjas_trivia.skill.ApiNinjasTriviaSkill.__init__: Ruby built-in skills use the SignalWire::Skills::SkillBase constructor
+signalwire.skills.api_ninjas_trivia.skill.ApiNinjasTriviaSkill.get_instance_key: Ruby SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.skills.api_ninjas_trivia.skill.ApiNinjasTriviaSkill.get_tools: Ruby built-in skills register tools in setup, not get_tools
+signalwire.skills.claude_skills.skill.ClaudeSkillsSkill.get_instance_key: Ruby SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.skills.datasphere.skill.DataSphereSkill.cleanup: not_yet_implemented: per-skill cleanup hook
+signalwire.skills.datasphere.skill.DataSphereSkill.get_hints: not_yet_implemented: per-skill get_hints override
+signalwire.skills.datasphere.skill.DataSphereSkill.get_instance_key: Ruby SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.skills.datasphere_serverless.skill.DataSphereServerlessSkill.get_hints: not_yet_implemented: per-skill get_hints override
+signalwire.skills.datasphere_serverless.skill.DataSphereServerlessSkill.get_instance_key: Ruby SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.skills.datetime.skill.DateTimeSkill.get_hints: not_yet_implemented: per-skill get_hints override
+signalwire.skills.datetime.skill.DateTimeSkill.get_parameter_schema: not_yet_implemented: per-skill get_parameter_schema override
+signalwire.skills.datetime.skill.DateTimeSkill.setup: not_yet_implemented: per-skill explicit setup hook (Ruby uses register_tools)
+signalwire.skills.google_maps.skill.GoogleMapsClient: internal HTTP client not exposed in Ruby port
+signalwire.skills.google_maps.skill.GoogleMapsClient.__init__: internal HTTP client not exposed in Ruby port
+signalwire.skills.google_maps.skill.GoogleMapsClient.compute_route: internal HTTP client not exposed in Ruby port
+signalwire.skills.google_maps.skill.GoogleMapsClient.validate_address: internal HTTP client not exposed in Ruby port
+signalwire.skills.info_gatherer.skill.InfoGathererSkill.get_instance_key: Ruby SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.skills.joke.skill.JokeSkill.get_hints: not_yet_implemented: per-skill get_hints override
+signalwire.skills.math.skill.MathSkill.get_hints: not_yet_implemented: per-skill get_hints override
+signalwire.skills.math.skill.MathSkill.get_parameter_schema: not_yet_implemented: per-skill get_parameter_schema override
+signalwire.skills.math.skill.MathSkill.setup: not_yet_implemented: per-skill explicit setup hook
+signalwire.skills.native_vector_search.skill.NativeVectorSearchSkill.cleanup: search subsystem omitted
+signalwire.skills.native_vector_search.skill.NativeVectorSearchSkill.get_global_data: search subsystem omitted
+signalwire.skills.native_vector_search.skill.NativeVectorSearchSkill.get_instance_key: Ruby SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.skills.native_vector_search.skill.NativeVectorSearchSkill.get_prompt_sections: search subsystem omitted
+signalwire.skills.play_background_file.skill.PlayBackgroundFileSkill.__init__: Ruby built-in skills use SignalWire::Skills::SkillBase constructor
+signalwire.skills.play_background_file.skill.PlayBackgroundFileSkill.get_instance_key: Ruby SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.skills.play_background_file.skill.PlayBackgroundFileSkill.get_tools: Ruby built-in skills register tools in setup
+signalwire.skills.registry.SkillRegistry.__init__: Ruby SignalWire::Skills::SkillRegistry is a singleton module; no constructor
+signalwire.skills.registry.SkillRegistry.add_skill_directory: not_yet_implemented: external skill directory discovery
+signalwire.skills.registry.SkillRegistry.discover_skills: not_yet_implemented: filesystem discover_skills (Ruby ships built-ins explicitly via register_builtins!)
+signalwire.skills.registry.SkillRegistry.get_all_skills_schema: not_yet_implemented: aggregate schema export
+signalwire.skills.registry.SkillRegistry.get_skill_class: Ruby SignalWire::Skills::SkillRegistry#get_factory returns class-or-factory - different name
+signalwire.skills.registry.SkillRegistry.list_all_skill_sources: not_yet_implemented: external skill source listing
+signalwire.skills.spider.skill.SpiderSkill.__init__: Ruby built-in skills use SignalWire::Skills::SkillBase constructor
+signalwire.skills.spider.skill.SpiderSkill.cleanup: not_yet_implemented: per-skill cleanup hook
+signalwire.skills.spider.skill.SpiderSkill.get_instance_key: Ruby SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.skills.swml_transfer.skill.SWMLTransferSkill.get_instance_key: Ruby SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.skills.weather_api.skill.WeatherApiSkill.__init__: Ruby built-in skills use SignalWire::Skills::SkillBase constructor
+signalwire.skills.weather_api.skill.WeatherApiSkill.get_tools: Ruby built-in skills register tools in setup
+signalwire.skills.web_search.skill.GoogleSearchScraper: part of search subsystem; scraper class omitted
+signalwire.skills.web_search.skill.GoogleSearchScraper.__init__: part of search subsystem; scraper class omitted
+signalwire.skills.web_search.skill.GoogleSearchScraper.extract_html_content: part of search subsystem; scraper class omitted
+signalwire.skills.web_search.skill.GoogleSearchScraper.extract_reddit_content: part of search subsystem; scraper class omitted
+signalwire.skills.web_search.skill.GoogleSearchScraper.extract_text_from_url: part of search subsystem; scraper class omitted
+signalwire.skills.web_search.skill.GoogleSearchScraper.is_reddit_url: part of search subsystem; scraper class omitted
+signalwire.skills.web_search.skill.GoogleSearchScraper.search_and_scrape: part of search subsystem; scraper class omitted
+signalwire.skills.web_search.skill.GoogleSearchScraper.search_and_scrape_best: part of search subsystem; scraper class omitted
+signalwire.skills.web_search.skill.GoogleSearchScraper.search_google: part of search subsystem; scraper class omitted
+signalwire.skills.web_search.skill.WebSearchSkill.get_hints: not_yet_implemented: per-skill get_hints override
+signalwire.skills.web_search.skill.WebSearchSkill.get_instance_key: Ruby SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.skills.web_search.skill_improved.GoogleSearchScraper: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_improved.GoogleSearchScraper.__init__: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_improved.GoogleSearchScraper.extract_text_from_url: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_improved.GoogleSearchScraper.search_and_scrape: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_improved.GoogleSearchScraper.search_and_scrape_best: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_improved.GoogleSearchScraper.search_google: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_improved.WebSearchSkill: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_improved.WebSearchSkill.get_global_data: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_improved.WebSearchSkill.get_hints: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_improved.WebSearchSkill.get_instance_key: Ruby SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.skills.web_search.skill_improved.WebSearchSkill.get_parameter_schema: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_improved.WebSearchSkill.get_prompt_sections: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_improved.WebSearchSkill.register_tools: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_improved.WebSearchSkill.setup: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_original.GoogleSearchScraper: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_original.GoogleSearchScraper.__init__: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_original.GoogleSearchScraper.extract_text_from_url: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_original.GoogleSearchScraper.search_and_scrape: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_original.GoogleSearchScraper.search_google: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_original.WebSearchSkill: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_original.WebSearchSkill.get_global_data: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_original.WebSearchSkill.get_hints: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_original.WebSearchSkill.get_instance_key: Ruby SignalWire::Skills::SkillBase#instance_key (attr_reader)
+signalwire.skills.web_search.skill_original.WebSearchSkill.get_parameter_schema: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_original.WebSearchSkill.get_prompt_sections: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_original.WebSearchSkill.register_tools: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.web_search.skill_original.WebSearchSkill.setup: search subsystem variant (Python has three parallel skill files); not ported
+signalwire.skills.wikipedia_search.skill.WikipediaSearchSkill.get_hints: not_yet_implemented: per-skill get_hints override
+signalwire.skills.wikipedia_search.skill.WikipediaSearchSkill.search_wiki: not_yet_implemented: extracted search_wiki helper
+signalwire.start_agent: Ruby agents use agent.serve directly; no top-level start_agent convenience
+signalwire.utils.is_serverless_mode: not_yet_implemented: top-level is_serverless_mode helper
+signalwire.utils.schema_utils.SchemaUtils: SchemaUtils consolidated into SignalWire::SWML::Schema - see port_surface.json signalwire.swml.schema
+signalwire.utils.schema_utils.SchemaUtils.__init__: SchemaUtils consolidated into SignalWire::SWML::Schema - see port_surface.json signalwire.swml.schema
+signalwire.utils.schema_utils.SchemaUtils.full_validation_available: SchemaUtils consolidated into SignalWire::SWML::Schema - see port_surface.json signalwire.swml.schema
+signalwire.utils.schema_utils.SchemaUtils.generate_method_body: SchemaUtils consolidated into SignalWire::SWML::Schema - see port_surface.json signalwire.swml.schema
+signalwire.utils.schema_utils.SchemaUtils.generate_method_signature: SchemaUtils consolidated into SignalWire::SWML::Schema - see port_surface.json signalwire.swml.schema
+signalwire.utils.schema_utils.SchemaUtils.get_all_verb_names: SchemaUtils consolidated into SignalWire::SWML::Schema - see port_surface.json signalwire.swml.schema
+signalwire.utils.schema_utils.SchemaUtils.get_verb_parameters: SchemaUtils consolidated into SignalWire::SWML::Schema - see port_surface.json signalwire.swml.schema
+signalwire.utils.schema_utils.SchemaUtils.get_verb_properties: SchemaUtils consolidated into SignalWire::SWML::Schema - see port_surface.json signalwire.swml.schema
+signalwire.utils.schema_utils.SchemaUtils.get_verb_required_properties: SchemaUtils consolidated into SignalWire::SWML::Schema - see port_surface.json signalwire.swml.schema
+signalwire.utils.schema_utils.SchemaUtils.load_schema: SchemaUtils consolidated into SignalWire::SWML::Schema - see port_surface.json signalwire.swml.schema
+signalwire.utils.schema_utils.SchemaUtils.validate_document: SchemaUtils consolidated into SignalWire::SWML::Schema - see port_surface.json signalwire.swml.schema
+signalwire.utils.schema_utils.SchemaUtils.validate_verb: SchemaUtils consolidated into SignalWire::SWML::Schema - see port_surface.json signalwire.swml.schema
+signalwire.utils.schema_utils.SchemaValidationError: not_yet_implemented: named SchemaValidationError class
+signalwire.utils.schema_utils.SchemaValidationError.__init__: not_yet_implemented: named SchemaValidationError class
+signalwire.utils.url_validator.validate_url: not_yet_implemented: top-level validate_url helper
+signalwire.web.web_service.WebService: standalone WebService not ported; static files served from SignalWire::Server::AgentServer
+signalwire.web.web_service.WebService.__init__: standalone WebService not ported; static files served from SignalWire::Server::AgentServer
+signalwire.web.web_service.WebService.add_directory: standalone WebService not ported; static files served from SignalWire::Server::AgentServer
+signalwire.web.web_service.WebService.remove_directory: standalone WebService not ported; static files served from SignalWire::Server::AgentServer
+signalwire.web.web_service.WebService.start: standalone WebService not ported; static files served from SignalWire::Server::AgentServer
+signalwire.web.web_service.WebService.stop: standalone WebService not ported; static files served from SignalWire::Server::AgentServer

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,0 +1,1854 @@
+{
+  "generated_from": "signalwire-ruby @ 710f5e76d4d2d59c312f152659527bdcef948a52",
+  "modules": {
+    "signalwire.agent_server": {
+      "classes": {
+        "AgentServer": [
+          "__init__",
+          "get_agent",
+          "get_agents",
+          "host",
+          "port",
+          "rack_app",
+          "register",
+          "register_sip_username",
+          "run",
+          "serve_static_files",
+          "setup_sip_routing",
+          "unregister"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.contexts": {
+      "classes": {
+        "Contexts": [
+          "create_simple_context"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.core.agent_base": {
+      "classes": {
+        "AgentBase": [
+          "__init__",
+          "add_answer_verb",
+          "add_function_include",
+          "add_hint",
+          "add_hints",
+          "add_internal_filler",
+          "add_language",
+          "add_mcp_server",
+          "add_pattern_hint",
+          "add_post_ai_verb",
+          "add_post_answer_verb",
+          "add_pre_answer_verb",
+          "add_pronunciation",
+          "add_skill",
+          "add_swaig_query_params",
+          "as_rack_app",
+          "clear_post_ai_verbs",
+          "clear_post_answer_verbs",
+          "clear_pre_answer_verbs",
+          "clear_swaig_query_params",
+          "contexts",
+          "define_contexts",
+          "define_tool",
+          "define_tools",
+          "enable_debug_events",
+          "enable_debug_routes",
+          "enable_mcp_server",
+          "enable_sip_routing",
+          "extract_sip_username",
+          "extract_sip_username_from_request",
+          "get_basic_auth_credentials",
+          "get_prompt",
+          "has_skill?",
+          "host",
+          "list_skills",
+          "list_tool_names",
+          "logger",
+          "manual_set_proxy_url",
+          "name",
+          "on_debug_event",
+          "on_function_call",
+          "on_summary",
+          "port",
+          "prompt_add_section",
+          "prompt_add_subsection",
+          "prompt_add_to_section",
+          "prompt_has_section?",
+          "rack_app",
+          "register_sip_username",
+          "register_swaig_function",
+          "remove_skill",
+          "render_swml",
+          "reset_contexts",
+          "route",
+          "run",
+          "serve",
+          "set_dynamic_config_callback",
+          "set_function_includes",
+          "set_global_data",
+          "set_internal_fillers",
+          "set_languages",
+          "set_native_functions",
+          "set_param",
+          "set_params",
+          "set_post_prompt",
+          "set_post_prompt_llm_params",
+          "set_post_prompt_url",
+          "set_prompt_llm_params",
+          "set_prompt_pom",
+          "set_prompt_text",
+          "set_pronunciations",
+          "set_web_hook_url",
+          "update_global_data"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.core.contexts": {
+      "classes": {
+        "Context": [
+          "__init__",
+          "add_bullets",
+          "add_enter_filler",
+          "add_exit_filler",
+          "add_section",
+          "add_step",
+          "add_system_bullets",
+          "add_system_section",
+          "get_step",
+          "move_step",
+          "name",
+          "remove_step",
+          "set_consolidate",
+          "set_enter_fillers",
+          "set_exit_fillers",
+          "set_full_reset",
+          "set_initial_step",
+          "set_isolated",
+          "set_post_prompt",
+          "set_prompt",
+          "set_system_prompt",
+          "set_user_prompt",
+          "set_valid_contexts",
+          "set_valid_steps",
+          "to_h"
+        ],
+        "ContextBuilder": [
+          "__init__",
+          "add_context",
+          "attach_agent",
+          "get_context",
+          "reset",
+          "to_h",
+          "validate!"
+        ],
+        "GatherInfo": [
+          "__init__",
+          "add_question",
+          "completion_action",
+          "output_key",
+          "prompt",
+          "questions",
+          "to_h"
+        ],
+        "GatherQuestion": [
+          "__init__",
+          "confirm",
+          "functions",
+          "key",
+          "prompt",
+          "question",
+          "to_h",
+          "type"
+        ],
+        "Step": [
+          "__init__",
+          "add_bullets",
+          "add_gather_question",
+          "add_section",
+          "clear_sections",
+          "name",
+          "set_end",
+          "set_functions",
+          "set_gather_info",
+          "set_reset_consolidate",
+          "set_reset_full_reset",
+          "set_reset_system_prompt",
+          "set_reset_user_prompt",
+          "set_skip_to_next_step",
+          "set_skip_user_turn",
+          "set_step_criteria",
+          "set_text",
+          "set_valid_contexts",
+          "set_valid_steps",
+          "to_h"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.core.data_map": {
+      "classes": {
+        "DataMap": [
+          "__init__",
+          "body",
+          "create_expression_tool",
+          "create_simple_api_tool",
+          "description",
+          "error_keys",
+          "expression",
+          "fallback_output",
+          "foreach",
+          "function_name",
+          "global_error_keys",
+          "output",
+          "parameter",
+          "params",
+          "purpose",
+          "to_swaig_function",
+          "webhook",
+          "webhook_expressions"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.core.function_result": {
+      "classes": {
+        "FunctionResult": [
+          "__init__",
+          "action",
+          "add_action",
+          "add_actions",
+          "add_dynamic_hints",
+          "clear_dynamic_hints",
+          "connect",
+          "create_payment_action",
+          "create_payment_parameter",
+          "create_payment_prompt",
+          "enable_extensive_data",
+          "enable_functions_on_timeout",
+          "execute_rpc",
+          "execute_swml",
+          "hangup",
+          "hold",
+          "join_conference",
+          "join_room",
+          "pay",
+          "play_background_file",
+          "post_process",
+          "record_call",
+          "remove_global_data",
+          "remove_metadata",
+          "replace_in_history",
+          "response",
+          "rpc_ai_message",
+          "rpc_ai_unhold",
+          "rpc_dial",
+          "say",
+          "send_sms",
+          "set_end_of_speech_timeout",
+          "set_metadata",
+          "set_post_process",
+          "set_response",
+          "set_speech_event_timeout",
+          "simulate_user_input",
+          "sip_refer",
+          "stop",
+          "stop_background_file",
+          "stop_record_call",
+          "stop_tap",
+          "switch_context",
+          "swml_change_context",
+          "swml_change_step",
+          "swml_transfer",
+          "swml_user_event",
+          "tap",
+          "to_h",
+          "to_json",
+          "toggle_functions",
+          "update_global_data",
+          "update_settings",
+          "wait_for_user"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.core.security.session_manager": {
+      "classes": {
+        "SessionManager": [
+          "__init__",
+          "create_token",
+          "validate_token"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.core.skill_base": {
+      "classes": {
+        "SkillBase": [
+          "__init__",
+          "cleanup",
+          "description",
+          "get_global_data",
+          "get_hints",
+          "get_param",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "instance_key",
+          "name",
+          "params",
+          "register_tools",
+          "required_env_vars",
+          "setup",
+          "supports_multiple_instances?",
+          "version"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.core.skill_manager": {
+      "classes": {
+        "SkillManager": [
+          "__init__",
+          "clear",
+          "get",
+          "load",
+          "loaded?",
+          "loaded_keys",
+          "size",
+          "unload"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.logging": {
+      "classes": {
+        "Logging": [
+          "global_level",
+          "logger",
+          "reset!",
+          "suppressed?"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.prefabs.concierge": {
+      "classes": {
+        "ConciergeAgent": [
+          "__init__",
+          "amenities",
+          "global_data",
+          "handle_amenity_info",
+          "handle_service_info",
+          "name",
+          "prompt_sections",
+          "route",
+          "services",
+          "tools",
+          "venue_name"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.prefabs.faq_bot": {
+      "classes": {
+        "FAQBotAgent": [
+          "__init__",
+          "faqs",
+          "global_data",
+          "handle_search",
+          "name",
+          "prompt_sections",
+          "route",
+          "tools"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.prefabs.info_gatherer": {
+      "classes": {
+        "InfoGathererAgent": [
+          "__init__",
+          "global_data",
+          "handle_start",
+          "handle_submit",
+          "name",
+          "prompt_sections",
+          "questions",
+          "route",
+          "tools"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.prefabs.receptionist": {
+      "classes": {
+        "ReceptionistAgent": [
+          "__init__",
+          "departments",
+          "global_data",
+          "greeting",
+          "handle_transfer",
+          "name",
+          "prompt_sections",
+          "route",
+          "tools"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.prefabs.survey": {
+      "classes": {
+        "SurveyAgent": [
+          "__init__",
+          "global_data",
+          "handle_start",
+          "handle_submit",
+          "handle_summary",
+          "name",
+          "prompt_sections",
+          "questions",
+          "route",
+          "survey_name",
+          "tools"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.relay.call": {
+      "classes": {
+        "AIAction": [
+          "__init__",
+          "stop"
+        ],
+        "Action": [
+          "__init__",
+          "call",
+          "completed",
+          "control_id",
+          "done?",
+          "is_done?",
+          "on_completed",
+          "result",
+          "wait"
+        ],
+        "Call": [
+          "__init__",
+          "ai",
+          "ai_hold",
+          "ai_message",
+          "ai_unhold",
+          "amazon_bedrock",
+          "answer",
+          "bind_digit",
+          "call_id",
+          "clear_digit_bindings",
+          "collect",
+          "connect",
+          "context",
+          "denoise",
+          "denoise_stop",
+          "detect",
+          "device",
+          "direction",
+          "disconnect",
+          "echo",
+          "ended?",
+          "hangup",
+          "hold",
+          "inspect",
+          "join_conference",
+          "join_room",
+          "leave_conference",
+          "leave_room",
+          "live_transcribe",
+          "live_translate",
+          "node_id",
+          "on",
+          "pass_call",
+          "pay",
+          "play",
+          "play_and_collect",
+          "project_id",
+          "queue_enter",
+          "queue_leave",
+          "receive_fax",
+          "record",
+          "refer",
+          "segment_id",
+          "send_digits",
+          "send_fax",
+          "state",
+          "stream",
+          "tag",
+          "tap_audio",
+          "to_s",
+          "transcribe",
+          "transfer",
+          "unhold",
+          "user_event",
+          "wait_for_ended"
+        ],
+        "CollectAction": [
+          "__init__",
+          "start_input_timers",
+          "stop",
+          "volume"
+        ],
+        "DetectAction": [
+          "__init__",
+          "stop"
+        ],
+        "FaxAction": [
+          "__init__",
+          "stop"
+        ],
+        "PayAction": [
+          "__init__",
+          "stop"
+        ],
+        "PlayAction": [
+          "__init__",
+          "pause",
+          "resume",
+          "stop",
+          "volume"
+        ],
+        "RecordAction": [
+          "__init__",
+          "pause",
+          "resume",
+          "stop"
+        ],
+        "StandaloneCollectAction": [
+          "__init__",
+          "start_input_timers",
+          "stop"
+        ],
+        "StreamAction": [
+          "__init__",
+          "stop"
+        ],
+        "TapAction": [
+          "__init__",
+          "stop"
+        ],
+        "TranscribeAction": [
+          "__init__",
+          "stop"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.relay.client": {
+      "classes": {
+        "ActionTimeoutError": [
+
+        ],
+        "RelayClient": [
+          "__init__",
+          "dial",
+          "execute",
+          "on_call",
+          "on_message",
+          "project_id",
+          "protocol",
+          "receive",
+          "run",
+          "send_message",
+          "stop",
+          "unreceive"
+        ],
+        "RelayError": [
+          "__init__",
+          "code",
+          "error_message"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.relay.event": {
+      "classes": {
+        "CallReceiveEvent": [
+          "__init__",
+          "call_state",
+          "context",
+          "device",
+          "direction",
+          "from_payload",
+          "node_id",
+          "project_id",
+          "segment_id",
+          "tag"
+        ],
+        "CallStateEvent": [
+          "__init__",
+          "call_state",
+          "device",
+          "direction",
+          "end_reason",
+          "from_payload"
+        ],
+        "CallingErrorEvent": [
+          "__init__",
+          "code",
+          "from_payload",
+          "message"
+        ],
+        "CollectEvent": [
+          "__init__",
+          "control_id",
+          "final",
+          "from_payload",
+          "result_data",
+          "state"
+        ],
+        "ConferenceEvent": [
+          "__init__",
+          "conference_id",
+          "from_payload",
+          "name",
+          "status"
+        ],
+        "ConnectEvent": [
+          "__init__",
+          "connect_state",
+          "from_payload",
+          "peer"
+        ],
+        "DenoiseEvent": [
+          "__init__",
+          "denoised",
+          "from_payload"
+        ],
+        "DetectEvent": [
+          "__init__",
+          "control_id",
+          "detect",
+          "from_payload"
+        ],
+        "DialEvent": [
+          "__init__",
+          "call_data",
+          "dial_state",
+          "from_payload",
+          "tag"
+        ],
+        "EchoEvent": [
+          "__init__",
+          "from_payload",
+          "state"
+        ],
+        "FaxEvent": [
+          "__init__",
+          "control_id",
+          "fax",
+          "from_payload"
+        ],
+        "HoldEvent": [
+          "__init__",
+          "from_payload",
+          "state"
+        ],
+        "MessageReceiveEvent": [
+          "__init__",
+          "body",
+          "context",
+          "direction",
+          "from_number",
+          "from_payload",
+          "media",
+          "message_id",
+          "message_state",
+          "segments",
+          "tags",
+          "to_number"
+        ],
+        "MessageStateEvent": [
+          "__init__",
+          "body",
+          "context",
+          "direction",
+          "from_number",
+          "from_payload",
+          "media",
+          "message_id",
+          "message_state",
+          "reason",
+          "segments",
+          "tags",
+          "to_number"
+        ],
+        "PayEvent": [
+          "__init__",
+          "control_id",
+          "from_payload",
+          "state"
+        ],
+        "PlayEvent": [
+          "__init__",
+          "control_id",
+          "from_payload",
+          "state"
+        ],
+        "QueueEvent": [
+          "__init__",
+          "control_id",
+          "from_payload",
+          "position",
+          "queue_id",
+          "queue_name",
+          "size",
+          "status"
+        ],
+        "RecordEvent": [
+          "__init__",
+          "control_id",
+          "duration",
+          "from_payload",
+          "record",
+          "size",
+          "state",
+          "url"
+        ],
+        "ReferEvent": [
+          "__init__",
+          "from_payload",
+          "sip_notify_response_code",
+          "sip_refer_response_code",
+          "sip_refer_to",
+          "state"
+        ],
+        "RelayEvent": [
+          "__init__",
+          "call_id",
+          "event_type",
+          "from_payload",
+          "params",
+          "timestamp"
+        ],
+        "SendDigitsEvent": [
+          "__init__",
+          "control_id",
+          "from_payload",
+          "state"
+        ],
+        "StreamEvent": [
+          "__init__",
+          "control_id",
+          "from_payload",
+          "name",
+          "state",
+          "url"
+        ],
+        "TapEvent": [
+          "__init__",
+          "control_id",
+          "device",
+          "from_payload",
+          "state",
+          "tap"
+        ],
+        "TranscribeEvent": [
+          "__init__",
+          "control_id",
+          "duration",
+          "from_payload",
+          "recording_id",
+          "size",
+          "state",
+          "url"
+        ]
+      },
+      "functions": [
+        "parse_event"
+      ]
+    },
+    "signalwire.relay.message": {
+      "classes": {
+        "Message": [
+          "__init__",
+          "body",
+          "context",
+          "direction",
+          "done?",
+          "from_number",
+          "inspect",
+          "is_done?",
+          "media",
+          "message_id",
+          "on_completed",
+          "on_event",
+          "reason",
+          "result",
+          "segments",
+          "state",
+          "tags",
+          "to_number",
+          "to_s",
+          "wait"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest._base": {
+      "classes": {
+        "BaseResource": [
+          "__init__"
+        ],
+        "CrudResource": [
+          "create",
+          "delete",
+          "get",
+          "list",
+          "update",
+          "update_method"
+        ],
+        "HttpClient": [
+          "__init__",
+          "base_url",
+          "delete",
+          "get",
+          "patch",
+          "post",
+          "put"
+        ],
+        "SignalWireRestError": [
+          "__init__",
+          "body",
+          "method_name",
+          "status_code",
+          "url"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.client": {
+      "classes": {
+        "RestClient": [
+          "__init__",
+          "addresses",
+          "calling",
+          "chat",
+          "compat",
+          "datasphere",
+          "fabric",
+          "imported_numbers",
+          "logs",
+          "lookup",
+          "mfa",
+          "number_groups",
+          "phone_numbers",
+          "project",
+          "pubsub",
+          "queues",
+          "recordings",
+          "registry",
+          "short_codes",
+          "sip_profile",
+          "verified_callers",
+          "video"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.addresses": {
+      "classes": {
+        "AddressesResource": [
+          "__init__",
+          "create",
+          "delete",
+          "get",
+          "list"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.calling": {
+      "classes": {
+        "CallingNamespace": [
+          "__init__",
+          "ai_hold",
+          "ai_message",
+          "ai_stop",
+          "ai_unhold",
+          "collect",
+          "collect_start_input_timers",
+          "collect_stop",
+          "denoise",
+          "denoise_stop",
+          "detect",
+          "detect_stop",
+          "dial",
+          "disconnect",
+          "end_call",
+          "live_transcribe",
+          "live_translate",
+          "play",
+          "play_pause",
+          "play_resume",
+          "play_stop",
+          "play_volume",
+          "receive_fax_stop",
+          "record",
+          "record_pause",
+          "record_resume",
+          "record_stop",
+          "refer",
+          "send_fax_stop",
+          "stream",
+          "stream_stop",
+          "tap",
+          "tap_stop",
+          "transcribe",
+          "transcribe_stop",
+          "transfer",
+          "update",
+          "user_event"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.chat": {
+      "classes": {
+        "ChatResource": [
+          "__init__",
+          "create_token"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.compat": {
+      "classes": {
+        "CompatAccounts": [
+          "__init__",
+          "create",
+          "get",
+          "list",
+          "update"
+        ],
+        "CompatApplications": [
+          "update"
+        ],
+        "CompatCalls": [
+          "start_recording",
+          "start_stream",
+          "stop_stream",
+          "update",
+          "update_recording"
+        ],
+        "CompatConferences": [
+          "delete_recording",
+          "get",
+          "get_participant",
+          "get_recording",
+          "list",
+          "list_participants",
+          "list_recordings",
+          "remove_participant",
+          "start_stream",
+          "stop_stream",
+          "update",
+          "update_participant",
+          "update_recording"
+        ],
+        "CompatFaxes": [
+          "delete_media",
+          "get_media",
+          "list_media",
+          "update"
+        ],
+        "CompatLamlBins": [
+          "update"
+        ],
+        "CompatMessages": [
+          "delete_media",
+          "get_media",
+          "list_media",
+          "update"
+        ],
+        "CompatNamespace": [
+          "__init__",
+          "accounts",
+          "applications",
+          "calls",
+          "conferences",
+          "faxes",
+          "laml_bins",
+          "messages",
+          "phone_numbers",
+          "queues",
+          "recordings",
+          "tokens",
+          "transcriptions"
+        ],
+        "CompatPhoneNumbers": [
+          "__init__",
+          "delete",
+          "get",
+          "import_number",
+          "list",
+          "list_available_countries",
+          "purchase",
+          "search_local",
+          "search_toll_free",
+          "update"
+        ],
+        "CompatQueues": [
+          "dequeue_member",
+          "get_member",
+          "list_members",
+          "update"
+        ],
+        "CompatRecordings": [
+          "delete",
+          "get",
+          "list"
+        ],
+        "CompatTokens": [
+          "create",
+          "delete",
+          "update"
+        ],
+        "CompatTranscriptions": [
+          "delete",
+          "get",
+          "list"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.datasphere": {
+      "classes": {
+        "DatasphereDocuments": [
+          "__init__",
+          "delete_chunk",
+          "get_chunk",
+          "list_chunks",
+          "search"
+        ],
+        "DatasphereNamespace": [
+          "__init__",
+          "documents"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.fabric": {
+      "classes": {
+        "AutoMaterializedWebhook": [
+          "create"
+        ],
+        "CallFlowsResource": [
+          "deploy_version",
+          "list_addresses",
+          "list_versions"
+        ],
+        "ConferenceRoomsResource": [
+          "list_addresses"
+        ],
+        "CxmlApplicationsResource": [
+          "create"
+        ],
+        "CxmlWebhooksResource": [
+
+        ],
+        "FabricAddresses": [
+          "get",
+          "list"
+        ],
+        "FabricNamespace": [
+          "__init__",
+          "addresses",
+          "ai_agents",
+          "call_flows",
+          "conference_rooms",
+          "cxml_applications",
+          "cxml_scripts",
+          "cxml_webhooks",
+          "freeswitch_connectors",
+          "relay_applications",
+          "resources",
+          "sip_endpoints",
+          "sip_gateways",
+          "subscribers",
+          "swml_scripts",
+          "swml_webhooks",
+          "tokens"
+        ],
+        "FabricResource": [
+          "list_addresses"
+        ],
+        "FabricResourcePUT": [
+
+        ],
+        "FabricTokens": [
+          "__init__",
+          "create_embed_token",
+          "create_guest_token",
+          "create_invite_token",
+          "create_subscriber_token",
+          "refresh_subscriber_token"
+        ],
+        "GenericResources": [
+          "assign_domain_application",
+          "assign_phone_route",
+          "delete",
+          "get",
+          "list",
+          "list_addresses"
+        ],
+        "SubscribersResource": [
+          "create_sip_endpoint",
+          "delete_sip_endpoint",
+          "get_sip_endpoint",
+          "list_sip_endpoints",
+          "update_sip_endpoint"
+        ],
+        "SwmlWebhooksResource": [
+
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.imported_numbers": {
+      "classes": {
+        "ImportedNumbersResource": [
+          "__init__",
+          "create"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.logs": {
+      "classes": {
+        "ConferenceLogs": [
+          "list"
+        ],
+        "FaxLogs": [
+          "get",
+          "list"
+        ],
+        "LogsNamespace": [
+          "__init__",
+          "conferences",
+          "fax",
+          "messages",
+          "voice"
+        ],
+        "MessageLogs": [
+          "get",
+          "list"
+        ],
+        "VoiceLogs": [
+          "get",
+          "list",
+          "list_events"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.lookup": {
+      "classes": {
+        "LookupResource": [
+          "__init__",
+          "phone_number"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.mfa": {
+      "classes": {
+        "MfaResource": [
+          "__init__",
+          "call",
+          "sms",
+          "verify"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.number_groups": {
+      "classes": {
+        "NumberGroupsResource": [
+          "__init__",
+          "add_membership",
+          "delete_membership",
+          "get_membership",
+          "list_memberships"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.phone_numbers": {
+      "classes": {
+        "PhoneNumbersResource": [
+          "__init__",
+          "search",
+          "set_ai_agent",
+          "set_call_flow",
+          "set_cxml_application",
+          "set_cxml_webhook",
+          "set_relay_application",
+          "set_relay_topic",
+          "set_swml_webhook"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.project": {
+      "classes": {
+        "ProjectNamespace": [
+          "__init__",
+          "tokens"
+        ],
+        "ProjectTokens": [
+          "__init__",
+          "create",
+          "delete",
+          "update"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.pubsub": {
+      "classes": {
+        "PubSubResource": [
+          "__init__",
+          "create_token"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.queues": {
+      "classes": {
+        "QueuesResource": [
+          "__init__",
+          "get_member",
+          "get_next_member",
+          "list_members"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.recordings": {
+      "classes": {
+        "RecordingsResource": [
+          "__init__",
+          "delete",
+          "get",
+          "list"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.registry": {
+      "classes": {
+        "RegistryBrands": [
+          "create",
+          "create_campaign",
+          "get",
+          "list",
+          "list_campaigns"
+        ],
+        "RegistryCampaigns": [
+          "create_order",
+          "get",
+          "list_numbers",
+          "list_orders",
+          "update"
+        ],
+        "RegistryNamespace": [
+          "__init__",
+          "brands",
+          "campaigns",
+          "numbers",
+          "orders"
+        ],
+        "RegistryNumbers": [
+          "delete"
+        ],
+        "RegistryOrders": [
+          "get"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.short_codes": {
+      "classes": {
+        "ShortCodesResource": [
+          "__init__",
+          "get",
+          "list",
+          "update"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.sip_profile": {
+      "classes": {
+        "SipProfileResource": [
+          "__init__",
+          "get",
+          "update"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.verified_callers": {
+      "classes": {
+        "VerifiedCallersResource": [
+          "__init__",
+          "redial_verification",
+          "submit_verification"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.rest.namespaces.video": {
+      "classes": {
+        "VideoConferenceTokens": [
+          "get",
+          "reset"
+        ],
+        "VideoConferences": [
+          "create_stream",
+          "list_conference_tokens",
+          "list_streams"
+        ],
+        "VideoNamespace": [
+          "__init__",
+          "conference_tokens",
+          "conferences",
+          "room_recordings",
+          "room_sessions",
+          "room_tokens",
+          "rooms",
+          "streams"
+        ],
+        "VideoRoomRecordings": [
+          "delete",
+          "get",
+          "list",
+          "list_events"
+        ],
+        "VideoRoomSessions": [
+          "get",
+          "list",
+          "list_events",
+          "list_members",
+          "list_recordings"
+        ],
+        "VideoRoomTokens": [
+          "create"
+        ],
+        "VideoRooms": [
+          "create_stream",
+          "list_streams"
+        ],
+        "VideoStreams": [
+          "delete",
+          "get",
+          "update"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.runtime": {
+      "classes": {
+        "Runtime": [
+          "execution_mode",
+          "lambda?",
+          "lambda_base_url",
+          "serverless?"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.serverless.lambda_handler": {
+      "classes": {
+        "LambdaHandler": [
+          "__init__",
+          "call",
+          "for"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.api_ninjas_trivia.skill": {
+      "classes": {
+        "ApiNinjasTriviaSkill": [
+          "description",
+          "get_parameter_schema",
+          "instance_key",
+          "name",
+          "register_tools",
+          "setup",
+          "supports_multiple_instances?"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.builtin.custom_skills_skill": {
+      "classes": {
+        "CustomSkillsSkill": [
+          "description",
+          "get_parameter_schema",
+          "instance_key",
+          "name",
+          "register_tools",
+          "setup",
+          "supports_multiple_instances?"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.claude_skills.skill": {
+      "classes": {
+        "ClaudeSkillsSkill": [
+          "description",
+          "get_hints",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "instance_key",
+          "name",
+          "register_tools",
+          "setup",
+          "supports_multiple_instances?"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.datasphere.skill": {
+      "classes": {
+        "DataSphereSkill": [
+          "description",
+          "get_global_data",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "instance_key",
+          "name",
+          "register_tools",
+          "setup",
+          "supports_multiple_instances?"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.datasphere_serverless.skill": {
+      "classes": {
+        "DataSphereServerlessSkill": [
+          "description",
+          "get_global_data",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "instance_key",
+          "name",
+          "register_tools",
+          "setup",
+          "supports_multiple_instances?"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.datetime.skill": {
+      "classes": {
+        "DateTimeSkill": [
+          "description",
+          "get_prompt_sections",
+          "name",
+          "register_tools"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.google_maps.skill": {
+      "classes": {
+        "GoogleMapsSkill": [
+          "description",
+          "get_hints",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "name",
+          "register_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.info_gatherer.skill": {
+      "classes": {
+        "InfoGathererSkill": [
+          "description",
+          "get_global_data",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "instance_key",
+          "name",
+          "register_tools",
+          "setup",
+          "supports_multiple_instances?"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.joke.skill": {
+      "classes": {
+        "JokeSkill": [
+          "description",
+          "get_global_data",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "name",
+          "register_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.math.skill": {
+      "classes": {
+        "MathSkill": [
+          "description",
+          "get_prompt_sections",
+          "name",
+          "register_tools"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.mcp_gateway.skill": {
+      "classes": {
+        "MCPGatewaySkill": [
+          "description",
+          "get_global_data",
+          "get_hints",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "name",
+          "register_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.native_vector_search.skill": {
+      "classes": {
+        "NativeVectorSearchSkill": [
+          "description",
+          "get_hints",
+          "get_parameter_schema",
+          "instance_key",
+          "name",
+          "register_tools",
+          "setup",
+          "supports_multiple_instances?"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.play_background_file.skill": {
+      "classes": {
+        "PlayBackgroundFileSkill": [
+          "description",
+          "get_parameter_schema",
+          "instance_key",
+          "name",
+          "register_tools",
+          "setup",
+          "supports_multiple_instances?"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.registry": {
+      "classes": {
+        "SkillRegistry": [
+          "get_factory",
+          "list_skills",
+          "register",
+          "register_builtins!",
+          "register_skill",
+          "registered?",
+          "reset!"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.spider.skill": {
+      "classes": {
+        "SpiderSkill": [
+          "description",
+          "get_hints",
+          "get_parameter_schema",
+          "instance_key",
+          "name",
+          "register_tools",
+          "setup",
+          "supports_multiple_instances?"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.swml_transfer.skill": {
+      "classes": {
+        "SWMLTransferSkill": [
+          "description",
+          "get_hints",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "instance_key",
+          "name",
+          "register_tools",
+          "setup",
+          "supports_multiple_instances?"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.weather_api.skill": {
+      "classes": {
+        "WeatherApiSkill": [
+          "description",
+          "get_parameter_schema",
+          "name",
+          "register_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.web_search.skill": {
+      "classes": {
+        "WebSearchSkill": [
+          "description",
+          "get_global_data",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "instance_key",
+          "name",
+          "register_tools",
+          "setup",
+          "supports_multiple_instances?",
+          "version"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.skills.wikipedia_search.skill": {
+      "classes": {
+        "WikipediaSearchSkill": [
+          "description",
+          "get_parameter_schema",
+          "get_prompt_sections",
+          "name",
+          "register_tools",
+          "setup"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.swml": {
+      "classes": {
+        "SWML": [
+          "reset_schema!",
+          "schema"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.swml.document": {
+      "classes": {
+        "Document": [
+          "__init__",
+          "add_section",
+          "add_verb",
+          "add_verb_to_section",
+          "get_verbs",
+          "has_section?",
+          "render",
+          "render_pretty",
+          "reset",
+          "sections",
+          "to_h",
+          "version"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.swml.schema": {
+      "classes": {
+        "Schema": [
+          "__init__",
+          "get_verb",
+          "valid_verb?",
+          "verb_count",
+          "verb_names",
+          "verbs"
+        ]
+      },
+      "functions": [
+
+      ]
+    },
+    "signalwire.swml.service": {
+      "classes": {
+        "Service": [
+          "__init__",
+          "document",
+          "execute_verb",
+          "get_basic_auth_credentials",
+          "get_full_url",
+          "host",
+          "method_missing",
+          "name",
+          "on_request",
+          "port",
+          "rack_app",
+          "register_routing_callback",
+          "render",
+          "render_pretty",
+          "route",
+          "serve",
+          "stop"
+        ]
+      },
+      "functions": [
+
+      ]
+    }
+  },
+  "ruby_version": "3.3.6",
+  "version": "1"
+}

--- a/scripts/enumerate_surface.rb
+++ b/scripts/enumerate_surface.rb
@@ -1,0 +1,453 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# enumerate_surface.rb --- emit port_surface.json for the Ruby SignalWire SDK.
+#
+# The porting-sdk ships a canonical inventory (python_surface.json) of every
+# public class, method, and module-level function in signalwire-python. Each
+# port must produce a JSON file in the same shape so the language-agnostic
+# diff_port_surface.py tool can check symbol-level drift.
+#
+# Output shape (must match python_surface.json exactly):
+#
+#   {
+#     "version": "1",
+#     "generated_from": "signalwire-ruby @ <git sha or N/A>",
+#     "ruby_version": "3.x",
+#     "modules": {
+#       "signalwire.core.agent_base": {
+#         "classes": { "AgentBase": ["__init__", "serve", ...] },
+#         "functions": [...]
+#       }
+#     }
+#   }
+#
+# Critically, module paths in the emitted JSON use the **Python-reference**
+# dotted names. Ruby's SignalWire::AgentBase becomes signalwire.core.agent_base
+# (with class AgentBase), not signalwire.agent_base. That way, diff_port_surface
+# can compare symbols one-to-one without a per-language translation table on
+# the diff side.
+#
+# Method-name rules:
+#   * Ruby methods are already snake_case; leave as-is.
+#   * Ruby's `initialize` maps to Python's `__init__`.
+#   * Private/protected methods are excluded (we use instance_methods(false)
+#     which already filters private/protected).
+#   * Methods starting with a single `_` are skipped (Python convention we
+#     mirror in the port).
+#
+# Usage:
+#   ruby scripts/enumerate_surface.rb                       # print to stdout
+#   ruby scripts/enumerate_surface.rb --output port_surface.json
+#   ruby scripts/enumerate_surface.rb --check --output port_surface.json
+
+require 'json'
+require 'optparse'
+require 'pathname'
+
+REPO_ROOT = Pathname.new(__dir__).parent.expand_path
+LIB_DIR   = REPO_ROOT.join('lib')
+PORTING_SDK_DEFAULT = Pathname.new(ENV['PORTING_SDK_PATH'] ||
+                                   File.expand_path('~/src/porting-sdk'))
+
+# -----------------------------------------------------------------------------
+# Python class -> module index. Loaded from python_surface.json so we can look
+# up the canonical module for each class in the port. If a Ruby class name has
+# an exact match in Python, we use the Python module. If it doesn't (port-only
+# classes like Runtime, LambdaHandler, Logging::Logger), we fall back to a
+# translation of the Ruby namespace.
+# -----------------------------------------------------------------------------
+def load_python_index(python_surface_path)
+  return {} unless python_surface_path.file?
+
+  data = JSON.parse(python_surface_path.read)
+  index = {}
+  data.fetch('modules', {}).each do |mod, entry|
+    entry.fetch('classes', {}).each_key do |cls|
+      (index[cls] ||= []) << mod
+    end
+  end
+  index
+end
+
+# When a class name has multiple Python modules or when Ruby's class name
+# doesn't match Python's exactly, we need an explicit override. Keys are
+# fully-qualified Ruby names; values are the canonical Python module.
+#
+# Ruby name -> Python module (the class name gets translated via
+# RUBY_TO_PYTHON_CLASS_ALIASES below if it differs).
+RUBY_TO_PYTHON_MODULE_OVERRIDES = {
+  # AgentServer is duplicated in Python (agent_server + livewire). The Ruby
+  # port matches the standalone agent_server.
+  'SignalWire::AgentServer' => 'signalwire.agent_server',
+  # SessionManager is duplicated in Python (core.security + mcp_gateway). The
+  # Ruby port only ships the core one.
+  'SignalWire::Security::SessionManager' => 'signalwire.core.security.session_manager',
+  # Prefabs: Ruby uses short names, Python appends "Agent".
+  'SignalWire::Prefabs::Concierge' => 'signalwire.prefabs.concierge',
+  'SignalWire::Prefabs::FaqBot' => 'signalwire.prefabs.faq_bot',
+  'SignalWire::Prefabs::InfoGatherer' => 'signalwire.prefabs.info_gatherer',
+  'SignalWire::Prefabs::Receptionist' => 'signalwire.prefabs.receptionist',
+  'SignalWire::Prefabs::Survey' => 'signalwire.prefabs.survey',
+  # Built-in skills that don't match Python names 1:1.
+  'SignalWire::Skills::Builtin::SwmlTransferSkill' => 'signalwire.skills.swml_transfer.skill',
+  'SignalWire::Skills::Builtin::McpGatewaySkill' => 'signalwire.skills.mcp_gateway.skill',
+  'SignalWire::Skills::Builtin::DatasphereSkill' => 'signalwire.skills.datasphere.skill',
+  'SignalWire::Skills::Builtin::DatasphereServerlessSkill' => 'signalwire.skills.datasphere_serverless.skill',
+  # WebSearchSkill has duplicates in Python (skill, skill_improved, skill_original);
+  # the Ruby port matches the canonical `skill` module.
+  'SignalWire::Skills::Builtin::WebSearchSkill' => 'signalwire.skills.web_search.skill',
+  # Built-in skills where Ruby names match Python names but are in a deeper
+  # namespace (SignalWire::Skills::Builtin::*) than Python's module path.
+  'SignalWire::Skills::Builtin::ApiNinjasTriviaSkill' => 'signalwire.skills.api_ninjas_trivia.skill',
+  'SignalWire::Skills::Builtin::ClaudeSkillsSkill' => 'signalwire.skills.claude_skills.skill',
+  'SignalWire::Skills::Builtin::DateTimeSkill' => 'signalwire.skills.datetime.skill',
+  'SignalWire::Skills::Builtin::GoogleMapsSkill' => 'signalwire.skills.google_maps.skill',
+  'SignalWire::Skills::Builtin::InfoGathererSkill' => 'signalwire.skills.info_gatherer.skill',
+  'SignalWire::Skills::Builtin::JokeSkill' => 'signalwire.skills.joke.skill',
+  'SignalWire::Skills::Builtin::MathSkill' => 'signalwire.skills.math.skill',
+  'SignalWire::Skills::Builtin::NativeVectorSearchSkill' => 'signalwire.skills.native_vector_search.skill',
+  'SignalWire::Skills::Builtin::PlayBackgroundFileSkill' => 'signalwire.skills.play_background_file.skill',
+  'SignalWire::Skills::Builtin::SpiderSkill' => 'signalwire.skills.spider.skill',
+  'SignalWire::Skills::Builtin::WeatherApiSkill' => 'signalwire.skills.weather_api.skill',
+  'SignalWire::Skills::Builtin::WikipediaSearchSkill' => 'signalwire.skills.wikipedia_search.skill',
+  # Relay Client -> Python RelayClient in signalwire.relay.client.
+  'SignalWire::Relay::Client' => 'signalwire.relay.client',
+  # Relay error types - ActionTimeoutError is port-only; Ruby RelayError maps
+  # to Python's RelayError in signalwire.relay.client (unique class name so
+  # the auto-resolver already handles it, but we pin it for clarity).
+  'SignalWire::Relay::ActionTimeoutError' => 'signalwire.relay.client',
+}.freeze
+
+# Ruby module -> Python module mapping for module-level functions.
+# When we find singleton methods on a Ruby module, we emit them under the
+# Python-reference module path (not the Ruby namespace fallback).
+RUBY_MODULE_TO_PYTHON = {
+  # SignalWire::Relay.parse_event -> Python's signalwire.relay.event.parse_event
+  # (Ruby hoists it one level up to avoid a dedicated relay_event module).
+  'SignalWire::Relay' => 'signalwire.relay.event',
+}.freeze
+
+# Ruby class name -> Python class name (when they differ).
+RUBY_TO_PYTHON_CLASS_ALIASES = {
+  'SignalWire::Prefabs::Concierge' => 'ConciergeAgent',
+  'SignalWire::Prefabs::FaqBot' => 'FAQBotAgent',
+  'SignalWire::Prefabs::InfoGatherer' => 'InfoGathererAgent',
+  'SignalWire::Prefabs::Receptionist' => 'ReceptionistAgent',
+  'SignalWire::Prefabs::Survey' => 'SurveyAgent',
+  'SignalWire::Skills::Builtin::SwmlTransferSkill' => 'SWMLTransferSkill',
+  'SignalWire::Skills::Builtin::McpGatewaySkill' => 'MCPGatewaySkill',
+  'SignalWire::Skills::Builtin::DatasphereSkill' => 'DataSphereSkill',
+  'SignalWire::Skills::Builtin::DatasphereServerlessSkill' => 'DataSphereServerlessSkill',
+  # Ruby Relay::Client maps to Python RelayClient.
+  'SignalWire::Relay::Client' => 'RelayClient',
+}.freeze
+
+# Ruby SWML classes (Document/Schema/Service) are consolidated wrappers that
+# do not have exact Python counterparts — Python splits the same surface
+# across SWMLBuilder, SwmlRenderer, SchemaUtils, and SWMLService. We emit
+# these under Ruby-namespaced module paths (signalwire.swml.*) so they show
+# up as port additions; the Python classes are recorded as omissions with
+# rationale. This surfaces the design delta honestly rather than hiding it
+# behind fuzzy renames.
+RUBY_SWML_MODULE_OVERRIDES = {}.freeze
+
+# Nested helper/middleware classes we don't want in the surface (they're
+# internal plumbing, not public API).
+RUBY_EXCLUDED_CLASSES = %w[
+  SignalWire::AgentBase::AgentBodyLimitMiddleware
+  SignalWire::AgentBase::AgentSecurityHeadersMiddleware
+  SignalWire::AgentBase::AgentTimingSafeBasicAuth
+  SignalWire::SWML::Service::SecurityHeadersMiddleware
+  SignalWire::SWML::Service::TimingSafeBasicAuth
+  SignalWire::Logging::Logger
+  SignalWire::REST::Namespaces
+].freeze
+
+# -----------------------------------------------------------------------------
+# Name translation
+# -----------------------------------------------------------------------------
+def snake_case(camel)
+  camel
+    .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+    .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+    .downcase
+end
+
+# Translate a fully-qualified Ruby name to the Python-reference dotted module
+# + class name. Returns [module_path, class_name].
+def translate_class(ruby_fqn, python_index)
+  # 1. Explicit override wins.
+  if RUBY_TO_PYTHON_MODULE_OVERRIDES.key?(ruby_fqn)
+    mod = RUBY_TO_PYTHON_MODULE_OVERRIDES[ruby_fqn]
+    cls = RUBY_TO_PYTHON_CLASS_ALIASES[ruby_fqn] || ruby_fqn.split('::').last
+    return [mod, cls]
+  end
+
+  # 2. SWML-specific mapping.
+  if RUBY_SWML_MODULE_OVERRIDES.key?(ruby_fqn)
+    return [RUBY_SWML_MODULE_OVERRIDES[ruby_fqn], ruby_fqn.split('::').last]
+  end
+
+  cls = ruby_fqn.split('::').last
+
+  # 3. Ruby class name matches a Python class name uniquely -> use Python mod.
+  if python_index.key?(cls) && python_index[cls].length == 1
+    return [python_index[cls].first, cls]
+  end
+
+  # 4. No Python match -> translate Ruby namespace to dotted snake_case path,
+  # emitting under a signalwire.* module. Port-only additions show up in
+  # PORT_ADDITIONS.md.
+  #
+  # Python uses per-file module paths (signalwire.core.agent_base.AgentBase),
+  # so for Ruby we append snake_case(class_name) to the namespace segments —
+  # that matches Ruby's convention of one class per file (agent_base.rb holds
+  # SignalWire::AgentBase). This keeps port-only classes in distinct modules
+  # rather than collapsing them into their parent namespace.
+  parts = ruby_fqn.split('::').map { |p| snake_case(p) }
+  # SignalWire -> signalwire
+  parts[0] = 'signalwire'
+  # Drop the class name segment and append it as the final module segment
+  # (so SignalWire::Runtime -> signalwire.runtime, and
+  #  SignalWire::SWML::Document -> signalwire.swml.document).
+  mod_parts = parts[0..-2] + [snake_case(cls)]
+  [mod_parts.join('.'), cls]
+end
+
+# Translate a Ruby module FQN (e.g. "SignalWire::Runtime") to the module path
+# used for port-only modules. Mirrors the fallback in `translate_class`.
+def ruby_fqn_to_port_module(fqn)
+  parts = fqn.split('::').map { |p| snake_case(p) }
+  parts[0] = 'signalwire'
+  parts.join('.')
+end
+
+# Singleton methods on a Ruby module mirror Python's @classmethod/@staticmethod
+# methods on a class. Emit them using the same filtering rules as class
+# methods. No `initialize` handling because modules aren't instantiated.
+def enumerate_module_methods(mod)
+  seen = {}
+  mod.singleton_methods(false).map(&:to_s).each do |m|
+    next if m.start_with?('_') && !m.start_with?('__')
+    next if m.end_with?('=')
+    seen[m] = true
+  end
+  seen.keys.sort
+end
+
+# -----------------------------------------------------------------------------
+# Enumerate public methods of a Ruby class.
+#
+# public_instance_methods(false) already excludes private and protected; we
+# only add "initialize" back (it's private by default in Ruby) since it maps
+# to Python's __init__.
+# -----------------------------------------------------------------------------
+def enumerate_methods(klass)
+  raw = []
+  raw.concat(klass.public_instance_methods(false).map(&:to_s))
+  # Class methods (Python module-level "classmethod"/"staticmethod" show up as
+  # methods on the class too).
+  raw.concat(klass.singleton_methods(false).map(&:to_s))
+  # initialize is private by default — include it explicitly.
+  raw << 'initialize' if klass.private_instance_methods(false).include?(:initialize)
+
+  seen = {}
+  raw.each do |m|
+    # Skip single-underscore-prefixed methods (Python convention mirrored).
+    next if m.start_with?('_') && !m.start_with?('__')
+    # Skip auto-generated writer methods (attr_writer/attr_accessor). The
+    # Python surface file doesn't emit setters either.
+    next if m.end_with?('=')
+    # Keep `?`- and `!`-suffixed method names as-is. Ruby predicate
+    # methods (has_skill?) and bang methods (reset!) are idiomatic; they
+    # show up as port additions (Python has no equivalent, so they end up
+    # in PORT_ADDITIONS.md with the Ruby-idiom rationale).
+    name = m == 'initialize' ? '__init__' : m
+    seen[name] = true
+  end
+  seen.keys.sort
+end
+
+# -----------------------------------------------------------------------------
+# Gather everything.
+# -----------------------------------------------------------------------------
+def collect_modules(python_index)
+  # Modules in the final snapshot. Each entry: {"classes" => {...}, "functions" => [...]}.
+  modules = Hash.new { |h, k| h[k] = { 'classes' => {}, 'functions' => [] } }
+
+  seen_classes = {}
+  ObjectSpace.each_object(Module) do |m|
+    name = m.name
+    next unless name && name.start_with?('SignalWire')
+    # ObjectSpace yields modules and classes; skip anonymous and the top-level
+    # SignalWire module itself.
+    next if name == 'SignalWire'
+    next if seen_classes[name]
+    seen_classes[name] = true
+
+    # Skip excluded internal classes (middlewares, nested helpers).
+    next if RUBY_EXCLUDED_CLASSES.include?(name)
+
+    # Skip private constants (class name starts with `_`).
+    leaf = name.split('::').last
+    next if leaf.start_with?('_')
+
+    # Modules (not Classes): if they have singleton methods, those are
+    # Ruby module functions. Map them to a Python module's functions[]
+    # when we have a mapping; otherwise emit as a class-like entry so
+    # port-only modules (Runtime, Logging) still show up.
+    unless m.is_a?(Class)
+      # Skip pure namespace modules with no functions of their own.
+      if m.singleton_methods(false).empty? && m.instance_methods(false).empty?
+        next
+      end
+
+      if RUBY_MODULE_TO_PYTHON.key?(name)
+        target_mod = RUBY_MODULE_TO_PYTHON[name]
+        fns = m.singleton_methods(false).map(&:to_s)
+              .reject { |meth| meth.start_with?('_') && !meth.start_with?('__') }
+              .reject { |meth| meth.end_with?('=') }
+              .sort
+        modules[target_mod]['functions'] = (modules[target_mod]['functions'] + fns).uniq.sort
+        next
+      end
+
+      # Port-only module with its own singleton methods: emit as a class-like
+      # entry (signalwire.runtime.Runtime etc.). These land in PORT_ADDITIONS.
+      mod_path = ruby_fqn_to_port_module(name)
+      modules[mod_path]['classes'][leaf] = enumerate_module_methods(m)
+      next
+    end
+
+    mod, cls = translate_class(name, python_index)
+    methods = enumerate_methods(m)
+    modules[mod]['classes'][cls] = methods
+  end
+
+  # Top-level signalwire functions (Ruby's top-level "def" equivalents). In
+  # Ruby, these are typically module-level singleton methods on the SignalWire
+  # module. The Python "signalwire" module exposes run_agent, start_agent,
+  # etc., which in Ruby don't exist as module functions yet — they're invoked
+  # via instance methods on AgentBase. So we emit the empty set for the base
+  # "signalwire" module if no functions are found; PORT_OMISSIONS accounts
+  # for the missing ones.
+  sig_funcs = SignalWire.singleton_methods(false).map(&:to_s).reject { |m| m.start_with?('_') }.sort
+  if sig_funcs.any? || modules.key?('signalwire')
+    modules['signalwire'] ||= { 'classes' => {}, 'functions' => [] }
+    modules['signalwire']['functions'] = sig_funcs
+  end
+
+  # Drop modules that ended up completely empty after filtering (no classes,
+  # no functions) — matches the Python enumerator's behaviour.
+  modules.reject { |_k, v| v['classes'].empty? && v['functions'].empty? }
+end
+
+def git_sha
+  sha = `git -C #{REPO_ROOT} rev-parse HEAD 2>/dev/null`.strip
+  sha.empty? ? 'N/A' : sha
+end
+
+def build_snapshot(python_surface_path)
+  python_index = load_python_index(python_surface_path)
+
+  # Load all Ruby source files so every class/module is visible to ObjectSpace.
+  # We intentionally require each file under lib/signalwire/ so that a missing
+  # entry in lib/signalwire.rb doesn't silently shrink the surface.
+  $LOAD_PATH.unshift(LIB_DIR.to_s) unless $LOAD_PATH.include?(LIB_DIR.to_s)
+  require 'signalwire'
+  Dir[LIB_DIR.join('signalwire/**/*.rb').to_s].sort.each { |f| require f }
+
+  mods = collect_modules(python_index)
+
+  # Sort everything for deterministic output: modules by key, classes within
+  # each module by key, methods/functions as arrays of sorted strings.
+  sorted = {}
+  mods.keys.sort.each do |k|
+    entry = mods[k]
+    sorted_classes = {}
+    entry['classes'].keys.sort.each do |cls|
+      sorted_classes[cls] = entry['classes'][cls]
+    end
+    sorted[k] = {
+      'classes'   => sorted_classes,
+      'functions' => entry['functions'].sort
+    }
+  end
+
+  {
+    'version'        => '1',
+    'generated_from' => "signalwire-ruby @ #{git_sha}",
+    'ruby_version'   => RUBY_VERSION,
+    'modules'        => sorted
+  }
+end
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+def strip_meta(obj)
+  obj.reject { |k, _| k == 'generated_from' }
+end
+
+def main(argv)
+  options = {
+    output:         nil,
+    check:          false,
+    python_surface: PORTING_SDK_DEFAULT.join('python_surface.json')
+  }
+  OptionParser.new do |o|
+    o.banner = 'Usage: ruby scripts/enumerate_surface.rb [options]'
+    o.on('--output PATH', 'Write JSON to this path (default: stdout)') { |v| options[:output] = Pathname.new(v) }
+    o.on('--check', 'Compare against --output; exit 1 on drift') { options[:check] = true }
+    o.on('--python-surface PATH', 'Path to python_surface.json') { |v| options[:python_surface] = Pathname.new(v) }
+    o.on('-h', '--help', 'Show this help') { puts o; exit 0 }
+  end.parse!(argv)
+
+  if options[:check] && options[:output].nil?
+    warn 'error: --check requires --output'
+    return 2
+  end
+
+  snapshot = build_snapshot(options[:python_surface])
+  rendered = JSON.pretty_generate(deep_sort(snapshot)) + "\n"
+
+  if options[:check]
+    unless options[:output].file?
+      warn "error: #{options[:output]} does not exist"
+      return 1
+    end
+    existing = JSON.parse(options[:output].read)
+    actual   = JSON.parse(rendered)
+    if strip_meta(existing) != strip_meta(actual)
+      warn 'DRIFT: port_surface.json is stale relative to lib/.'
+      warn '  Regenerate: ruby scripts/enumerate_surface.rb --output port_surface.json'
+      return 1
+    end
+    return 0
+  end
+
+  if options[:output]
+    options[:output].write(rendered)
+  else
+    $stdout.write(rendered)
+  end
+  0
+end
+
+# JSON.pretty_generate doesn't recursively sort hash keys; the Python reference
+# emits with sort_keys=True. Mirror that here.
+def deep_sort(obj)
+  case obj
+  when Hash
+    sorted = {}
+    obj.keys.sort.each { |k| sorted[k] = deep_sort(obj[k]) }
+    sorted
+  when Array
+    obj.map { |x| deep_sort(x) }
+  else
+    obj
+  end
+end
+
+exit main(ARGV) if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
## Summary

Wires Layer B of the porting-sdk's symbol-parity contract. Every public class and method in the Python reference SDK is now either present in this port or explicitly listed in `PORT_OMISSIONS.md` with a concrete rationale. Drift fails CI.

- **`scripts/enumerate_surface.rb`** — reflection-based. `require 'lib/signalwire'` + `ObjectSpace.each_object(Module)` walk, honoring source-level `private`/`protected` via `public_instance_methods(false)`. `initialize` remapped to `__init__`.
- **Name translation**: loads `python_surface.json` at runtime to build a class-name → module index. Ruby classes matching a unique Python class emit under the Python module. Explicit overrides for duplicates (AgentServer, SessionManager), skill-naming (`FaqBot → FAQBotAgent`), and module functions (`SignalWire::Relay.parse_event` → `signalwire.relay.event.parse_event`).
- **`port_surface.json`** — 1223 symbols in the `python_surface.json` shape.
- **`PORT_OMISSIONS.md`** — 672 rationalized symbols. Major buckets: CLI tooling (~120), search/vector subsystem (~60), LiveKit shim (~65), MCP gateway daemon (~35), Python mixins collapsed into `SignalWire::AgentBase` (~66), POM internals (~24), SWML internal class splits (~47), Ruby-keyword conflicts (`Call.pass_`/`tap`, `CallingNamespace.end`, `Message.on`), Python async-context-manager dunders on RelayClient.
- **`PORT_ADDITIONS.md`** — 509 additions: Lambda stack from `feat/lambda-support` (`signalwire.runtime.Runtime`, `signalwire.serverless.lambda_handler.LambdaHandler`), ~56 mixin methods hoisted onto `AgentBase`, ~118 relay event `attr_reader` accessors, Ruby idioms (`to_h`/`to_json`/`to_s`/`inspect`/`?`/`!`).
- **`.github/workflows/surface-audit.yml`** — PR + nightly. Clones porting-sdk alongside, runs enumerator, invokes diff.

## Upstream

Contributed a purely additive regex extension to porting-sdk's `diff_port_surface.py` so Ruby predicate/bang symbol names (`has_skill?`, `reset!`) parse cleanly in exemption files. That landed in porting-sdk `01c4e47` on `main`.

## Test plan

- [x] `port matches Python reference (1223 symbols; 672 excused omissions, 509 excused additions)` — diff exit 0.
- [x] `bundle exec rake test` — 981 runs, 2432 assertions, 0 failures, 0 errors, 0 skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)