### PR TITLE
test: isolate mock sessions for parallel-safe relay/REST suites

### DIFF
--- a/lib/signalwire/relay/client.rb
+++ b/lib/signalwire/relay/client.rb
@@ -135,6 +135,15 @@ module SignalWire
         # Session state
         @protocol            = nil
         @authorization_state = nil
+        # Server-assigned session id from the connect handshake. Kept off the
+        # public surface (single-underscore reader, like +_set_protocol+ and
+        # +_authorization_state+, so the surface oracle excludes it) and never
+        # widens the developer-facing API. Test-harness support only: the
+        # mock-relay tests read it (via +_session_id+) to scope the shared
+        # mock's journal to their own connection. This mirrors the frozen
+        # TypeScript port's private +_sessionId+ capture; Python's RelayClient
+        # doesn't surface it either, so no public-surface parity is affected.
+        @session_id          = nil
         @ws                  = nil
         @running             = false
         @connected           = false
@@ -200,6 +209,18 @@ module SignalWire
       # +signalwire.authorization.state+ events for use on reconnect.
       def _authorization_state
         @authorization_state
+      end
+
+      # Return the server-assigned session id captured from the connect
+      # handshake. Internal/test surface only (single-underscore => excluded
+      # from the public surface oracle, like +_set_protocol+): the mock-relay
+      # test harness reads it to scope its journal/scenario calls to this
+      # connection so the shared mock is safe under parallel test execution.
+      # Mirrors the frozen TypeScript port's private +_sessionId+; not part of
+      # Python's public surface. +nil+ until +run+/+connect+ completes the
+      # handshake.
+      def _session_id
+        @session_id
       end
 
       # True when the client believes the WebSocket is open. Exposed for
@@ -537,6 +558,11 @@ module SignalWire
 
         result = execute(METHOD_SIGNALWIRE_CONNECT, params)
         @protocol = result['protocol'] if result['protocol']
+        # Capture the server-assigned session id from the ConnectResult. Stays
+        # internal (test-harness only, via +_session_id+) to scope the shared
+        # mock relay's journal to this connection for parallel-safe tests;
+        # mirrors the frozen TypeScript port's +_sessionId+ capture.
+        @session_id = result['sessionid'] if result['sessionid']
       end
 
       def _apply_session_restore(params)

--- a/tests/relay/actions_mock_test.rb
+++ b/tests/relay/actions_mock_test.rb
@@ -19,15 +19,20 @@ require_relative 'mock_test'
 
 # Shared setup + answered-call helper for the action mock test groups below.
 class RelayActionsTestBase < Minitest::Test
+  # Parallelize: each test's client owns a distinct server session + scoped
+  # harness, so action scenarios/journals never cross between concurrent tests.
+  # Subclasses inherit this (Minitest's parallelize_me! defines a test_order
+  # method, which subclasses inherit).
+  parallelize_me!
+
   def setup
-    RelayMockTest.reset
     @handle = RelayMockTest.client
     @client = @handle[:client]
+    @mock   = @handle[:mock]
   end
 
   def teardown
     RelayMockTest.shutdown_client(@handle) if @handle
-    RelayMockTest.reset
   end
 
   # ---- Helper: establish an answered inbound call ----------------------
@@ -36,7 +41,7 @@ class RelayActionsTestBase < Minitest::Test
     captured_q = Queue.new
     handler_done = Queue.new
     @client.on_call { |call| _capture_answered_call(call, captured_q, handler_done) }
-    RelayMockTest.journal.inbound_call(call_id: call_id, auto_states: ['created'])
+    @mock.inbound_call(call_id: call_id, auto_states: ['created'])
     Timeout.timeout(5) { handler_done.pop }
     call = Timeout.timeout(5) { captured_q.pop }
     # Mark answered so subsequent actions don't think it's gone.
@@ -52,15 +57,15 @@ class RelayActionsTestBase < Minitest::Test
 
   # Push a signalwire.event frame carrying a calling.* event onto the mock.
   def push_call_event(event_type, params)
-    RelayMockTest.journal.push({
-                                 'jsonrpc' => '2.0', 'id' => SecureRandom.uuid, 'method' => 'signalwire.event',
-                                 'params' => { 'event_type' => event_type, 'params' => params }
-                               })
+    @mock.push({
+                 'jsonrpc' => '2.0', 'id' => SecureRandom.uuid, 'method' => 'signalwire.event',
+                 'params' => { 'event_type' => event_type, 'params' => params }
+               })
   end
 
   # Journaled outbound frames recorded for a RELAY method.
   def recv(method)
-    RelayMockTest.journal.journal_recv(method: method)
+    @mock.journal_recv(method: method)
   end
 end
 
@@ -81,10 +86,10 @@ class RelayPlayActionTest < RelayActionsTestBase
 
   def test_play_resolves_on_finished_event
     call = answered_inbound_call('call-play-fin')
-    RelayMockTest.journal.arm_method('calling.play', [
-                                       { 'emit' => { 'state' => 'playing' },  'delay_ms' => 1 },
-                                       { 'emit' => { 'state' => 'finished' }, 'delay_ms' => 5 }
-                                     ])
+    @mock.arm_method('calling.play', [
+                       { 'emit' => { 'state' => 'playing' }, 'delay_ms' => 1 },
+                       { 'emit' => { 'state' => 'finished' }, 'delay_ms' => 5 }
+                     ])
     action = call.play([{ 'type' => 'silence', 'params' => { 'duration' => 1 } }], control_id: 'play-ctl-fin')
 
     assert_kind_of SignalWire::Relay::PlayAction, action
@@ -121,7 +126,7 @@ class RelayPlayActionTest < RelayActionsTestBase
 
   def test_play_on_completed_callback_fires
     call = answered_inbound_call('call-play-cb')
-    RelayMockTest.journal.arm_method('calling.play', [{ 'emit' => { 'state' => 'finished' }, 'delay_ms' => 1 }])
+    @mock.arm_method('calling.play', [{ 'emit' => { 'state' => 'finished' }, 'delay_ms' => 1 }])
     cb_q = Queue.new
     cb = ->(event) { cb_q.push(event) }
     action = call.play([{ 'type' => 'silence', 'params' => { 'duration' => 1 } }],
@@ -150,10 +155,10 @@ class RelayRecordActionTest < RelayActionsTestBase
 
   def test_record_resolves_on_finished_event
     call = answered_inbound_call('call-rec-fin')
-    RelayMockTest.journal.arm_method('calling.record',
-                                     [{ 'emit' => { 'state' => 'recording' }, 'delay_ms' => 1 },
-                                      { 'emit' => { 'state' => 'finished', 'url' => 'http://r.wav' },
-                                        'delay_ms' => 5 }])
+    @mock.arm_method('calling.record',
+                     [{ 'emit' => { 'state' => 'recording' }, 'delay_ms' => 1 },
+                      { 'emit' => { 'state' => 'finished', 'url' => 'http://r.wav' },
+                        'delay_ms' => 5 }])
     action = call.record(audio: { 'format' => 'wav' }, control_id: 'rec-ctl-fin')
 
     assert_kind_of SignalWire::Relay::RecordAction, action
@@ -178,9 +183,9 @@ class RelayDetectActionTest < RelayActionsTestBase
   def test_detect_resolves_on_first_detect_payload
     call = answered_inbound_call('call-det')
     machine_detect = { 'detect' => { 'type' => 'machine', 'params' => { 'event' => 'MACHINE' } } }
-    RelayMockTest.journal.arm_method('calling.detect',
-                                     [{ 'emit' => machine_detect, 'delay_ms' => 1 },
-                                      { 'emit' => { 'state' => 'finished' }, 'delay_ms' => 10 }])
+    @mock.arm_method('calling.detect',
+                     [{ 'emit' => machine_detect, 'delay_ms' => 1 },
+                      { 'emit' => { 'state' => 'finished' }, 'delay_ms' => 10 }])
     action = call.detect({ 'type' => 'machine', 'params' => {} }, control_id: 'det-ctl-1')
 
     assert_kind_of SignalWire::Relay::DetectAction, action

--- a/tests/relay/connect_mock_test.rb
+++ b/tests/relay/connect_mock_test.rb
@@ -23,14 +23,21 @@ require_relative 'mock_test'
 # classes. The suite is split into topic classes so no single class grows
 # unbounded; they all mix in this module.
 module RelayConnectHelpers
+  # Run this class's tests in parallel threads. Session isolation (each client
+  # gets its own server session id + scoped harness) makes the shared mock
+  # safe under concurrency, so parallelism stress-proves the isolation.
+  def self.included(base)
+    base.parallelize_me!
+  end
+
   def setup
-    RelayMockTest.reset
+    # No global reset: each client's @handle[:mock] is session-scoped and
+    # starts empty, so connect-frame counts stay parallel-safe.
     @handle = nil
   end
 
   def teardown
     RelayMockTest.shutdown_client(@handle) if @handle
-    RelayMockTest.reset
   end
 
   # Open a raw WS, send +frame+, and return the raw response with matching id.
@@ -102,9 +109,10 @@ module RelayConnectHelpers
     issued_protocol
   end
 
-  # All journaled signalwire.connect frames received by the mock.
+  # The signalwire.connect frames THIS test's client sent, read through its
+  # session-scoped harness (so a parallel test's connect is never counted).
   def connect_frames
-    RelayMockTest.journal.journal_recv(method: SignalWire::Relay::METHOD_SIGNALWIRE_CONNECT)
+    @handle[:mock].journal_recv(method: SignalWire::Relay::METHOD_SIGNALWIRE_CONNECT)
   end
 
   def connect_protocol(entry)

--- a/tests/relay/convenience_mock_test.rb
+++ b/tests/relay/convenience_mock_test.rb
@@ -28,15 +28,19 @@ require_relative 'mock_test'
 
 # Shared fixture + dial/journal helpers for the Call-convenience mock tests.
 module RelayConvenienceHelpers
+  # Parallelize: per-client session scoping isolates each test's journal/scenarios.
+  def self.included(base)
+    base.parallelize_me!
+  end
+
   def setup
-    RelayMockTest.reset
     @handle = RelayMockTest.client
     @client = @handle[:client]
+    @mock   = @handle[:mock]
   end
 
   def teardown
     RelayMockTest.shutdown_client(@handle) if @handle
-    RelayMockTest.reset
   end
 
   def phone_device(to: '+15551112222', frm: '+15553334444')
@@ -46,8 +50,8 @@ module RelayConvenienceHelpers
   # Dial a single-leg call through the mock and return the resolved Call.
   # The winner ends in the requested final state (default `answered`).
   def dial_call(tag:, call_id:, states: %w[created answered])
-    RelayMockTest.journal.arm_dial(tag: tag, winner_call_id: call_id, states: states,
-                                   node_id: 'node-mock-1', device: phone_device)
+    @mock.arm_dial(tag: tag, winner_call_id: call_id, states: states,
+                   node_id: 'node-mock-1', device: phone_device)
     call = @client.dial([[phone_device]], tag: tag, timeout: 5)
 
     assert_kind_of SignalWire::Relay::Call, call
@@ -57,7 +61,7 @@ module RelayConvenienceHelpers
 
   # Pull the single calling.<method> frame's params off the journal.
   def last_params(method)
-    frames = RelayMockTest.journal.journal_recv(method: method)
+    frames = @mock.journal_recv(method: method)
 
     refute_empty frames, "no #{method} frame in journal"
     frames.last.frame['params']

--- a/tests/relay/event_dispatch_mock_test.rb
+++ b/tests/relay/event_dispatch_mock_test.rb
@@ -15,22 +15,29 @@ require_relative 'mock_test'
 
 # Shared mock lifecycle + frame helpers for the event-dispatch test classes.
 module RelayEventDispatchSupport
+  # Parallelize: per-client session scoping isolates each test's journal/pushes.
+  def self.included(base)
+    base.parallelize_me!
+  end
+
   def setup
-    RelayMockTest.reset
+    # No global reset: the per-client @mock is scoped to this connection's
+    # session id and starts with an empty (scoped) journal, so the shared mock
+    # is safe under parallel execution.
     @handle = RelayMockTest.client
     @client = @handle[:client]
+    @mock   = @handle[:mock]
   end
 
   def teardown
     RelayMockTest.shutdown_client(@handle) if @handle
-    RelayMockTest.reset
   end
 
   def answered_call(call_id = 'evt-call-1')
     captured_q = Queue.new
     handler_done = Queue.new
     @client.on_call { |call| _answer_and_signal(call, captured_q, handler_done) }
-    RelayMockTest.journal.inbound_call(call_id: call_id, auto_states: ['created'])
+    @mock.inbound_call(call_id: call_id, auto_states: ['created'])
     Timeout.timeout(5) { handler_done.pop }
     call = Timeout.timeout(5) { captured_q.pop }
     call.state = 'answered'
@@ -54,10 +61,10 @@ module RelayEventDispatchSupport
 
   # Push a calling.call.play "finished" event for the given call/control id.
   def push_play_finished(call_id, control_id)
-    RelayMockTest.journal.push(bare_event_frame(
-                                 'calling.call.play',
-                                 { 'call_id' => call_id, 'control_id' => control_id, 'state' => 'finished' }
-                               ))
+    @mock.push(bare_event_frame(
+                 'calling.call.play',
+                 { 'call_id' => call_id, 'control_id' => control_id, 'state' => 'finished' }
+               ))
   end
 
   # Start a 60s silence playback on +call+ under the given control id.
@@ -68,16 +75,16 @@ module RelayEventDispatchSupport
   # Journaled 'recv' frames carrying the given id that include a 'result'
   # (i.e. ACK/PONG responses the SDK sent back).
   def recv_results_for(frame_id)
-    RelayMockTest.journal.journal.select do |e|
+    @mock.journal.select do |e|
       e.direction == 'recv' && e.frame['id'] == frame_id && e.frame.key?('result')
     end
   end
 
   # All 'recv' frames carrying the given id (for diagnostics).
   def recv_frames_for(frame_id)
-    RelayMockTest.journal.journal
-                 .select { |e| e.direction == 'recv' && e.frame['id'] == frame_id }
-                 .map(&:frame)
+    @mock.journal
+         .select { |e| e.direction == 'recv' && e.frame['id'] == frame_id }
+         .map(&:frame)
   end
 end
 
@@ -90,7 +97,7 @@ class RelayEventDispatchMockTest < Minitest::Test
     call = answered_call('ec-rec-pa')
     action = call.record(audio: { 'format' => 'wav' }, control_id: 'ec-rec-pa-1')
     action.pause(behavior: 'continuous')
-    pauses = RelayMockTest.journal.journal_recv(method: 'calling.record.pause')
+    pauses = @mock.journal_recv(method: 'calling.record.pause')
 
     refute_empty pauses
     p = pauses.last.frame['params']
@@ -103,7 +110,7 @@ class RelayEventDispatchMockTest < Minitest::Test
     call = answered_call('ec-rec-re')
     action = call.record(audio: { 'format' => 'wav' }, control_id: 'ec-rec-re-1')
     action.resume
-    resumes = RelayMockTest.journal.journal_recv(method: 'calling.record.resume')
+    resumes = @mock.journal_recv(method: 'calling.record.resume')
 
     refute_empty resumes
     assert_equal 'ec-rec-re-1', resumes.last.frame['params']['control_id']
@@ -113,7 +120,7 @@ class RelayEventDispatchMockTest < Minitest::Test
     call = answered_call('ec-col-sit')
     digits = { 'digits' => { 'max' => 4 }, 'start_input_timers' => false }
     call.collect(digits, control_id: 'ec-col-sit-1').start_input_timers
-    starts = RelayMockTest.journal.journal_recv(method: 'calling.collect.start_input_timers')
+    starts = @mock.journal_recv(method: 'calling.collect.start_input_timers')
 
     refute_empty starts
     assert_equal 'ec-col-sit-1', starts.last.frame['params']['control_id']
@@ -126,7 +133,7 @@ class RelayEventDispatchMockTest < Minitest::Test
       control_id: 'ec-pvol-1'
     )
     action.volume(-5.5)
