### PR TITLE
fix(surface-fresh): regen surface via bundle exec so rack loads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,16 @@ jobs:
           path: porting-sdk
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 
+      # The EMISSION gate compares this port's to_dict() output against the
+      # signalwire-python oracle (FunctionResult), which pulls fastapi via
+      # signalwire/__init__. Check it out so the EMISSION gate has its reference.
+      - name: Checkout signalwire-python (EMISSION oracle)
+        uses: actions/checkout@v5
+        with:
+          repository: signalwire/signalwire-python
+          path: signalwire-python
+          ref: main
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -46,6 +56,16 @@ jobs:
         run: |
           pip install -e porting-sdk/test_harness/mock_relay
           pip install -e porting-sdk/test_harness/mock_signalwire
+
+      # EMISSION needs `import signalwire` (the oracle). Install from the
+      # adjacent checkout only if not already importable.
+      - name: Install signalwire-python (EMISSION oracle) if not importable
+        run: |
+          if python -c "import signalwire.core.function_result" 2>/dev/null; then
+            echo "signalwire-python already importable; skipping install"
+          else
+            pip install ./signalwire-python
+          fi
 
       - name: Run CI gate script (TEST -> SIGNATURES -> DRIFT -> NO-CHEAT)
         working-directory: signalwire-ruby

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -86,7 +86,9 @@ run_gate "DRIFT" "diff_port_signatures vs python reference" \
 surface_fresh_gate() {
     git show HEAD:port_surface.json > /tmp/committed_surface.json 2>/dev/null \
         || cp "$PORT_ROOT/port_surface.json" /tmp/committed_surface.json
-    ruby scripts/enumerate_surface.rb --output "$PORT_ROOT/port_surface.json"
+    # `bundle exec` so the regen loads gems from the Gemfile (it `require`s
+    # signalwire → rack); bare `ruby` failed in CI with `cannot load -- rack`.
+    bundle exec ruby scripts/enumerate_surface.rb --output "$PORT_ROOT/port_surface.json"
     local regen_rc=$?
     if [ "$regen_rc" -ne 0 ]; then
         git checkout -- port_surface.json 2>/dev/null


### PR DESCRIPTION
## Bug
The SURFACE-FRESH gate regenerated `port_surface.json` with bare `ruby`, but `enumerate_surface.rb` `require`s signalwire (→ rack), so without the Gemfile's gem context it failed in CI:

```
cannot load such file -- rack (LoadError)
```

(Pre-existing; was masked behind the now-fixed EMISSION red.)

## Fix
The TEST gate already runs under `bundle exec rake test`; the surface regen was just inconsistent. Run it via `bundle exec ruby` so the bundle's gems are on the load path. Verified: regen + freshness check pass locally.

Pairs with the porting-sdk SURFACE-FRESH fix (PR #5) that also clears the latent `ruby_version` env-leaf which would otherwise mismatch across Ruby versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)