### PR TITLE
chore: prune 2 redundant signature exemptions

### DIFF
--- a/PORT_SIGNATURE_OMISSIONS.md
+++ b/PORT_SIGNATURE_OMISSIONS.md
@@ -211,11 +211,9 @@ signalwire.relay.client.RelayClient.dial: kwargs-spread — Ruby `dial_timeout:`
 # Prompt Object Model — Ruby keyword-arg idiom
 
 signalwire.pom.pom.PromptObjectModel.__init__: Ruby keyword-arg idiom — `debug:` defaults are keyword in Ruby, positional with default in Python
-signalwire.pom.pom.PromptObjectModel.to_dict: Ruby convention — to_h replaces to_dict (see SignalWire::POM::PromptObjectModel#to_h in PORT_OMISSIONS.md)
 signalwire.pom.pom.PromptObjectModel.to_json: Ruby JSON convention — `to_json(*_args)` accepts the optional state argument that Ruby's JSON.generate forwards
 signalwire.pom.pom.Section.render_markdown: Ruby keyword-arg idiom — `level:` and `section_number:` are keyword in Ruby, positional with default in Python
 signalwire.pom.pom.Section.render_xml: Ruby keyword-arg idiom — `indent:` and `section_number:` are keyword in Ruby, positional with default in Python
-signalwire.pom.pom.Section.to_dict: Ruby convention — to_h replaces to_dict (see SignalWire::POM::Section#to_h in PORT_OMISSIONS.md)
 
 # Cross-port parity methods — Ruby keyword-arg idiom (positional-with-default in Python)
 


### PR DESCRIPTION
Verification-driven cleanup of `PORT_SIGNATURE_OMISSIONS.md`: removed **2** entries that the cross-port DRIFT checker now handles by rule rather than needing a manual exemption — factory-constructor `__init__`, fluent-void returns (incl. the mixin-projected case generalized in signalwire/porting-sdk#33), and port-state accessors.

Method: remove each entry, confirm DRIFT stays 0, then re-verify the whole batch collectively. **163** genuinely load-bearing exemptions remain, so the file now means what it says (every line = a real divergence the checker can't infer).

Verified: `diff_port_signatures.py` (regenerated signatures) → `signatures match`, drift = 0. Docs/exemptions only — no source change.

Depends on porting-sdk#33 (already merged to main), which CI checks out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)