-    vol = RelayMockTest.journal.journal_recv(method: 'calling.play.volume')
+    vol = @mock.journal_recv(method: 'calling.play.volume')
 
     refute_empty vol
     assert_in_delta(-5.5, vol.last.frame['params']['volume'])
@@ -135,25 +142,25 @@ class RelayEventDispatchMockTest < Minitest::Test
   # ---- Unknown event types ---------------------------------------------
 
   def test_unknown_event_type_does_not_crash
-    RelayMockTest.journal.push(bare_event_frame('nonsense.unknown', { 'foo' => 'bar' }))
+    @mock.push(bare_event_frame('nonsense.unknown', { 'foo' => 'bar' }))
     sleep 0.1
 
     assert_predicate @client, :_connected?, 'client should still be connected'
   end
 
   def test_event_with_bad_call_id_is_dropped
-    RelayMockTest.journal.push(bare_event_frame(
-                                 'calling.call.play',
-                                 { 'call_id' => 'no-such-call-bogus', 'control_id' => 'stranger',
-                                   'state' => 'playing' }
-                               ))
+    @mock.push(bare_event_frame(
+                 'calling.call.play',
+                 { 'call_id' => 'no-such-call-bogus', 'control_id' => 'stranger',
+                   'state' => 'playing' }
+               ))
     sleep 0.1
 
     assert_predicate @client, :_connected?
   end
 
   def test_event_with_empty_event_type_is_dropped
-    RelayMockTest.journal.push(bare_event_frame('', { 'call_id' => 'x' }))
+    @mock.push(bare_event_frame('', { 'call_id' => 'x' }))
     sleep 0.1
 
     assert_predicate @client, :_connected?
@@ -196,7 +203,7 @@ class RelayEventDispatchConcurrencyMockTest < Minitest::Test
   def test_event_ack_sent_back_to_server
     evt_id = 'evt-ack-test-1'
     params = { 'call_id' => 'anything', 'control_id' => 'x', 'state' => 'playing' }
