### PR TITLE
chore: raise Ruby floor from EOL 3.0 to 3.2

### DIFF
--- a/signalwire-sdk.gemspec
+++ b/signalwire-sdk.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/signalwire/signalwire-ruby'
   s.license     = 'MIT'
 
-  s.required_ruby_version = '>= 3.0'
+  s.required_ruby_version = '>= 3.2'
 
   s.files = Dir['lib/**/*', 'bin/*', 'README.md', 'LICENSE']
   s.require_paths = ['lib']


### PR DESCRIPTION
## What

Change `signalwire-sdk.gemspec` `s.required_ruby_version` from `>= 3.0` to `>= 3.2`.

## Why

The gemspec declared `>= 3.0` (EOL since April 2024) but CI only tests 3.2 — the floor advertised support for an unmaintained, untested runtime. Raise to `>= 3.2` to match the tested + maintained version (same stale-floor fix as the perl 5.026→5.36 change).

## Verification

- `grep required_ruby_version signalwire-sdk.gemspec` → `>= 3.2`
- `gem build signalwire-sdk.gemspec` → Successfully built RubyGem (signalwire-sdk-2.0.0)
- Checked `lib/` for syntax newer than 3.2: only Ruby 3.0 pattern matching is used; no `Data.define`, no `it` implicit block param, nothing 3.3/3.4-only. So 3.2 is the correct floor.
- Gemspec-only change; no `.github/workflows/` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)