-    RelayMockTest.journal.push(bare_event_frame('calling.call.play', params, id: evt_id))
+    @mock.push(bare_event_frame('calling.call.play', params, id: evt_id))
     sleep 0.3
 
     refute_empty(
@@ -214,7 +221,7 @@ class RelayEventDispatchConcurrencyMockTest < Minitest::Test
     call = @client.dial([[device]], tag: 'ec-tag-route', timeout: 5)
 
     assert_equal 'WINTAG', call.call_id
-    sends = RelayMockTest.journal.journal_send(event_type: 'calling.call.dial')
+    sends = @mock.journal_send(event_type: 'calling.call.dial')
 
     refute_empty sends, 'no calling.call.dial event in journal'
     inner = sends.last.frame['params']['params']
@@ -224,7 +231,7 @@ class RelayEventDispatchConcurrencyMockTest < Minitest::Test
   end
 
   def arm_tag_dial(tag, winner_call_id)
-    RelayMockTest.journal.arm_dial(
+    @mock.arm_dial(
       tag: tag, winner_call_id: winner_call_id, states: %w[created answered],
       node_id: 'n', device: { 'type' => 'phone', 'params' => {} }
     )
@@ -237,7 +244,7 @@ class RelayEventDispatchStateMockTest < Minitest::Test
 
   def test_server_ping_acked_by_sdk
     ping_id = 'ping-test-1'
-    RelayMockTest.journal.push(
+    @mock.push(
       { 'jsonrpc' => '2.0', 'id' => ping_id, 'method' => 'signalwire.ping', 'params' => {} }
     )
     sleep 0.3
@@ -250,10 +257,10 @@ class RelayEventDispatchStateMockTest < Minitest::Test
   # ---- Authorization state ---------------------------------------------
 
   def test_authorization_state_event_captured
-    RelayMockTest.journal.push(bare_event_frame(
-                                 'signalwire.authorization.state',
-                                 { 'authorization_state' => 'test-auth-state-blob' }
-                               ))
+    @mock.push(bare_event_frame(
+                 'signalwire.authorization.state',
+                 { 'authorization_state' => 'test-auth-state-blob' }
+               ))
     deadline = Time.now + 5
     sleep 0.02 until @client._authorization_state || Time.now > deadline
 
@@ -263,10 +270,10 @@ class RelayEventDispatchStateMockTest < Minitest::Test
   # ---- calling.error event ---------------------------------------------
 
   def test_calling_error_event_does_not_crash
-    RelayMockTest.journal.push(bare_event_frame(
-                                 'calling.error',
-                                 { 'code' => '5001', 'message' => 'synthetic error' }
-                               ))
+    @mock.push(bare_event_frame(
+                 'calling.error',
+                 { 'code' => '5001', 'message' => 'synthetic error' }
+               ))
     sleep 0.1
 
     assert_predicate @client, :_connected?
@@ -276,10 +283,10 @@ class RelayEventDispatchStateMockTest < Minitest::Test
 
   def test_call_state_event_updates_state
     call = answered_call('ec-stt')
-    RelayMockTest.journal.push(bare_event_frame(
-                                 'calling.call.state',
-                                 { 'call_id' => 'ec-stt', 'call_state' => 'ending', 'direction' => 'inbound' }
-                               ))
+    @mock.push(bare_event_frame(
+                 'calling.call.state',
+                 { 'call_id' => 'ec-stt', 'call_state' => 'ending', 'direction' => 'inbound' }
+               ))
     deadline = Time.now + 5
     sleep 0.02 until call.state == 'ending' || Time.now > deadline
 
@@ -291,7 +298,7 @@ class RelayEventDispatchStateMockTest < Minitest::Test
     fired_q = Queue.new
     call.on('calling.call.play') { |event| fired_q.push(event) }
     params = { 'call_id' => 'ec-list', 'control_id' => 'x', 'state' => 'playing' }
-    RelayMockTest.journal.push(bare_event_frame('calling.call.play', params))
+    @mock.push(bare_event_frame('calling.call.play', params))
     event = Timeout.timeout(2) { fired_q.pop }
 
     assert_equal 'calling.call.play', event.event_type

--- a/tests/relay/inbound_call_mock_test.rb
+++ b/tests/relay/inbound_call_mock_test.rb
@@ -20,15 +20,22 @@ module RelayInboundCallHelpers
   TIMEOUT = 5
   STATE_DEADLINE = 5
 
+  # Parallelize: each test's client owns a distinct server session + scoped
+  # harness, so inbound-call pushes target only that test's client.
+  def self.included(base)
+    base.parallelize_me!
+  end
+
   def setup
-    RelayMockTest.reset
+    # No global reset: @mock is scoped to this client's session and starts
+    # empty, so the shared mock stays parallel-safe.
     @handle = RelayMockTest.client
     @client = @handle[:client]
+    @mock   = @handle[:mock]
   end
 
   def teardown
     RelayMockTest.shutdown_client(@handle) if @handle
-    RelayMockTest.reset
   end
 
   # A signalwire.event JSON-RPC frame wrapping +event_type+ + inner params.
@@ -61,7 +68,7 @@ module RelayInboundCallHelpers
     mapper ||= ->(call) { call }
     queue = Queue.new
     @client.on_call { |call| queue.push(mapper.call(call)) }
-    RelayMockTest.journal.inbound_call(call_id: call_id, auto_states: ['created'], **)
+    @mock.inbound_call(call_id: call_id, auto_states: ['created'], **)
     Timeout.timeout(TIMEOUT) { queue.pop }
   end
 
@@ -73,7 +80,7 @@ module RelayInboundCallHelpers
 
   # Fire a bare inbound call (created state) without registering a handler.
   def fire_inbound(call_id)
-    RelayMockTest.journal.inbound_call(call_id: call_id, auto_states: ['created'])
+    @mock.inbound_call(call_id: call_id, auto_states: ['created'])
   end
 
   # Spin (briefly) until +block+ returns truthy or the deadline passes.
@@ -84,7 +91,7 @@ module RelayInboundCallHelpers
 
   # Assert a frame for +method+ was journalled and (optionally) carries call_id.
   def assert_journalled(method, call_id: nil)
-    frames = RelayMockTest.journal.journal_recv(method: method)
+    frames = @mock.journal_recv(method: method)
 
     refute_empty frames, "no #{method} frame in journal"
     last = frames.last.frame['params']
@@ -139,7 +146,7 @@ class RelayInboundCallMockTest < Minitest::Test
       c.answer
       c
     end
-    RelayMockTest.journal.push(state_push_frame('c-ans-state', 'answered'))
+    @mock.push(state_push_frame('c-ans-state', 'answered'))
     wait_until_state(call, 'answered')
 
     assert_equal 'answered', call.state
@@ -181,7 +188,7 @@ class RelayInboundCallMockTest < Minitest::Test
   def test_multiple_inbound_calls_no_state_bleed
     fetch = answer_two_inbound_calls('cb-1', 'cb-2')
 
-    RelayMockTest.journal.push(state_push_frame('cb-1', 'answered'))
+    @mock.push(state_push_frame('cb-1', 'answered'))
     wait_until { fetch.call('cb-1')&.state == 'answered' }
 
     assert_equal 'answered', fetch.call('cb-1').state
@@ -221,8 +228,8 @@ class RelayInboundCallMockTest < Minitest::Test
       c.answer
       c
     end
-    RelayMockTest.journal.push(state_push_frame('c-scripted', 'answered'))
-    RelayMockTest.journal.push(state_push_frame('c-scripted', 'ended'))
+    @mock.push(state_push_frame('c-scripted', 'answered'))
+    @mock.push(state_push_frame('c-scripted', 'ended'))
     wait_until_state(call, 'ended')
 
     assert_equal 'ended', call.state
@@ -248,7 +255,7 @@ class RelayInboundCallFlowMockTest < Minitest::Test
     # Drive a follow-up round-trip to prove the connection survived.
     fire_inbound('c-raise-2')
     sleep 0.2
-    sessions = RelayMockTest.journal.sessions
+    sessions = @mock.sessions
 
     assert_predicate sessions, :any?, 'WebSocket session should still be open after handler raise'
   end
@@ -270,7 +277,7 @@ class RelayInboundCallFlowMockTest < Minitest::Test
 
   def test_scenario_play_full_inbound_flow
     captured_q, started_q = register_capturing_answer_handler
-    result = RelayMockTest.journal.scenario_play(full_inbound_timeline)
+    result = @mock.scenario_play(full_inbound_timeline)
 
     assert_equal 'completed', result['status'], "scenario didn't complete: #{result.inspect}"
 
@@ -318,7 +325,7 @@ class RelayInboundCallFlowMockTest < Minitest::Test
 
   def test_inbound_call_journal_send_records_calling_call_receive
     receive_inbound(call_id: 'c-wire')
-    sends = RelayMockTest.journal.journal_send(event_type: 'calling.call.receive')
+    sends = @mock.journal_send(event_type: 'calling.call.receive')
 
     refute_empty sends, 'no calling.call.receive frame in journal'
     inner = sends.last.frame['params']['params']
@@ -332,10 +339,11 @@ class RelayInboundCallFlowMockTest < Minitest::Test
   def test_inbound_without_handler_does_not_crash
     # Use a fresh client so there's no registered handler from prior tests.
     h = RelayMockTest.client
+    hmock = h[:mock]
     begin
-      RelayMockTest.journal.inbound_call(call_id: 'c-nohandler', auto_states: ['created'])
+      hmock.inbound_call(call_id: 'c-nohandler', auto_states: ['created'])
       sleep 0.3
-      sessions = RelayMockTest.journal.sessions
+      sessions = hmock.sessions
 
       assert_predicate sessions, :any?, 'session should still be open without handler'
     ensure

--- a/tests/relay/messaging_mock_test.rb
+++ b/tests/relay/messaging_mock_test.rb
@@ -12,15 +12,19 @@ require_relative 'mock_test'
 
 # Shared fixture + send/event/assert helpers for the messaging mock tests.
 module RelayMessagingHelpers
+  # Parallelize: per-client session scoping isolates each test's journal/pushes.
+  def self.included(base)
+    base.parallelize_me!
+  end
+
   def setup
-    RelayMockTest.reset
     @handle = RelayMockTest.client
     @client = @handle[:client]
+    @mock   = @handle[:mock]
   end
 
   def teardown
     RelayMockTest.shutdown_client(@handle) if @handle
-    RelayMockTest.reset
   end
 
   # Send a message with the standard test numbers; +body+ defaults to 'hi'.
@@ -31,7 +35,7 @@ module RelayMessagingHelpers
 
   # The single messaging.send frame's params (asserts exactly one was sent).
   def sole_send_params
-    sends = RelayMockTest.journal.journal_recv(method: 'messaging.send')
+    sends = @mock.journal_recv(method: 'messaging.send')
 
     assert_equal 1, sends.size
     sends[0].frame['params']
@@ -39,12 +43,12 @@ module RelayMessagingHelpers
 
   # Push a signalwire.event frame with the given event_type + inner params.
   def push_event(event_type, params)
-    RelayMockTest.journal.push({
-                                 'jsonrpc' => '2.0',
-                                 'id' => SecureRandom.uuid,
-                                 'method' => 'signalwire.event',
-                                 'params' => { 'event_type' => event_type, 'params' => params }
-                               })
+    @mock.push({
+                 'jsonrpc' => '2.0',
+                 'id' => SecureRandom.uuid,
+                 'method' => 'signalwire.event',
+                 'params' => { 'event_type' => event_type, 'params' => params }
+               })
   end
 
   def push_message_state(message_id, state, extra: {})

--- a/tests/relay/mock_test.rb
+++ b/tests/relay/mock_test.rb
@@ -62,6 +62,25 @@ module RelayMockTest
   module HarnessTransport
     private
 
+    # "?session_id=<id>" suffix for control-plane calls when scoped, else "".
+    # Reads the host Harness's @session_id (this module is included into it).
+    def session_query
+      @session_id ? "?session_id=#{URI.encode_www_form_component(@session_id)}" : ''
+    end
+
+    # Stamp this session id onto a timeline op's push/expect_recv spec when the
+    # op doesn't already specify a session_id. Leaves sleep ops untouched.
+    def scope_op(timeline_op)
+      out = timeline_op.dup
+      %w[push expect_recv].each do |key|
+        spec = out[key]
+        next unless spec.is_a?(Hash) && !spec.key?('session_id')
+
+        out[key] = spec.merge('session_id' => @session_id)
+      end
+      out
+    end
+
     def build_entry(row)
       JournalEntry.new(
         timestamp: row['timestamp'],
@@ -133,11 +152,28 @@ module RelayMockTest
   class Harness
     attr_reader :http_url, :ws_port, :http_port, :host
 
+    # When set, journal reads, +reset+, scenario arming, pushes, inbound calls,
+    # and +scenario_play+ ops are scoped to this session id (the server-assigned
+    # +sessionid+ from the connect handshake), so a test only ever sees its own
+    # frames and never disturbs another test's. +RelayMockTest.client+ sets this
+    # automatically. +nil+ => global (legacy, single-threaded) view.
+    attr_accessor :session_id
+
     def initialize(host:, ws_port:, http_port:)
-      @host      = host
-      @ws_port   = ws_port
-      @http_port = http_port
-      @http_url  = "http://#{host}:#{http_port}"
+      @host       = host
+      @ws_port    = ws_port
+      @http_port  = http_port
+      @http_url   = "http://#{host}:#{http_port}"
+      @session_id = nil
+    end
+
+    # Return a view of this harness scoped to +sid+. Shares the same HTTP
+    # endpoint; only the session-scoping changes. Mirrors the TS
+    # +newRelayClient+ per-call +MockRelayHarness+ whose +sessionId+ is set.
+    def scoped(sid)
+      view = Harness.new(host: @host, ws_port: @ws_port, http_port: @http_port)
+      view.session_id = sid
+      view
     end
 
     # WebSocket URL the SDK should connect to.
@@ -162,9 +198,10 @@ module RelayMockTest
       entries.last
     end
 
-    # Returns every entry recorded since the last reset, in arrival order.
+    # Returns every entry recorded since the last reset, in arrival order
+    # (scoped to this harness's +session_id+ when set).
     def journal
-      raw = http_get('/__mock__/journal')
+      raw = http_get("/__mock__/journal#{session_query}")
       arr = JSON.parse(raw)
       arr.map { |e| build_entry(e) }
     end
@@ -190,29 +227,41 @@ module RelayMockTest
       end
     end
 
-    # Clears journal + scenarios on the mock server.
+    # Clears journal + scenarios for this session (both scoped when
+    # +session_id+ is set, global otherwise). Tests typically call this from
+    # setup.
     def reset
-      http_post('/__mock__/journal/reset')
-      http_post('/__mock__/scenarios/reset')
+      http_post("/__mock__/journal/reset#{session_query}")
+      http_post("/__mock__/scenarios/reset#{session_query}")
+    end
+
+    # Reset this session's armed scenario queues (or all when unscoped).
+    # Scenarios are session-scoped on the server, so a scoped harness clears
+    # only its own queue -- safe under parallel execution.
+    def reset_scenarios
+      http_post("/__mock__/scenarios/reset#{session_query}")
     end
 
     # ------------------------------------------------------------------
     # Scenario plumbing
     # ------------------------------------------------------------------
 
-    # Queue scripted post-RPC events for `method` (FIFO consume-once).
+    # Queue scripted post-RPC events for `method` (FIFO consume-once). Scoped
+    # to this harness's session when set, so a parallel test's matching RPC
+    # can't consume it.
     def arm_method(method, events)
       http_post(
-        "/__mock__/scenarios/#{method}",
+        "/__mock__/scenarios/#{method}#{session_query}",
         JSON.generate(events.is_a?(Array) ? events : [events])
       )
     end
 
     # Queue a dial-dance scenario (winner state events + final dial event).
     # kwargs: tag, winner_call_id, states, node_id, device, losers, delay_ms.
+    # Scoped to this harness's session when set.
     def arm_dial(**kwargs)
       http_post(
-        '/__mock__/scenarios/dial',
+        "/__mock__/scenarios/dial#{session_query}",
         JSON.generate(stringify_keys(kwargs))
       )
     end
@@ -221,15 +270,21 @@ module RelayMockTest
     # Server-initiated pushes
     # ------------------------------------------------------------------
 
-    # Push a single signalwire.event (or other) frame to the SDK.
+    # Push a single signalwire.event (or other) frame to the SDK. Targets this
+    # harness's session by default (so a parallel test's client never receives
+    # it); an explicit +session_id+ overrides, and an unscoped harness with no
+    # arg broadcasts (legacy single-threaded behavior).
     def push(frame, session_id: nil)
+      target = session_id || @session_id
       path = '/__mock__/push'
-      path += "?session_id=#{session_id}" if session_id
+      path += "?session_id=#{URI.encode_www_form_component(target)}" if target
       resp = http_post(path, JSON.generate('frame' => frame))
       JSON.parse(resp)
     end
 
-    # Inject an inbound call announcement into one or every session.
+    # Inject an inbound call announcement. Targets this harness's session by
+    # default so the inbound-call sequence is delivered only to this test's
+    # client; an explicit +session_id+ overrides (unscoped harness broadcasts).
     def inbound_call(call_id: nil, from_number: '+15551234567',
                      to_number: '+15559876543', context: 'default',
                      auto_states: nil, delay_ms: 50, session_id: nil)
@@ -237,14 +292,20 @@ module RelayMockTest
         'from_number' => from_number, 'to_number' => to_number, 'context' => context,
         'auto_states' => auto_states || ['created'], 'delay_ms' => delay_ms
       }
-      body['call_id']    = call_id    unless call_id.nil?
-      body['session_id'] = session_id unless session_id.nil?
+      body['call_id'] = call_id unless call_id.nil?
+      sid = session_id || @session_id
+      body['session_id'] = sid unless sid.nil?
       JSON.parse(http_post('/__mock__/inbound_call', JSON.generate(body)))
     end
 
     # Run a scripted timeline of pushes/sleeps/expect_recv on the server.
+    # When scoped, each +push+/+expect_recv+ op is stamped with this session id
+    # (unless it already carries one), so the timeline targets only this test's
+    # client and +expect_recv+ matches only this session's frames -- making it
+    # parallel-safe.
     def scenario_play(ops)
-      resp = http_post('/__mock__/scenario_play', JSON.generate(ops),
+      scoped = @session_id ? ops.map { |op| scope_op(op) } : ops
+      resp = http_post('/__mock__/scenario_play', JSON.generate(scoped),
                        read_timeout: 30)
       JSON.parse(resp)
     end
@@ -410,8 +471,13 @@ module RelayMockTest
   # Spawn a real RelayClient connected to the mock-relay server.
   #
   # Returns a Hash with:
-  #   :client    -- the connected SignalWire::Relay::Client
+  #   :client     -- the connected SignalWire::Relay::Client
   #   :run_thread -- the background Thread running client.run
+  #   :mock       -- a Harness view scoped to THIS client's session id, so the
+  #                  test's journal reads/resets/scenarios/pushes see only its
+  #                  own frames -- making the shared mock safe under parallel
+  #                  (parallelized) test execution. No global reset is needed:
+  #                  a brand-new session starts with an empty (scoped) journal.
   #
   # The caller MUST eventually call RelayMockTest.shutdown_client(...) to stop
   # the run loop and join the thread.
@@ -424,13 +490,15 @@ module RelayMockTest
              contexts: ['default'], resume_protocol: nil)
     h = harness
     sdk_client = build_sdk_client(h, project, token, jwt_token, contexts)
-    pre_run_connects = h.journal_recv(method: 'signalwire.connect').size
     sdk_client._set_protocol(resume_protocol) if resume_protocol
 
     run_thread = spawn_run_thread(sdk_client)
-    await_authenticated(h, sdk_client, run_thread, pre_run_connects)
+    await_authenticated(sdk_client, run_thread)
 
-    { client: sdk_client, run_thread: run_thread }
+    # Scope a per-client harness to the session id the server assigned on the
+    # connect handshake (mirrors the TS newRelayClient's per-call harness).
+    mock = h.scoped(sdk_client._session_id)
+    { client: sdk_client, run_thread: run_thread, mock: mock }
   end
 
   # Force the SDK to dial ws://host:ws_port (not wss://{space}) and build it.
@@ -451,21 +519,23 @@ module RelayMockTest
     end
   end
 
-  # Wait for the SDK's signalwire.connect to land in the journal AND for
-  # client.protocol to be set; raise (after cleanup) if it never authenticates.
-  def await_authenticated(harness, sdk_client, run_thread, pre_run_connects)
+  # Wait for the connect handshake to complete -- the SDK captures both its
+  # protocol string AND the server-assigned session id from the same
+  # ConnectResult, so both being set proves the round-trip landed. Reading the
+  # client's own state (rather than counting frames in the SHARED journal)
+  # keeps readiness race-free under parallel execution.
+  def await_authenticated(sdk_client, run_thread)
     deadline = Time.now + 10
-    sleep 0.05 until authenticated?(harness, sdk_client, pre_run_connects) || Time.now > deadline
-    return if authenticated?(harness, sdk_client, pre_run_connects)
+    sleep 0.05 until authenticated?(sdk_client) || Time.now > deadline
+    return if authenticated?(sdk_client)
 
     sdk_client.stop
     run_thread.kill
     raise 'mocktest: client did not authenticate within 10s'
   end
 
-  def authenticated?(harness, sdk_client, pre_run_connects)
-    sdk_client.protocol &&
-      harness.journal_recv(method: 'signalwire.connect').size > pre_run_connects
+  def authenticated?(sdk_client)
+    !sdk_client.protocol.nil? && !sdk_client._session_id.nil?
   end
 
   # Cleanly stop a client started by RelayMockTest.client.

--- a/tests/relay/outbound_call_mock_test.rb
+++ b/tests/relay/outbound_call_mock_test.rb
@@ -17,15 +17,19 @@ require_relative 'mock_test'
 
 # Shared fixture + dial/journal helpers for the outbound-call (dial) tests.
 module RelayOutboundCallHelpers
+  # Parallelize: per-client session scoping isolates each test's dial scenarios.
+  def self.included(base)
+    base.parallelize_me!
+  end
+
   def setup
-    RelayMockTest.reset
     @handle = RelayMockTest.client
     @client = @handle[:client]
+    @mock   = @handle[:mock]
   end
 
   def teardown
     RelayMockTest.shutdown_client(@handle) if @handle
-    RelayMockTest.reset
   end
 
   def phone_device(to: '+15551112222', frm: '+15553334444')
@@ -36,14 +40,14 @@ module RelayOutboundCallHelpers
   # +arm:+ extra arm_dial kwargs (states/losers/delay_ms/...); +dial:+ extra
   # dial kwargs (max_duration/...); +devices:+ the device matrix to dial.
   def arm_and_dial(tag:, winner:, states: %w[created answered], arm: {}, dial: {}, devices: nil)
-    RelayMockTest.journal.arm_dial(tag: tag, winner_call_id: winner, states: states,
-                                   node_id: 'node-mock-1', device: phone_device, **arm)
+    @mock.arm_dial(tag: tag, winner_call_id: winner, states: states,
+                   node_id: 'node-mock-1', device: phone_device, **arm)
     @client.dial(devices || [[phone_device]], tag: tag, timeout: 5, **dial)
   end
 
   # The single calling.dial frame's params (asserts exactly one was sent).
   def sole_dial_params
-    dials = RelayMockTest.journal.journal_recv(method: 'calling.dial')
+    dials = @mock.journal_recv(method: 'calling.dial')
 
     assert_equal 1, dials.size
     dials[0].frame['params']
@@ -117,13 +121,13 @@ class RelayOutboundCallMockTest < Minitest::Test
 
     winner = { 'call_id' => 'auto-tag-winner', 'node_id' => 'node-mock-1', 'tag' => tag,
                'device' => phone_device, 'dial_winner' => true }
-    RelayMockTest.journal.push(call_dial_event(tag, 'answered', winner))
+    @mock.push(call_dial_event(tag, 'answered', winner))
   end
 
   # Poll for the calling.dial frame; return its tag (or nil after ~2s).
   def wait_for_dial_tag
     40.times do
-      entries = RelayMockTest.journal.journal_recv(method: 'calling.dial')
+      entries = @mock.journal_recv(method: 'calling.dial')
       return entries.last.frame['params']['tag'] unless entries.empty?
 
       sleep 0.05
@@ -136,7 +140,7 @@ class RelayOutboundCallMockTest < Minitest::Test
   def test_dial_failed_raises_relay_error
     pusher = Thread.new do
       wait_for_dial_tag
-      RelayMockTest.journal.push(call_dial_event('t-fail', 'failed', {}))
+      @mock.push(call_dial_event('t-fail', 'failed', {}))
     end
     err = assert_raises(SignalWire::Relay::RelayError) do
       @client.dial([[phone_device]], tag: 't-fail', timeout: 5)
@@ -178,7 +182,7 @@ class RelayOutboundCallWireMockTest < Minitest::Test
 
   # The single answered calling.call.dial event's inner params.
   def sole_answered_dial_event
-    sends = RelayMockTest.journal.journal_send(event_type: 'calling.call.dial')
+    sends = @mock.journal_send(event_type: 'calling.call.dial')
 
     refute_empty sends, 'no calling.call.dial event was pushed'
     finals = sends.select do |e|
@@ -210,9 +214,9 @@ class RelayOutboundCallWireMockTest < Minitest::Test
 
   # The pushed calling.call.state events' inner params for +call_id+.
   def sent_call_states(call_id)
-    RelayMockTest.journal.journal_send(event_type: 'calling.call.state')
-                 .map { |e| e.frame['params']['params'] }
-                 .select { |p| p['call_id'] == call_id }
+    @mock.journal_send(event_type: 'calling.call.state')
+         .map { |e| e.frame['params']['params'] }
+         .select { |p| p['call_id'] == call_id }
   end
 
   # ---- Devices shape on the wire ---------------------------------------
@@ -251,7 +255,7 @@ class RelayOutboundCallWireMockTest < Minitest::Test
   def test_dialed_call_can_send_subsequent_command
     call = arm_and_dial(tag: 't-after', winner: 'WIN-AFTER')
     call.hangup
-    end_frames = RelayMockTest.journal.journal_recv(method: 'calling.end')
+    end_frames = @mock.journal_recv(method: 'calling.end')
 
     refute_empty end_frames, 'no calling.end frame in journal'
     assert_equal 'WIN-AFTER', end_frames.last.frame['params']['call_id']
@@ -260,7 +264,7 @@ class RelayOutboundCallWireMockTest < Minitest::Test
   def test_dialed_call_can_play
     call = arm_and_dial(tag: 't-play', winner: 'WIN-PLAY')
     call.play([{ 'type' => 'tts', 'params' => { 'text' => 'hi' } }])
-    play_frames = RelayMockTest.journal.journal_recv(method: 'calling.play')
+    play_frames = @mock.journal_recv(method: 'calling.play')
 
     refute_empty play_frames, 'no calling.play frame after dial'
     p = play_frames.last.frame['params']
@@ -281,7 +285,7 @@ class RelayOutboundCallWireMockTest < Minitest::Test
 
   def test_dial_frame_uses_jsonrpc_envelope
     arm_and_dial(tag: 't-rpc', winner: 'W')
-    dials = RelayMockTest.journal.journal_recv(method: 'calling.dial')
+    dials = @mock.journal_recv(method: 'calling.dial')
 
     assert_equal 1, dials.size
     f = dials[0].frame

--- a/tests/relay/tier3_typed_objects_test.rb
+++ b/tests/relay/tier3_typed_objects_test.rb
@@ -32,15 +32,21 @@ require_relative 'mock_test'
 module RelayTier3Helpers
   R = SignalWire::Relay
 
+  # Parallelize: per-client session scoping isolates each test's dial journals.
+  def self.included(base)
+    base.parallelize_me!
+  end
+
   def setup
-    RelayMockTest.reset
+    # No global reset: @mock is scoped to this client's session and starts
+    # empty, keeping the shared mock parallel-safe.
     @handle = RelayMockTest.client
     @client = @handle[:client]
+    @mock   = @handle[:mock]
   end
 
   def teardown
     RelayMockTest.shutdown_client(@handle) if @handle
-    RelayMockTest.reset
   end
 
   # The hand-written phone device literal the existing suite uses verbatim.
@@ -49,8 +55,8 @@ module RelayTier3Helpers
   end
 
   def dial_call(tag:, call_id:, devices:, states: %w[created answered])
-    RelayMockTest.journal.arm_dial(tag: tag, winner_call_id: call_id, states: states,
-                                   node_id: 'node-mock-1', device: phone_device_hash)
+    @mock.arm_dial(tag: tag, winner_call_id: call_id, states: states,
+                   node_id: 'node-mock-1', device: phone_device_hash)
     call = @client.dial(devices, tag: tag, timeout: 5)
 
     assert_kind_of R::Call, call
@@ -59,7 +65,7 @@ module RelayTier3Helpers
   end
 
   def last_params(method)
-    frames = RelayMockTest.journal.journal_recv(method: method)
+    frames = @mock.journal_recv(method: method)
 
     refute_empty frames, "no #{method} frame in journal"
     frames.last.frame['params']
@@ -155,7 +161,7 @@ class RelayTier3DeviceTest < Minitest::Test
     dial_call(tag: 't-raw', call_id: 'W-RAW', devices: [[phone_device_hash]])
     raw_frame = last_params('calling.dial')['devices']
 
-    RelayMockTest.reset
+    @mock.reset
     # Typed-Device dial (same data).
     dev = R::Device.phone(to: '+15551112222', from: '+15553334444')
     dial_call(tag: 't-typed', call_id: 'W-TYP', devices: [[dev.to_h]])
@@ -427,7 +433,7 @@ class RelayTier3StateEnumsTest < Minitest::Test
   # classifies as terminal.
   def test_dial_state_terminal_over_real_dispatched_dial_event
     dial_call(tag: 't-ds', call_id: 'WIN-DS', devices: [[phone_device_hash]])
-    sends = RelayMockTest.journal.journal_send(event_type: 'calling.call.dial')
+    sends = @mock.journal_send(event_type: 'calling.call.dial')
 
     refute_empty sends, 'mock did not push a calling.call.dial event'
     final = sends.map { |e| (e.frame['params'] || {})['params'] }

--- a/tests/rest/calling_mock_test.rb
+++ b/tests/rest/calling_mock_test.rb
@@ -8,7 +8,7 @@
 #
 # 1. Calls the SDK method (no transport patching).
 # 2. Asserts on the response body shape that the mock returns from the spec.
-# 3. Asserts on MockTest.journal.last so we know the SDK sent the right
+# 3. Asserts on @mock.last so we know the SDK sent the right
 #    wire request — method, path, command field, and (where applicable)
 #    the id and any keyword params.
 
@@ -19,15 +19,19 @@ require_relative 'mock_test'
 # The suite is split into topic classes so no single class grows unbounded;
 # they all mix in this module.
 module CallingMockHelpers
+  # Parallelize: each test's client uses a unique project + auth-scoped harness,
+  # so the shared mock is concurrency-safe. Parallelism stress-proves isolation.
+  def self.included(base)
+    base.parallelize_me!
+  end
+
   CALLS_PATH = '/api/calling/calls'
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
-  end
-
-  def teardown
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
   # Assert the common calling-command journal shape and return the entry.
@@ -40,7 +44,7 @@ module CallingMockHelpers
     assert_kind_of Hash, body
     assert body.key?('id')
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_command_envelope(last, command, id)
     params.each { |k, v| assert_equal v, last.body['params'][k], "params[#{k.inspect}]" }

--- a/tests/rest/compat_accounts_mock_test.rb
+++ b/tests/rest/compat_accounts_mock_test.rb
@@ -11,15 +11,16 @@ require 'minitest/autorun'
 require_relative 'mock_test'
 
 class CompatAccountsMockTest < Minitest::Test
+  # Parallelize: per-client unique-project + auth-scoped harness isolates each test.
+  parallelize_me!
+
   ACCOUNTS_BASE = '/api/laml/2010-04-01/Accounts'
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
-  end
-
-  def teardown
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
   # Assert a journaled response carried a 2xx/3xx status.
@@ -48,7 +49,7 @@ class CompatAccountsMockTest < Minitest::Test
 
   def test_create_journal_records_post_to_accounts
     @client.compat.accounts.create(FriendlyName: 'Sub-B')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'POST', j.method
     # Accounts.create lives at the top-level Accounts collection - no
@@ -71,7 +72,7 @@ class CompatAccountsMockTest < Minitest::Test
 
   def test_get_journal_records_get_with_sid
     @client.compat.accounts.get('AC_SAMPLE_SID')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
     assert_equal "#{ACCOUNTS_BASE}/AC_SAMPLE_SID", j.path
@@ -90,7 +91,7 @@ class CompatAccountsMockTest < Minitest::Test
 
   def test_update_journal_records_post_to_account_path
     @client.compat.accounts.update('AC_X', FriendlyName: 'NewName')
-    j = MockTest.journal.last
+    j = @mock.last
     # Twilio-compat update is POST (not PATCH/PUT).
     assert_equal 'POST', j.method
     assert_equal "#{ACCOUNTS_BASE}/AC_X", j.path

--- a/tests/rest/compat_calls_streams_mock_test.rb
+++ b/tests/rest/compat_calls_streams_mock_test.rb
@@ -10,13 +10,14 @@ require 'minitest/autorun'
 require_relative 'mock_test'
 
 class CompatCallsStreamsMockTest < Minitest::Test
-  def setup
-    @client = MockTest.client
-    MockTest.reset
-  end
+  # Parallelize: per-client unique-project + auth-scoped harness isolates each test.
+  parallelize_me!
 
-  def teardown
-    MockTest.reset
+  def setup
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
   # ---- start_stream → POST /Calls/{sid}/Streams --------------------------
@@ -35,11 +36,11 @@ class CompatCallsStreamsMockTest < Minitest::Test
 
   def test_start_stream_journal_records_post_to_streams_collection
     @client.compat.calls.start_stream('CA_JX1', Url: 'wss://a.b/s', Name: 'strm-x')
-    j = MockTest.journal.last
+    j = @mock.last
     body = j.body
 
     assert_equal 'POST', j.method
-    assert_equal '/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_JX1/Streams', j.path
+    assert_equal "/api/laml/2010-04-01/Accounts/#{@project}/Calls/CA_JX1/Streams", j.path
     assert_kind_of Hash, body
     assert_equal 'wss://a.b/s', body['Url']
     assert_equal 'strm-x', body['Name']
@@ -61,10 +62,10 @@ class CompatCallsStreamsMockTest < Minitest::Test
     @client.compat.calls.stop_stream(
       'CA_S1', 'ST_S1', Status: 'stopped'
     )
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'POST', j.method
-    assert_equal '/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_S1/Streams/ST_S1', j.path
+    assert_equal "/api/laml/2010-04-01/Accounts/#{@project}/Calls/CA_S1/Streams/ST_S1", j.path
     assert_kind_of Hash, j.body
     assert_equal 'stopped', j.body['Status']
   end
@@ -85,10 +86,10 @@ class CompatCallsStreamsMockTest < Minitest::Test
     @client.compat.calls.update_recording(
       'CA_R1', 'RE_R1', Status: 'paused'
     )
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'POST', j.method
-    assert_equal '/api/laml/2010-04-01/Accounts/test_proj/Calls/CA_R1/Recordings/RE_R1', j.path
+    assert_equal "/api/laml/2010-04-01/Accounts/#{@project}/Calls/CA_R1/Recordings/RE_R1", j.path
     assert_kind_of Hash, j.body
     assert_equal 'paused', j.body['Status']
   end

--- a/tests/rest/compat_conferences_mock_test.rb
+++ b/tests/rest/compat_conferences_mock_test.rb
@@ -11,16 +11,25 @@ require_relative 'mock_test'
 
 # Shared mock lifecycle, base paths, and POST-body assertion helper.
 module CompatConferencesSupport
-  ACCOUNT_BASE = '/api/laml/2010-04-01/Accounts/test_proj'
-  CONF_BASE    = "#{ACCOUNT_BASE}/Conferences".freeze
-
-  def setup
-    @client = MockTest.client
-    MockTest.reset
+  # Parallelize: each test's client uses a unique project + auth-scoped harness,
+  # so the shared mock is concurrency-safe. Parallelism stress-proves isolation.
+  def self.included(base)
+    base.parallelize_me!
   end
 
-  def teardown
-    MockTest.reset
+  def setup
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
+  end
+
+  def account_base
+    "/api/laml/2010-04-01/Accounts/#{@project}"
+  end
+
+  def conf_base
+    "#{account_base}/Conferences"
   end
 
   # Assert the last journaled request was a POST to +path+ with a Hash body,
@@ -51,10 +60,10 @@ class CompatConferencesMockTest < Minitest::Test
 
   def test_list_journal_records_get_to_conferences
     @client.compat.conferences.list
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal CONF_BASE, j.path
+    assert_equal conf_base, j.path
     refute_nil j.matched_route, 'spec gap: conferences.list'
   end
 
@@ -68,10 +77,10 @@ class CompatConferencesMockTest < Minitest::Test
 
   def test_get_journal_records_get_with_sid
     @client.compat.conferences.get('CF_GETSID')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{CONF_BASE}/CF_GETSID", j.path
+    assert_equal "#{conf_base}/CF_GETSID", j.path
   end
 
   def test_update_returns_updated_conference
@@ -85,7 +94,7 @@ class CompatConferencesMockTest < Minitest::Test
     @client.compat.conferences.update(
       'CF_UPD', Status: 'completed', AnnounceUrl: 'https://a.b'
     )
-    body = assert_post_with_body(MockTest.journal.last, "#{CONF_BASE}/CF_UPD")
+    body = assert_post_with_body(@mock.last, "#{conf_base}/CF_UPD")
 
     assert_equal 'completed', body['Status']
     assert_equal 'https://a.b', body['AnnounceUrl']
@@ -103,10 +112,10 @@ class CompatConferencesMockTest < Minitest::Test
 
   def test_get_participant_journal_records_get
     @client.compat.conferences.get_participant('CF_GP', 'CA_GP')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{CONF_BASE}/CF_GP/Participants/CA_GP", j.path
+    assert_equal "#{conf_base}/CF_GP/Participants/CA_GP", j.path
   end
 
   def test_update_participant_returns_participant_resource
@@ -120,7 +129,7 @@ class CompatConferencesMockTest < Minitest::Test
     @client.compat.conferences.update_participant(
       'CF_M', 'CA_M', Muted: true, Hold: false
     )
-    body = assert_post_with_body(MockTest.journal.last, "#{CONF_BASE}/CF_M/Participants/CA_M")
+    body = assert_post_with_body(@mock.last, "#{conf_base}/CF_M/Participants/CA_M")
 
     assert body['Muted']
     refute body['Hold']
@@ -137,10 +146,10 @@ class CompatConferencesMockTest < Minitest::Test
 
   def test_remove_participant_journal_records_delete
     @client.compat.conferences.remove_participant('CF_RM', 'CA_RM')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'DELETE', j.method
-    assert_equal "#{CONF_BASE}/CF_RM/Participants/CA_RM", j.path
+    assert_equal "#{conf_base}/CF_RM/Participants/CA_RM", j.path
   end
 end
 
@@ -161,10 +170,10 @@ class CompatConferencesMediaMockTest < Minitest::Test
 
   def test_list_recordings_journal_records_get
     @client.compat.conferences.list_recordings('CF_LRX')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{CONF_BASE}/CF_LRX/Recordings", j.path
+    assert_equal "#{conf_base}/CF_LRX/Recordings", j.path
   end
 
   def test_get_recording_returns_recording_resource
@@ -177,10 +186,10 @@ class CompatConferencesMediaMockTest < Minitest::Test
 
   def test_get_recording_journal_records_get
     @client.compat.conferences.get_recording('CF_GRX', 'RE_GRX')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{CONF_BASE}/CF_GRX/Recordings/RE_GRX", j.path
+    assert_equal "#{conf_base}/CF_GRX/Recordings/RE_GRX", j.path
   end
 
   def test_update_recording_returns_recording_resource
@@ -192,10 +201,10 @@ class CompatConferencesMediaMockTest < Minitest::Test
 
   def test_update_recording_journal_records_post_with_status
     @client.compat.conferences.update_recording('CF_UR', 'RE_UR', Status: 'paused')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'POST', j.method
-    assert_equal "#{CONF_BASE}/CF_UR/Recordings/RE_UR", j.path
+    assert_equal "#{conf_base}/CF_UR/Recordings/RE_UR", j.path
     assert_kind_of Hash, j.body
     assert_equal 'paused', j.body['Status']
   end
@@ -208,10 +217,10 @@ class CompatConferencesMediaMockTest < Minitest::Test
 
   def test_delete_recording_journal_records_delete
     @client.compat.conferences.delete_recording('CF_DRX', 'RE_DRX')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'DELETE', j.method
-    assert_equal "#{CONF_BASE}/CF_DRX/Recordings/RE_DRX", j.path
+    assert_equal "#{conf_base}/CF_DRX/Recordings/RE_DRX", j.path
   end
 
   # ---- Streams --------------------------------------------------------
@@ -227,10 +236,10 @@ class CompatConferencesMediaMockTest < Minitest::Test
     @client.compat.conferences.start_stream(
       'CF_SSX', Url: 'wss://a.b/s', Name: 'strm'
     )
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'POST', j.method
-    assert_equal "#{CONF_BASE}/CF_SSX/Streams", j.path
+    assert_equal "#{conf_base}/CF_SSX/Streams", j.path
     assert_kind_of Hash, j.body
     assert_equal 'wss://a.b/s', j.body['Url']
   end
@@ -248,10 +257,10 @@ class CompatConferencesMediaMockTest < Minitest::Test
     @client.compat.conferences.stop_stream(
       'CF_TSX', 'ST_TSX', Status: 'stopped'
     )
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'POST', j.method
-    assert_equal "#{CONF_BASE}/CF_TSX/Streams/ST_TSX", j.path
+    assert_equal "#{conf_base}/CF_TSX/Streams/ST_TSX", j.path
     assert_kind_of Hash, j.body
     assert_equal 'stopped', j.body['Status']
   end

--- a/tests/rest/compat_messages_faxes_mock_test.rb
+++ b/tests/rest/compat_messages_faxes_mock_test.rb
@@ -12,13 +12,14 @@ require 'minitest/autorun'
 require_relative 'mock_test'
 
 class CompatMessagesFaxesMockTest < Minitest::Test
-  def setup
-    @client = MockTest.client
-    MockTest.reset
-  end
+  # Parallelize: per-client unique-project + auth-scoped harness isolates each test.
+  parallelize_me!
 
-  def teardown
-    MockTest.reset
+  def setup
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
   # ---- Messages.update --------------------------------------------------
@@ -33,9 +34,9 @@ class CompatMessagesFaxesMockTest < Minitest::Test
 
   def test_messages_update_journal_records_post_to_message
     @client.compat.messages.update('MM_U1', Body: 'x', Status: 'canceled')
-    j = MockTest.journal.last
+    j = @mock.last
 
-    assert_journal_request(j, 'POST', '/api/laml/2010-04-01/Accounts/test_proj/Messages/MM_U1')
+    assert_journal_request(j, 'POST', "/api/laml/2010-04-01/Accounts/#{@project}/Messages/MM_U1")
     assert_equal 'x', j.body['Body']
     assert_equal 'canceled', j.body['Status']
   end
@@ -52,10 +53,10 @@ class CompatMessagesFaxesMockTest < Minitest::Test
 
   def test_messages_get_media_journal_records_get_to_media_path
     @client.compat.messages.get_media('MM_X', 'ME_X')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal '/api/laml/2010-04-01/Accounts/test_proj/Messages/MM_X/Media/ME_X', j.path
+    assert_equal "/api/laml/2010-04-01/Accounts/#{@project}/Messages/MM_X/Media/ME_X", j.path
   end
 
   # ---- Messages.delete_media -------------------------------------------
@@ -69,10 +70,10 @@ class CompatMessagesFaxesMockTest < Minitest::Test
 
   def test_messages_delete_media_journal_records_delete
     @client.compat.messages.delete_media('MM_D', 'ME_D')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'DELETE', j.method
-    assert_equal '/api/laml/2010-04-01/Accounts/test_proj/Messages/MM_D/Media/ME_D', j.path
+    assert_equal "/api/laml/2010-04-01/Accounts/#{@project}/Messages/MM_D/Media/ME_D", j.path
   end
 
   # ---- Faxes.update -----------------------------------------------------
@@ -87,10 +88,10 @@ class CompatMessagesFaxesMockTest < Minitest::Test
 
   def test_faxes_update_journal_records_post_with_status
     @client.compat.faxes.update('FX_U2', Status: 'canceled')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'POST', j.method
-    assert_equal '/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_U2', j.path
+    assert_equal "/api/laml/2010-04-01/Accounts/#{@project}/Faxes/FX_U2", j.path
     assert_kind_of Hash, j.body
     assert_equal 'canceled', j.body['Status']
   end
@@ -107,10 +108,10 @@ class CompatMessagesFaxesMockTest < Minitest::Test
 
   def test_faxes_list_media_journal_records_get_to_fax_media
     @client.compat.faxes.list_media('FX_LM_X')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal '/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_LM_X/Media', j.path
+    assert_equal "/api/laml/2010-04-01/Accounts/#{@project}/Faxes/FX_LM_X/Media", j.path
   end
 
   # ---- Faxes.get_media --------------------------------------------------
@@ -125,10 +126,10 @@ class CompatMessagesFaxesMockTest < Minitest::Test
 
   def test_faxes_get_media_journal_records_get_to_specific_media
     @client.compat.faxes.get_media('FX_G', 'ME_G')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal '/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_G/Media/ME_G', j.path
+    assert_equal "/api/laml/2010-04-01/Accounts/#{@project}/Faxes/FX_G/Media/ME_G", j.path
   end
 
   # ---- Faxes.delete_media ----------------------------------------------
@@ -141,10 +142,10 @@ class CompatMessagesFaxesMockTest < Minitest::Test
 
   def test_faxes_delete_media_journal_records_delete
     @client.compat.faxes.delete_media('FX_D', 'ME_D')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'DELETE', j.method
-    assert_equal '/api/laml/2010-04-01/Accounts/test_proj/Faxes/FX_D/Media/ME_D', j.path
+    assert_equal "/api/laml/2010-04-01/Accounts/#{@project}/Faxes/FX_D/Media/ME_D", j.path
   end
 
   private

--- a/tests/rest/compat_misc_mock_test.rb
+++ b/tests/rest/compat_misc_mock_test.rb
@@ -12,15 +12,18 @@ require 'minitest/autorun'
 require_relative 'mock_test'
 
 class CompatMiscMockTest < Minitest::Test
-  ACCOUNT_BASE = '/api/laml/2010-04-01/Accounts/test_proj'
+  # Parallelize: per-client unique-project + auth-scoped harness isolates each test.
+  parallelize_me!
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
-  def teardown
-    MockTest.reset
+  def account_base
+    "/api/laml/2010-04-01/Accounts/#{@project}"
   end
 
   # ---- Applications.update --------------------------------------------
@@ -37,11 +40,11 @@ class CompatMiscMockTest < Minitest::Test
     @client.compat.applications.update(
       'AP_UU', FriendlyName: 'renamed', VoiceUrl: 'https://a.b/v'
     )
-    j = MockTest.journal.last
+    j = @mock.last
     body = j.body
 
     assert_equal 'POST', j.method
-    assert_equal "#{ACCOUNT_BASE}/Applications/AP_UU", j.path
+    assert_equal "#{account_base}/Applications/AP_UU", j.path
     assert_kind_of Hash, body
     assert_equal 'renamed', body['FriendlyName']
     assert_equal 'https://a.b/v', body['VoiceUrl']
@@ -61,11 +64,11 @@ class CompatMiscMockTest < Minitest::Test
     @client.compat.laml_bins.update(
       'LB_UU', FriendlyName: 'renamed', Contents: '<Response/>'
     )
-    j = MockTest.journal.last
+    j = @mock.last
     body = j.body
 
     assert_equal 'POST', j.method
-    assert_equal "#{ACCOUNT_BASE}/LamlBins/LB_UU", j.path
+    assert_equal "#{account_base}/LamlBins/LB_UU", j.path
     assert_kind_of Hash, body
     assert_equal 'renamed', body['FriendlyName']
     assert_equal '<Response/>', body['Contents']

--- a/tests/rest/compat_phone_numbers_mock_test.rb
+++ b/tests/rest/compat_phone_numbers_mock_test.rb
@@ -13,15 +13,18 @@ require 'minitest/autorun'
 require_relative 'mock_test'
 
 class CompatPhoneNumbersMockTest < Minitest::Test
-  ACCOUNT_BASE = '/api/laml/2010-04-01/Accounts/test_proj'
+  # Parallelize: per-client unique-project + auth-scoped harness isolates each test.
+  parallelize_me!
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
-  def teardown
-    MockTest.reset
+  def account_base
+    "/api/laml/2010-04-01/Accounts/#{@project}"
   end
 
   # ---- list -------------------------------------------------------------
@@ -37,10 +40,10 @@ class CompatPhoneNumbersMockTest < Minitest::Test
 
   def test_list_journal_records_get_to_incoming_phone_numbers
     @client.compat.phone_numbers.list
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{ACCOUNT_BASE}/IncomingPhoneNumbers", j.path
+    assert_equal "#{account_base}/IncomingPhoneNumbers", j.path
   end
 
   # ---- get --------------------------------------------------------------
@@ -55,10 +58,10 @@ class CompatPhoneNumbersMockTest < Minitest::Test
 
   def test_get_journal_records_get_with_sid
     @client.compat.phone_numbers.get('PN_GET')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{ACCOUNT_BASE}/IncomingPhoneNumbers/PN_GET", j.path
+    assert_equal "#{account_base}/IncomingPhoneNumbers/PN_GET", j.path
   end
 
   # ---- update -----------------------------------------------------------
@@ -73,11 +76,11 @@ class CompatPhoneNumbersMockTest < Minitest::Test
 
   def test_update_journal_records_post_with_friendly_name
     @client.compat.phone_numbers.update('PN_UU', FriendlyName: 'updated', VoiceUrl: 'https://a.b/v')
-    j = MockTest.journal.last
+    j = @mock.last
     body = j.body
 
     assert_equal 'POST', j.method
-    assert_equal "#{ACCOUNT_BASE}/IncomingPhoneNumbers/PN_UU", j.path
+    assert_equal "#{account_base}/IncomingPhoneNumbers/PN_UU", j.path
     assert_kind_of Hash, body
     assert_equal 'updated', body['FriendlyName']
     assert_equal 'https://a.b/v', body['VoiceUrl']
@@ -93,24 +96,27 @@ class CompatPhoneNumbersMockTest < Minitest::Test
 
   def test_delete_journal_records_delete_at_phone_number_path
     @client.compat.phone_numbers.delete('PN_DEL')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'DELETE', j.method
-    assert_equal "#{ACCOUNT_BASE}/IncomingPhoneNumbers/PN_DEL", j.path
+    assert_equal "#{account_base}/IncomingPhoneNumbers/PN_DEL", j.path
   end
 end
 
 # Provisioning + availability: purchase / import_number / countries / toll-free.
 class CompatPhoneNumbersProvisioningMockTest < Minitest::Test
-  ACCOUNT_BASE = '/api/laml/2010-04-01/Accounts/test_proj'
+  # Parallelize: per-client unique-project + auth-scoped harness isolates each test.
+  parallelize_me!
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
-  def teardown
-    MockTest.reset
+  def account_base
+    "/api/laml/2010-04-01/Accounts/#{@project}"
   end
 
   # ---- purchase (POST /IncomingPhoneNumbers) ---------------------------
@@ -125,11 +131,11 @@ class CompatPhoneNumbersProvisioningMockTest < Minitest::Test
 
   def test_purchase_journal_records_post_with_phone_number
     @client.compat.phone_numbers.purchase(PhoneNumber: '+15555550100', FriendlyName: 'Main')
-    j = MockTest.journal.last
+    j = @mock.last
     body = j.body
 
     assert_equal 'POST', j.method
-    assert_equal "#{ACCOUNT_BASE}/IncomingPhoneNumbers", j.path
+    assert_equal "#{account_base}/IncomingPhoneNumbers", j.path
     assert_kind_of Hash, body
     assert_equal '+15555550100', body['PhoneNumber']
     assert_equal 'Main', body['FriendlyName']
@@ -149,11 +155,11 @@ class CompatPhoneNumbersProvisioningMockTest < Minitest::Test
     @client.compat.phone_numbers.import_number(
       PhoneNumber: '+15555550111', VoiceUrl: 'https://a.b/v'
     )
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'POST', j.method
     # Note the path is ImportedPhoneNumbers, not IncomingPhoneNumbers.
-    assert_equal "#{ACCOUNT_BASE}/ImportedPhoneNumbers", j.path
+    assert_equal "#{account_base}/ImportedPhoneNumbers", j.path
     assert_kind_of Hash, j.body
     assert_equal '+15555550111', j.body['PhoneNumber']
   end
@@ -171,10 +177,10 @@ class CompatPhoneNumbersProvisioningMockTest < Minitest::Test
 
   def test_list_available_countries_journal_records_get
     @client.compat.phone_numbers.list_available_countries
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{ACCOUNT_BASE}/AvailablePhoneNumbers", j.path
+    assert_equal "#{account_base}/AvailablePhoneNumbers", j.path
   end
 
   # ---- search_toll_free (GET /AvailablePhoneNumbers/{c}/TollFree) -----
@@ -190,11 +196,11 @@ class CompatPhoneNumbersProvisioningMockTest < Minitest::Test
 
   def test_search_toll_free_journal_records_get_with_country_in_path
     @client.compat.phone_numbers.search_toll_free('US', AreaCode: '888')
-    j = MockTest.journal.last
+    j = @mock.last
     query = j.query_params
 
     assert_equal 'GET', j.method
-    assert_equal "#{ACCOUNT_BASE}/AvailablePhoneNumbers/US/TollFree", j.path
+    assert_equal "#{account_base}/AvailablePhoneNumbers/US/TollFree", j.path
     # The AreaCode should be on the query string, not body.
     assert(query.key?('AreaCode'), "expected AreaCode in query params, got #{query.keys.inspect}")
     assert_equal ['888'], query['AreaCode']

--- a/tests/rest/compat_queues_mock_test.rb
+++ b/tests/rest/compat_queues_mock_test.rb
@@ -9,16 +9,22 @@ require 'minitest/autorun'
 require_relative 'mock_test'
 
 class CompatQueuesMockTest < Minitest::Test
-  ACCOUNT_BASE = '/api/laml/2010-04-01/Accounts/test_proj'
-  QUEUES_BASE  = "#{ACCOUNT_BASE}/Queues".freeze
+  # Parallelize: per-client unique-project + auth-scoped harness isolates each test.
+  parallelize_me!
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
-  def teardown
-    MockTest.reset
+  def account_base
+    "/api/laml/2010-04-01/Accounts/#{@project}"
+  end
+
+  def queues_base
+    "#{account_base}/Queues"
   end
 
   # ---- update ----------------------------------------------------------
@@ -34,7 +40,7 @@ class CompatQueuesMockTest < Minitest::Test
   # Assert the last journal entry was a POST to +path+ with a Hash body,
   # returning that body for further per-field assertions.
   def assert_post_body(path)
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'POST', j.method
     assert_equal path, j.path
@@ -44,7 +50,7 @@ class CompatQueuesMockTest < Minitest::Test
 
   def test_update_journal_records_post_with_friendly_name
     @client.compat.queues.update('QU_UU', FriendlyName: 'renamed', MaxSize: 200)
-    body = assert_post_body("#{QUEUES_BASE}/QU_UU")
+    body = assert_post_body("#{queues_base}/QU_UU")
 
     assert_equal 'renamed', body['FriendlyName']
     assert_equal 200, body['MaxSize']
@@ -63,10 +69,10 @@ class CompatQueuesMockTest < Minitest::Test
 
   def test_list_members_journal_records_get
     @client.compat.queues.list_members('QU_LMX')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{QUEUES_BASE}/QU_LMX/Members", j.path
+    assert_equal "#{queues_base}/QU_LMX/Members", j.path
   end
 
   # ---- get_member -----------------------------------------------------
@@ -81,10 +87,10 @@ class CompatQueuesMockTest < Minitest::Test
 
   def test_get_member_journal_records_get
     @client.compat.queues.get_member('QU_GMX', 'CA_GMX')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{QUEUES_BASE}/QU_GMX/Members/CA_GMX", j.path
+    assert_equal "#{queues_base}/QU_GMX/Members/CA_GMX", j.path
   end
 
   # ---- dequeue_member -------------------------------------------------
@@ -102,7 +108,7 @@ class CompatQueuesMockTest < Minitest::Test
     @client.compat.queues.dequeue_member(
       'QU_DMX', 'CA_DMX', Url: 'https://a.b/url', Method: 'POST'
     )
-    body = assert_post_body("#{QUEUES_BASE}/QU_DMX/Members/CA_DMX")
+    body = assert_post_body("#{queues_base}/QU_DMX/Members/CA_DMX")
 
     assert_equal 'https://a.b/url', body['Url']
     assert_equal 'POST', body['Method']

--- a/tests/rest/compat_recordings_transcriptions_mock_test.rb
+++ b/tests/rest/compat_recordings_transcriptions_mock_test.rb
@@ -13,15 +13,18 @@ require 'minitest/autorun'
 require_relative 'mock_test'
 
 class CompatRecordingsTranscriptionsMockTest < Minitest::Test
-  ACCOUNT_BASE = '/api/laml/2010-04-01/Accounts/test_proj'
+  # Parallelize: per-client unique-project + auth-scoped harness isolates each test.
+  parallelize_me!
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
-  def teardown
-    MockTest.reset
+  def account_base
+    "/api/laml/2010-04-01/Accounts/#{@project}"
   end
 
   # ---- Recordings.list -------------------------------------------------
@@ -37,10 +40,10 @@ class CompatRecordingsTranscriptionsMockTest < Minitest::Test
 
   def test_recordings_list_journal_records_get
     @client.compat.recordings.list
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{ACCOUNT_BASE}/Recordings", j.path
+    assert_equal "#{account_base}/Recordings", j.path
   end
 
   # ---- Recordings.get --------------------------------------------------
@@ -55,10 +58,10 @@ class CompatRecordingsTranscriptionsMockTest < Minitest::Test
 
   def test_recordings_get_journal_records_get_with_sid
     @client.compat.recordings.get('RE_GET')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{ACCOUNT_BASE}/Recordings/RE_GET", j.path
+    assert_equal "#{account_base}/Recordings/RE_GET", j.path
   end
 
   # ---- Recordings.delete ----------------------------------------------
@@ -71,10 +74,10 @@ class CompatRecordingsTranscriptionsMockTest < Minitest::Test
 
   def test_recordings_delete_journal_records_delete
     @client.compat.recordings.delete('RE_DEL')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'DELETE', j.method
-    assert_equal "#{ACCOUNT_BASE}/Recordings/RE_DEL", j.path
+    assert_equal "#{account_base}/Recordings/RE_DEL", j.path
   end
 
   # ---- Transcriptions.list --------------------------------------------
@@ -90,10 +93,10 @@ class CompatRecordingsTranscriptionsMockTest < Minitest::Test
 
   def test_transcriptions_list_journal_records_get
     @client.compat.transcriptions.list
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{ACCOUNT_BASE}/Transcriptions", j.path
+    assert_equal "#{account_base}/Transcriptions", j.path
   end
 
   # ---- Transcriptions.get ---------------------------------------------
@@ -108,10 +111,10 @@ class CompatRecordingsTranscriptionsMockTest < Minitest::Test
 
   def test_transcriptions_get_journal_records_get_with_sid
     @client.compat.transcriptions.get('TR_GET')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'GET', j.method
-    assert_equal "#{ACCOUNT_BASE}/Transcriptions/TR_GET", j.path
+    assert_equal "#{account_base}/Transcriptions/TR_GET", j.path
   end
 
   # ---- Transcriptions.delete ------------------------------------------
@@ -124,9 +127,9 @@ class CompatRecordingsTranscriptionsMockTest < Minitest::Test
 
   def test_transcriptions_delete_journal_records_delete
     @client.compat.transcriptions.delete('TR_DEL')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'DELETE', j.method
-    assert_equal "#{ACCOUNT_BASE}/Transcriptions/TR_DEL", j.path
+    assert_equal "#{account_base}/Transcriptions/TR_DEL", j.path
   end
 end

--- a/tests/rest/compat_tokens_mock_test.rb
+++ b/tests/rest/compat_tokens_mock_test.rb
@@ -11,16 +11,22 @@ require 'minitest/autorun'
 require_relative 'mock_test'
 
 class CompatTokensMockTest < Minitest::Test
-  ACCOUNT_BASE = '/api/laml/2010-04-01/Accounts/test_proj'
-  TOKENS_BASE  = "#{ACCOUNT_BASE}/tokens".freeze
+  # Parallelize: per-client unique-project + auth-scoped harness isolates each test.
+  parallelize_me!
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
-  def teardown
-    MockTest.reset
+  def account_base
+    "/api/laml/2010-04-01/Accounts/#{@project}"
+  end
+
+  def tokens_base
+    "#{account_base}/tokens"
   end
 
   # ---- create ----------------------------------------------------------
@@ -35,9 +41,9 @@ class CompatTokensMockTest < Minitest::Test
 
   def test_create_journal_records_post_with_ttl
     @client.compat.tokens.create(Ttl: 3600, Name: 'api-key')
-    j = MockTest.journal.last
+    j = @mock.last
 
-    assert_journal_request(j, 'POST', TOKENS_BASE)
+    assert_journal_request(j, 'POST', tokens_base)
     assert_equal 3600, j.body['Ttl']
     assert_equal 'api-key', j.body['Name']
   end
@@ -53,10 +59,10 @@ class CompatTokensMockTest < Minitest::Test
 
   def test_update_journal_records_patch_with_ttl
     @client.compat.tokens.update('TK_UU', Ttl: 7200)
-    j = MockTest.journal.last
+    j = @mock.last
     # CompatTokens.update uses PATCH (BaseResource.update -> http.patch).
     assert_equal 'PATCH', j.method
-    assert_equal "#{TOKENS_BASE}/TK_UU", j.path
+    assert_equal "#{tokens_base}/TK_UU", j.path
     assert_kind_of Hash, j.body
     assert_equal 7200, j.body['Ttl']
   end
@@ -71,10 +77,10 @@ class CompatTokensMockTest < Minitest::Test
 
   def test_delete_journal_records_delete
     @client.compat.tokens.delete('TK_DEL')
-    j = MockTest.journal.last
+    j = @mock.last
 
     assert_equal 'DELETE', j.method
-    assert_equal "#{TOKENS_BASE}/TK_DEL", j.path
+    assert_equal "#{tokens_base}/TK_DEL", j.path
   end
 
   private

--- a/tests/rest/fabric_mock_test.rb
+++ b/tests/rest/fabric_mock_test.rb
@@ -15,22 +15,26 @@ require_relative 'mock_test'
 # Shared fixture + journal/collection assertion helpers for the Fabric mock
 # test classes below.
 module FabricMockHelpers
+  # Parallelize: each test's client uses a unique project + auth-scoped harness,
+  # so the shared mock is concurrency-safe. Parallelism stress-proves isolation.
+  def self.included(base)
+    base.parallelize_me!
+  end
+
   FABRIC_BASE = '/api/fabric'
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
-  end
-
-  def teardown
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
   # Assert the last journalled request's method + path, and optionally that a
   # route matched (+:matched+) or the exact matched_route id. Returns the
   # journal entry for any further per-field assertions.
   def assert_last_request(method, path, route: nil)
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal method, last.method
     assert_equal path, last.path
@@ -78,7 +82,7 @@ class FabricMockTest < Minitest::Test
     end
     assert_match(/cXML applications cannot/, err.message)
     # Nothing should have hit the wire.
-    assert_equal [], MockTest.journal.journal
+    assert_equal [], @mock.journal
   end
 
   # ---- CallFlowsResource.list_addresses — singular path ---------------

--- a/tests/rest/logs_mock_test.rb
+++ b/tests/rest/logs_mock_test.rb
@@ -11,13 +11,14 @@ require 'minitest/autorun'
 require_relative 'mock_test'
 
 class LogsMockTest < Minitest::Test
-  def setup
-    @client = MockTest.client
-    MockTest.reset
-  end
+  # Parallelize: per-client unique-project + auth-scoped harness isolates each test.
+  parallelize_me!
 
-  def teardown
-    MockTest.reset
+  def setup
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
   # ---- Message Logs — /api/messaging/logs -----------------------------
@@ -27,7 +28,7 @@ class LogsMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal '/api/messaging/logs', last.path
@@ -40,7 +41,7 @@ class LogsMockTest < Minitest::Test
     assert_kind_of Hash, body
     # Single-log endpoint returns one resource object, not a collection.
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal '/api/messaging/logs/ml-42', last.path
@@ -54,7 +55,7 @@ class LogsMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal '/api/voice/logs', last.path
@@ -66,7 +67,7 @@ class LogsMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal '/api/voice/logs/vl-99', last.path
@@ -79,7 +80,7 @@ class LogsMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal '/api/fax/logs', last.path
@@ -91,7 +92,7 @@ class LogsMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal '/api/fax/logs/fl-7', last.path
@@ -104,7 +105,7 @@ class LogsMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     # The conferences logs spec lives under /api/logs/conferences.

--- a/tests/rest/mock_test.rb
+++ b/tests/rest/mock_test.rb
@@ -19,6 +19,8 @@
 require 'net/http'
 require 'json'
 require 'uri'
+require 'base64'
+require 'securerandom'
 require 'singleton'
 require_relative '../../lib/signalwire/rest/rest_client'
 
@@ -58,14 +60,32 @@ module MockTest
   class Harness
     attr_reader :url, :port
 
+    # The unique random project this harness's client authenticates with
+    # (+test_proj_<hex>+). Tests that assert on the AccountSid embedded in a
+    # LAML path read it from here instead of hard-coding +test_proj+. Empty on
+    # an unscoped/raw harness.
+    attr_accessor :project
+
+    # When set, +journal+/+last+ return only the requests THIS test's client
+    # made -- identified by its +Authorization+ header (Basic +project:token+,
+    # with a per-test random project; see {MockTest.client}). REST is pure
+    # request/response, so the mock needs no session handshake: each request is
+    # self-identifying via its auth header, and filtering the shared global
+    # journal by that header makes the suite safe under parallelism without any
+    # change to the SDK or the mock server. Empty => unscoped (legacy view,
+    # returns every entry -- only correct under serial execution).
+    attr_accessor :auth_header
+
     def initialize(url, port)
-      @url  = url
-      @port = port
+      @url         = url
+      @port        = port
+      @project     = ''
+      @auth_header = ''
     end
 
-    # Returns the most recent journal entry. Raises if the journal is empty —
-    # every test that calls a mock-backed SDK method should produce at least
-    # one entry.
+    # Returns the most recent journal entry for THIS client. Raises if the
+    # journal is empty — every test that calls a mock-backed SDK method should
+    # produce at least one entry.
     def last
       entries = journal
       raise 'mocktest: journal is empty - SDK call did not reach the mock server' if entries.empty?
@@ -73,27 +93,40 @@ module MockTest
       entries.last
     end
 
-    # Returns every entry recorded since the last reset, in arrival order.
+    # Returns this client's recorded requests in arrival order. Scoped to this
+    # harness's +auth_header+ when set (so a parallel test never sees another
+    # test's requests); unscoped harnesses see the whole journal.
     def journal
-      raw = http_get('/__mock__/journal')
-      arr = JSON.parse(raw)
-      arr.map { |e| build_entry(e) }
+      arr = JSON.parse(http_get('/__mock__/journal'))
+      entries = arr.map { |e| build_entry(e) }
+      return entries if @auth_header.nil? || @auth_header.empty?
+
+      entries.select { |e| (e.headers['authorization'] || e.headers['Authorization']) == @auth_header }
     end
 
-    # Clears journal + scenarios on the mock server. Tests typically call
-    # this in #setup; #teardown calls it again to keep accidental leftover
-    # state from a panic from leaking into the next test.
+    # Clears journal + scenarios on the mock server. A scoped harness leaves
+    # the shared journal alone (it only ever reads its own entries, identified
+    # by auth header, so there is nothing to clear and a global wipe would race
+    # a concurrent test). Unscoped harnesses do the legacy global reset.
     def reset
+      return unless @auth_header.nil? || @auth_header.empty?
+
       http_post('/__mock__/journal/reset')
       http_post('/__mock__/scenarios/reset')
     end
 
     # Stages a one-shot response override for the route identified by
-    # endpoint_id. The status + body returned here will be served the next
-    # time the route is hit; subsequent hits fall back to spec synthesis.
+    # endpoint_id. Scoped to THIS client's auth header (REST's session key) so a
+    # concurrent test can't consume it and a stale one can't bleed across tests;
+    # an unscoped harness stages it shared.
     def push_scenario(endpoint_id, status:, response:)
       payload = JSON.generate('status' => status, 'response' => response)
-      http_post("/__mock__/scenarios/#{endpoint_id}", payload)
+      q = if @auth_header.nil? || @auth_header.empty?
+            ''
+          else
+            "?session_id=#{URI.encode_www_form_component(@auth_header)}"
+          end
+      http_post("/__mock__/scenarios/#{endpoint_id}#{q}", payload)
     end
 
     private
@@ -112,25 +145,49 @@ module MockTest
     end
 
     def http_get(path)
-      uri = URI("#{@url}#{path}")
-      Net::HTTP.start(uri.hostname, uri.port) do |http|
-        resp = http.get(uri.request_uri)
-        raise "mocktest: GET #{path} failed: #{resp.code} #{resp.body}" unless resp.is_a?(Net::HTTPSuccess)
-
-        resp.body
+      with_retry do
+        uri = URI("#{@url}#{path}")
+        Net::HTTP.start(uri.hostname, uri.port) do |http|
+          require_success('GET', path, http.get(uri.request_uri))
+        end
       end
     end
 
     def http_post(path, body = nil)
-      uri = URI("#{@url}#{path}")
-      Net::HTTP.start(uri.hostname, uri.port) do |http|
-        req = Net::HTTP::Post.new(uri.request_uri)
-        req['Content-Type'] = 'application/json'
-        req.body = body if body
-        resp = http.request(req)
-        raise "mocktest: POST #{path} failed: #{resp.code} #{resp.body}" unless resp.is_a?(Net::HTTPSuccess)
+      with_retry do
+        uri = URI("#{@url}#{path}")
+        Net::HTTP.start(uri.hostname, uri.port) do |http|
+          req = Net::HTTP::Post.new(uri.request_uri)
+          req['Content-Type'] = 'application/json'
+          req.body = body if body
+          require_success('POST', path, http.request(req))
+        end
+      end
+    end
 
-        resp.body
+    # Raise on a non-2xx response, else return its body.
+    def require_success(verb, path, resp)
+      raise "mocktest: #{verb} #{path} failed: #{resp.code} #{resp.body}" unless resp.is_a?(Net::HTTPSuccess)
+
+      resp.body
+    end
+
+    # Tolerate brief connection refusals while the mock is (re)started by
+    # +Lifecycle#respawn_if_dead+. Each retry waits 200ms and triggers a fresh
+    # health probe + spawn through the singleton lifecycle. Mirrors the relay
+    # harness's +with_retry+ so a transient mock crash under heavy parallel load
+    # doesn't cascade into N test errors.
+    def with_retry
+      attempts = 0
+      begin
+        yield
+      rescue Errno::ECONNREFUSED
+        attempts += 1
+        raise if attempts > 10
+
+        MockTest::Lifecycle.instance.respawn_if_dead
+        sleep 0.2
+        retry
       end
     end
   end
@@ -152,10 +209,10 @@ module MockTest
         return @harness if @started
 
         @started = true
-        port = resolve_port
-        url  = "http://127.0.0.1:#{port}"
+        @port = resolve_port
+        @url  = "http://127.0.0.1:#{@port}"
 
-        @harness = probe_health(url) ? Harness.new(url, port) : spawn_and_build(url, port)
+        @harness = probe_health(@url) ? Harness.new(@url, @port) : spawn_and_build(@url, @port)
       end
     end
 
@@ -163,6 +220,24 @@ module MockTest
       spawn_server(port)
       wait_for_health(url)
       Harness.new(url, port)
+    end
+
+    # Idempotent: probe; if the mock is dead, spawn a fresh one and wait for
+    # health. Called from the HTTP retry loop so a transient mock crash mid-suite
+    # (e.g. under heavy parallel load) doesn't cascade into N test errors.
+    # Mirrors RelayMockTest::Lifecycle#respawn_if_dead.
+    def respawn_if_dead
+      @mu.synchronize do
+        url  = @url  || "http://127.0.0.1:#{resolve_port}"
+        port = @port || resolve_port
+        @url ||= url
+        @port ||= port
+        return false if probe_health(url)
+
+        spawn_server(port)
+        wait_for_health(url)
+        true
+      end
     end
 
     private
@@ -269,20 +344,49 @@ module MockTest
     Lifecycle.instance.harness
   end
 
-  # Returns a fresh real RestClient pointed at the mock server. The mock
-  # accepts any non-empty Basic Auth header — credentials are
-  # 'test_proj' / 'test_tok' to match the Python signalwire_client fixture.
+  # Token shared by every mock-backed REST client (the project varies per
+  # test; only the project half of the Basic-auth pair needs to be unique).
+  REST_TOKEN = 'test_tok'
+
+  # Returns a handle for a fresh real RestClient pointed at the mock server,
+  # plus a per-client harness view scoped to THIS client's requests, so the
+  # test reads only its own journal entries — making the shared mock safe under
+  # parallelism with no SDK change and no mock-server change.
+  #
+  # Returns a Hash with:
+  #   :client  -- the real SignalWire::REST::RestClient
+  #   :mock    -- a Harness view scoped to this client's Authorization header
+  #   :project -- the unique random project (+test_proj_<hex>+) this client
+  #               authenticates with; tests that assert on the AccountSid in a
+  #               LAML path read it from here rather than hard-coding test_proj.
+  #
+  # Isolation key: each client gets a unique random project
+  # (+test_proj_<12 hex>+), so its +Authorization: Basic base64(project:token)+
+  # header is unique. The random suffix (not a counter) keeps it collision-free
+  # across parallel workers AND separate processes hitting one shared mock. The
+  # harness filters the global journal by that header.
   def client
     h = harness
-    SignalWire::REST::RestClient.new(
-      project: 'test_proj',
-      token: 'test_tok',
-      base_url: h.url
+    project = "test_proj_#{SecureRandom.hex(6)}"
+    auth_header = "Basic #{Base64.strict_encode64("#{project}:#{REST_TOKEN}")}"
+
+    sdk = SignalWire::REST::RestClient.new(
+      project: project, token: REST_TOKEN, base_url: h.url
     )
+
+    # Per-call harness view scoped to this client's auth header. No reset is
+    # needed: this client starts with zero entries in the (auth-filtered) view.
+    mock = Harness.new(h.url, h.port)
+    mock.auth_header = auth_header
+    mock.project = project
+
+    { client: sdk, mock: mock, project: project }
   end
 
   # Convenience method-name aliases so tests can use the journal/scenario
-  # helpers without grabbing a Harness instance first.
+  # helpers without grabbing a Harness instance first. NOTE: these return the
+  # UNSCOPED global harness (legacy, single-threaded view). Parallel-safe tests
+  # must use the per-client +:mock+ from {client} instead.
   def journal
     harness
   end
@@ -291,8 +395,8 @@ module MockTest
     harness
   end
 
-  # Resets journal + scenarios. Tests call this in setup so each test starts
-  # with a clean slate.
+  # Resets journal + scenarios globally. Parallel-safe tests do NOT call this;
+  # their per-client scoped harness starts empty and its #reset is a no-op.
   def reset
     harness.reset
   end

--- a/tests/rest/pagination_mock_test.rb
+++ b/tests/rest/pagination_mock_test.rb
@@ -17,6 +17,9 @@ require 'minitest/autorun'
 require_relative 'mock_test'
 
 class PaginationMockTest < Minitest::Test
+  # Parallelize: per-client unique-project + auth-scoped harness isolates each test.
+  parallelize_me!
+
   # Pick an endpoint that the scenario store can override. We use
   # GET /api/fabric/addresses because (a) it has a stable spec-derived
   # endpoint id and (b) the mock returns data + links shape by default.
@@ -24,12 +27,10 @@ class PaginationMockTest < Minitest::Test
   FABRIC_ADDRESSES_ENDPOINT_ID = 'fabric.list_fabric_addresses'
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
-  end
-
-  def teardown
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
   def test_init_state
@@ -38,7 +39,7 @@ class PaginationMockTest < Minitest::Test
 
     assert_init_state(iter)
     # Journal must be empty - no HTTP went out.
-    assert_equal [], MockTest.journal.journal
+    assert_equal [], @mock.journal
   end
 
   # Constructor must not have fetched anything yet.
@@ -62,7 +63,7 @@ class PaginationMockTest < Minitest::Test
 
     assert_kind_of Enumerator, enum
     # Still no HTTP yet - enum isn't realised.
-    assert_equal [], MockTest.journal.journal
+    assert_equal [], @mock.journal
   end
 
   def test_next_pages_through_all_items
@@ -77,7 +78,7 @@ class PaginationMockTest < Minitest::Test
 
   def assert_two_paginated_gets
     # Journal must have exactly two GETs at the same path.
-    gets = MockTest.journal.journal.select { |e| e.path == FABRIC_ADDRESSES_PATH }
+    gets = @mock.journal.select { |e| e.path == FABRIC_ADDRESSES_PATH }
     summary = gets.map { |e| [e.method, e.path, e.query_params] }
 
     assert_equal 2, gets.length, "expected 2 paginated GETs, got #{gets.length}: #{summary}"
@@ -90,7 +91,7 @@ class PaginationMockTest < Minitest::Test
 
   # Stage one page on the addresses endpoint with the given data + links.
   def push_page(data, links)
-    MockTest.scenarios.push_scenario(
+    @mock.push_scenario(
       FABRIC_ADDRESSES_ENDPOINT_ID,
       status: 200,
       response: { 'data' => data, 'links' => links }

--- a/tests/rest/registry_mock_test.rb
+++ b/tests/rest/registry_mock_test.rb
@@ -11,15 +11,16 @@ require 'minitest/autorun'
 require_relative 'mock_test'
 
 class RegistryMockTest < Minitest::Test
+  # Parallelize: per-client unique-project + auth-scoped harness isolates each test.
+  parallelize_me!
+
   REG_BASE = '/api/relay/rest/registry/beta'
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
-  end
-
-  def teardown
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
   # ---- Brands ---------------------------------------------------------
@@ -29,7 +30,7 @@ class RegistryMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{REG_BASE}/brands", last.path
@@ -42,7 +43,7 @@ class RegistryMockTest < Minitest::Test
     assert_kind_of Hash, body
     # Single-brand endpoint synthesises one resource object.
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{REG_BASE}/brands/brand-77", last.path
@@ -53,7 +54,7 @@ class RegistryMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{REG_BASE}/brands/brand-1/campaigns", last.path
@@ -67,7 +68,7 @@ class RegistryMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'POST', last.method
     assert_equal "#{REG_BASE}/brands/brand-2/campaigns", last.path
@@ -87,7 +88,7 @@ class RegistryMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{REG_BASE}/campaigns/camp-1", last.path
@@ -100,7 +101,7 @@ class RegistryMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'PUT', last.method
     assert_equal "#{REG_BASE}/campaigns/camp-2", last.path
@@ -113,7 +114,7 @@ class RegistryMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{REG_BASE}/campaigns/camp-3/numbers", last.path
@@ -127,7 +128,7 @@ class RegistryMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'POST', last.method
     assert_equal "#{REG_BASE}/campaigns/camp-4/orders", last.path
@@ -142,7 +143,7 @@ class RegistryMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{REG_BASE}/orders/order-1", last.path
@@ -156,7 +157,7 @@ class RegistryMockTest < Minitest::Test
     # SDK turns 204/empty into {} so we still get a dict back.
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'DELETE', last.method
     assert_equal "#{REG_BASE}/numbers/num-1", last.path

--- a/tests/rest/small_namespaces_mock_test.rb
+++ b/tests/rest/small_namespaces_mock_test.rb
@@ -15,21 +15,25 @@ require_relative 'mock_test'
 
 # Shared setup + journal assertions for the small-namespace mock tests.
 module SmallNamespacesHelpers
+  # Parallelize: each test's client uses a unique project + auth-scoped harness,
+  # so the shared mock is concurrency-safe. Parallelism stress-proves isolation.
+  def self.included(base)
+    base.parallelize_me!
+  end
+
   RELAY_BASE = '/api/relay/rest'
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
-  end
-
-  def teardown
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
   # Assert the last journaled request used +method+ against +path+ (matched).
   # Returns the journal entry for further assertions.
   def assert_request(method, path)
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal method, last.method
     assert_equal path, last.path
@@ -81,7 +85,7 @@ class SmallNamespacesMockTest < Minitest::Test
 
     assert_kind_of Hash, body
     assert body.key?('id')
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{RELAY_BASE}/addresses/addr-123", last.path
@@ -92,7 +96,7 @@ class SmallNamespacesMockTest < Minitest::Test
     body = @client.addresses.delete('addr-123')
     # 204 on delete returns {}.
     assert_kind_of Hash, body
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'DELETE', last.method
     assert_equal "#{RELAY_BASE}/addresses/addr-123", last.path
@@ -108,7 +112,7 @@ class SmallNamespacesMockTest < Minitest::Test
     assert_kind_of Hash, body
     assert body.key?('data')
     assert_kind_of Array, body['data']
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{RELAY_BASE}/recordings", last.path
@@ -121,7 +125,7 @@ class SmallNamespacesMockTest < Minitest::Test
     assert_kind_of Hash, body
     # The Recording schema has an 'id' field.
     assert body.key?('id')
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{RELAY_BASE}/recordings/rec-123", last.path
@@ -131,7 +135,7 @@ class SmallNamespacesMockTest < Minitest::Test
     body = @client.recordings.delete('rec-123')
 
     assert_kind_of Hash, body
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'DELETE', last.method
     assert_equal "#{RELAY_BASE}/recordings/rec-123", last.path
@@ -147,7 +151,7 @@ class SmallNamespacesMockTest < Minitest::Test
     assert_kind_of Hash, body
     assert body.key?('data')
     assert_kind_of Array, body['data']
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{RELAY_BASE}/short_codes", last.path
@@ -158,7 +162,7 @@ class SmallNamespacesMockTest < Minitest::Test
 
     assert_kind_of Hash, body
     assert body.key?('id')
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{RELAY_BASE}/short_codes/sc-1", last.path
@@ -169,7 +173,7 @@ class SmallNamespacesMockTest < Minitest::Test
 
     assert_kind_of Hash, body
     assert body.key?('id')
-    last = MockTest.journal.last
+    last = @mock.last
     # short_codes uses PUT for update per CrudResource override.
     assert_equal 'PUT', last.method
     assert_equal "#{RELAY_BASE}/short_codes/sc-1", last.path
@@ -239,7 +243,7 @@ class SmallNamespacesMockTestPartTwo < Minitest::Test
     assert_kind_of Hash, body
     assert body.key?('data')
     assert_kind_of Array, body['data']
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{RELAY_BASE}/number_groups/ng-1/number_group_memberships", last.path
@@ -250,7 +254,7 @@ class SmallNamespacesMockTestPartTwo < Minitest::Test
     body = @client.number_groups.delete_membership('mem-1')
 
     assert_kind_of Hash, body
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'DELETE', last.method
     assert_equal "#{RELAY_BASE}/number_group_memberships/mem-1", last.path
@@ -265,7 +269,7 @@ class SmallNamespacesMockTestPartTwo < Minitest::Test
 
     assert_kind_of Hash, body
     assert body.key?('id')
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'PATCH', last.method
     assert_equal '/api/project/tokens/tok-1', last.path
@@ -278,7 +282,7 @@ class SmallNamespacesMockTestPartTwo < Minitest::Test
     body = @client.project.tokens.delete('tok-1')
 
     assert_kind_of Hash, body
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'DELETE', last.method
     assert_equal '/api/project/tokens/tok-1', last.path
@@ -294,7 +298,7 @@ class SmallNamespacesMockTestPartTwo < Minitest::Test
     assert_kind_of Hash, body
     # The DatasphereChunk schema has an 'id'.
     assert body.key?('id')
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal '/api/datasphere/documents/doc-1/chunks/chunk-99', last.path
@@ -308,7 +312,7 @@ class SmallNamespacesMockTestPartTwo < Minitest::Test
     assert_kind_of Hash, body
     # A queue member has 'queue_id' and 'call_id' per the spec example.
     assert(body.key?('queue_id') || body.key?('call_id'))
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{RELAY_BASE}/queues/q-1/members/mem-7", last.path

--- a/tests/rest/video_mock_test.rb
+++ b/tests/rest/video_mock_test.rb
@@ -16,15 +16,19 @@ require_relative 'mock_test'
 
 # Shared mock lifecycle, base path, and journal assertion helpers.
 module VideoMockSupport
+  # Parallelize: each test's client uses a unique project + auth-scoped harness,
+  # so the shared mock is concurrency-safe. Parallelism stress-proves isolation.
+  def self.included(base)
+    base.parallelize_me!
+  end
+
   VIDEO_BASE = '/api/video'
 
   def setup
-    @client = MockTest.client
-    MockTest.reset
-  end
-
-  def teardown
-    MockTest.reset
+    h = MockTest.client
+    @client  = h[:client]
+    @mock    = h[:mock]
+    @project = h[:project]
   end
 
   # Assert +body+ is a paginated collection: a Hash with an Array 'data' key.
@@ -36,7 +40,7 @@ module VideoMockSupport
 
   # Assert the last journaled request was a GET to +path+.
   def assert_journaled_get(path)
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal path, last.path
@@ -59,7 +63,7 @@ class VideoMockTest < Minitest::Test
     # /api/video/rooms/{id}/streams returns a paginated list ('data').
     assert_data_collection(@client.video.rooms.list_streams('room-1'))
     assert_journaled_get("#{VIDEO_BASE}/rooms/room-1/streams")
-    refute_nil MockTest.journal.last.matched_route, 'spec gap: rooms streams list'
+    refute_nil @mock.last.matched_route, 'spec gap: rooms streams list'
   end
 
   def test_rooms_create_stream_posts_kwargs_in_body
@@ -67,7 +71,7 @@ class VideoMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'POST', last.method
     assert_equal "#{VIDEO_BASE}/rooms/room-1/streams", last.path
@@ -85,7 +89,7 @@ class VideoMockTest < Minitest::Test
   def test_room_sessions_get_returns_session_object
     assert_kind_of Hash, @client.video.room_sessions.get('sess-abc')
     assert_journaled_get("#{VIDEO_BASE}/room_sessions/sess-abc")
-    refute_nil MockTest.journal.last.matched_route
+    refute_nil @mock.last.matched_route
   end
 
   def test_room_sessions_list_events_uses_events_subpath
@@ -116,7 +120,7 @@ class VideoMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'DELETE', last.method
     assert_equal "#{VIDEO_BASE}/room_recordings/rec-del", last.path
@@ -151,12 +155,12 @@ class VideoConferencesMockTest < Minitest::Test
   def test_conference_tokens_get_returns_single_token
     assert_kind_of Hash, @client.video.conference_tokens.get('tok-1')
     assert_journaled_get("#{VIDEO_BASE}/conference_tokens/tok-1")
-    refute_nil MockTest.journal.last.matched_route
+    refute_nil @mock.last.matched_route
   end
 
   def test_conference_tokens_reset_posts_to_reset_subpath
     assert_kind_of Hash, @client.video.conference_tokens.reset('tok-2')
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'POST', last.method
     assert_equal "#{VIDEO_BASE}/conference_tokens/tok-2/reset", last.path
@@ -170,7 +174,7 @@ class VideoConferencesMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'GET', last.method
     assert_equal "#{VIDEO_BASE}/streams/stream-1", last.path
@@ -181,7 +185,7 @@ class VideoConferencesMockTest < Minitest::Test
 
     assert_kind_of Hash, body
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'PUT', last.method
     assert_equal "#{VIDEO_BASE}/streams/stream-2", last.path
@@ -194,7 +198,7 @@ class VideoConferencesMockTest < Minitest::Test
 
     assert_kind_of Hash, body # SDK turns 204 into {}
 
-    last = MockTest.journal.last
+    last = @mock.last
 
     assert_equal 'DELETE', last.method
     assert_equal "#{VIDEO_BASE}/streams/stream-3", last.path


### PR DESCRIPTION
## Summary

Makes the shared **relay** and **REST** mock servers safe under parallel test execution, then turns on `Minitest.parallelize_me!` across all mock suites. Each test now only ever sees — and only ever disturbs — its own frames/requests, so the suite stress-proves its own isolation.

## Design (matches the frozen TypeScript port)

**RELAY** — session key = the connect-handshake `sessionid`:
- The SDK captures `result['sessionid']` from `signalwire.connect` into `@session_id`, read via a single-underscore `_session_id` reader. This stays **off the public surface** (the surface oracle excludes single-underscore names, same as `_set_protocol` / `_authorization_state`), so no `PORT_ADDITIONS.md` entry is required and no developer-facing API widens. Mirrors the TS port's private `_sessionId` capture.
- The relay harness threads `?session_id=<id>` onto journal read/reset, `scenarios/<method>`, `scenarios/dial`, `scenarios/reset`, `push`, `inbound_call`, plus per-op stamping inside `scenario_play`. `RelayMockTest.client` returns a per-client harness view scoped to the assigned session id. Readiness now reads the client's own `protocol`/`_session_id` state instead of counting frames in the shared journal (race-free under parallelism).

**REST** — session key = the `Authorization` header, no SDK change:
- Each client authenticates with a unique random project `test_proj_<12 hex>`, giving it a unique Basic-auth header. The harness filters the global journal **client-side** by that header; scoped `reset()` is a no-op; scenarios scope by `?session_id=<urlencoded auth header>`. LAML-path assertions read the per-test project rather than a hard-coded `test_proj`. Added a connection-refused retry + respawn guard for transient mock crashes under load.

Per test: fresh client, no global reset — a brand-new session/header starts with an empty scoped view.

## Verification

- `scripts/run-ci.sh`: all gates green, drift 0.
- 6× full mock-suite runs at `MT_CPU=8` (parallel executor confirmed engaged, size 8) under 3× `yes` CPU load: **349 runs / 1422 assertions / 0 failures / 0 errors / 0 skips** each, varying seeds, deterministic.
- No stray mock processes on ports 9779/8779/8769 before runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ab1ghK8PCd2PzW79nzsAqT
