### PR TITLE
ruby: complete the gate set (FMT, LINT, DOC-AUDIT, SKILL-CONTRACT)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,18 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
+
 gemspec
+
+# Development dependencies (declared here, not in the gemspec, per RuboCop's
+# Gemspec/DevelopmentDependencies — so consumers installing the gem don't pull
+# the test/lint toolchain).
+group :development, :test do
+  gem 'minitest', '>= 5.0'
+  gem 'rack-test', '>= 2.0'
+  gem 'rake', '>= 13.0'
+  # Lint/format quality floor (FMT + LINT gates in scripts/run-ci.sh).
+  gem 'rubocop', '>= 1.80'
+  gem 'rubocop-minitest', '>= 0.38'
+  gem 'rubocop-performance', '>= 1.25'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|

--- a/bin/emit-corpus
+++ b/bin/emit-corpus
@@ -50,7 +50,7 @@ TD  = SignalWire::Swaig::TapDirection
 CDC = SignalWire::Swaig::Codec
 
 # fr builds a fresh FunctionResult; mirrors Go's `fr(response)` helper.
-def fr(response = "")
+def fr(response = '')
   FR.new(response)
 end
 
@@ -66,204 +66,204 @@ PAY_AI_RESPONSE =
 # whole-float artifact the differ normalises: Python 44.0 == Ruby 44).
 CORPUS = {
   # ---- envelope edge cases (to_h shape) -----------------------------------
-  'envelope.empty' => -> { fr("") },
-  'envelope.response_only' => -> { fr("Hello, world!") },
-  'envelope.post_process_no_action' => -> { fr("hi").set_post_process(true) },
-  'envelope.action_only' => -> { fr("").hangup },
-  'envelope.post_process_with_action' => -> { fr("Transferring").set_post_process(true).hangup },
-  'envelope.response_and_action' => -> { fr("Goodbye").hangup },
+  'envelope.empty' => -> { fr('') },
+  'envelope.response_only' => -> { fr('Hello, world!') },
+  'envelope.post_process_no_action' => -> { fr('hi').set_post_process(true) },
+  'envelope.action_only' => -> { fr('').hangup },
+  'envelope.post_process_with_action' => -> { fr('Transferring').set_post_process(true).hangup },
+  'envelope.response_and_action' => -> { fr('Goodbye').hangup },
 
   # ---- connect ------------------------------------------------------------
-  'connect.final_true' => -> { fr("").connect("+15551234567", final: true) },
-  'connect.final_false' => -> { fr("").connect("+15551234567", final: false) },
-  'connect.from_addr' => -> { fr("").connect("support@example.com", final: false, from_addr: "+15559876543") },
+  'connect.final_true' => -> { fr('').connect('+15551234567', final: true) },
+  'connect.final_false' => -> { fr('').connect('+15551234567', final: false) },
+  'connect.from_addr' => -> { fr('').connect('support@example.com', final: false, from_addr: '+15559876543') },
 
   # ---- swml_transfer ------------------------------------------------------
-  'swml_transfer.default' => -> { fr("").swml_transfer("https://dest.example.com/swml", "Goodbye!") },
+  'swml_transfer.default' => -> { fr('').swml_transfer('https://dest.example.com/swml', 'Goodbye!') },
   'swml_transfer.final_false' => lambda {
-    fr("").swml_transfer("https://dest.example.com/swml", "Welcome back. How else can I help?", final: false)
+    fr('').swml_transfer('https://dest.example.com/swml', 'Welcome back. How else can I help?', final: false)
   },
 
   # ---- simple call-control actions ---------------------------------------
-  'hangup' => -> { fr("").hangup },
-  'hold.default' => -> { fr("").hold },
-  'hold.value' => -> { fr("").hold(120) },
-  'hold.clamp_high' => -> { fr("").hold(5000) },
-  'hold.clamp_low' => -> { fr("").hold(-5) },
-  'stop' => -> { fr("").stop },
-  'say' => -> { fr("").say("Please hold while I connect you.") },
+  'hangup' => -> { fr('').hangup },
+  'hold.default' => -> { fr('').hold },
+  'hold.value' => -> { fr('').hold(120) },
+  'hold.clamp_high' => -> { fr('').hold(5000) },
+  'hold.clamp_low' => -> { fr('').hold(-5) },
+  'stop' => -> { fr('').stop },
+  'say' => -> { fr('').say('Please hold while I connect you.') },
 
   # ---- wait_for_user (each branch) ---------------------------------------
-  'wait_for_user.default' => -> { fr("").wait_for_user },
-  'wait_for_user.answer_first' => -> { fr("").wait_for_user(answer_first: true) },
-  'wait_for_user.timeout' => -> { fr("").wait_for_user(timeout: 30) },
-  'wait_for_user.enabled_true' => -> { fr("").wait_for_user(enabled: true) },
-  'wait_for_user.enabled_false' => -> { fr("").wait_for_user(enabled: false) },
+  'wait_for_user.default' => -> { fr('').wait_for_user },
+  'wait_for_user.answer_first' => -> { fr('').wait_for_user(answer_first: true) },
+  'wait_for_user.timeout' => -> { fr('').wait_for_user(timeout: 30) },
+  'wait_for_user.enabled_true' => -> { fr('').wait_for_user(enabled: true) },
+  'wait_for_user.enabled_false' => -> { fr('').wait_for_user(enabled: false) },
 
   # ---- global data / metadata --------------------------------------------
-  'set_global_data' => -> { fr("").update_global_data({ "plan" => "premium", "chips" => 1000 }) },
-  'unset_global_data.list' => -> { fr("").remove_global_data(["plan", "chips"]) },
-  'unset_global_data.str' => -> { fr("").remove_global_data("plan") },
-  'set_metadata' => -> { fr("").set_metadata({ "token" => "abc", "count" => 3 }) },
-  'unset_metadata.list' => -> { fr("").remove_metadata(["token", "count"]) },
-  'unset_metadata.str' => -> { fr("").remove_metadata("token") },
+  'set_global_data' => -> { fr('').update_global_data({ 'plan' => 'premium', 'chips' => 1000 }) },
+  'unset_global_data.list' => -> { fr('').remove_global_data(%w[plan chips]) },
+  'unset_global_data.str' => -> { fr('').remove_global_data('plan') },
+  'set_metadata' => -> { fr('').set_metadata({ 'token' => 'abc', 'count' => 3 }) },
+  'unset_metadata.list' => -> { fr('').remove_metadata(%w[token count]) },
+  'unset_metadata.str' => -> { fr('').remove_metadata('token') },
 
   # ---- swml_user_event ----------------------------------------------------
   'swml_user_event' => lambda {
-    fr("").swml_user_event({ "type" => "cards_dealt", "player_hand" => ["AS", "KH"], "player_score" => 21 })
+    fr('').swml_user_event({ 'type' => 'cards_dealt', 'player_hand' => %w[AS KH], 'player_score' => 21 })
   },
 
   # ---- step / context changes --------------------------------------------
-  'change_step' => -> { fr("").swml_change_step("collect_payment") },
-  'change_context' => -> { fr("").swml_change_context("billing") },
+  'change_step' => -> { fr('').swml_change_step('collect_payment') },
+  'change_context' => -> { fr('').swml_change_context('billing') },
 
   # ---- switch_context (simple-string vs object branches) -----------------
   # Python: switch_context(system_prompt, user_prompt, consolidate, full_reset).
   # Ruby exposes these as keyword args; the wire values are identical.
-  'switch_context.simple' => -> { fr("").switch_context(system_prompt: "You are now a billing agent.") },
+  'switch_context.simple' => -> { fr('').switch_context(system_prompt: 'You are now a billing agent.') },
   'switch_context.object' => lambda {
-    fr("").switch_context(system_prompt: "New system prompt", user_prompt: "User said something",
+    fr('').switch_context(system_prompt: 'New system prompt', user_prompt: 'User said something',
                           consolidate: true, full_reset: false)
   },
   'switch_context.full_reset' => lambda {
-    fr("").switch_context(system_prompt: "Reset prompt", user_prompt: nil,
+    fr('').switch_context(system_prompt: 'Reset prompt', user_prompt: nil,
                           consolidate: false, full_reset: true)
   },
 
   # ---- background file play/stop -----------------------------------------
-  'playback_bg.simple' => -> { fr("").play_background_file("music.mp3") },
-  'playback_bg.wait' => -> { fr("").play_background_file("music.mp3", wait: true) },
-  'stop_playback_bg' => -> { fr("").stop_background_file },
+  'playback_bg.simple' => -> { fr('').play_background_file('music.mp3') },
+  'playback_bg.wait' => -> { fr('').play_background_file('music.mp3', wait: true) },
+  'stop_playback_bg' => -> { fr('').stop_background_file },
 
   # ---- join_room / sip_refer ---------------------------------------------
-  'join_room' => -> { fr("").join_room("team-standup") },
-  'sip_refer' => -> { fr("").sip_refer("sip:agent@example.com") },
+  'join_room' => -> { fr('').join_room('team-standup') },
+  'sip_refer' => -> { fr('').sip_refer('sip:agent@example.com') },
 
   # ---- send_sms -----------------------------------------------------------
   # Python: send_sms(to_number, from_number, body=…). Ruby requires keyword
   # to_number:/from_number:; the wire values are identical.
   'send_sms.body' => lambda {
-    fr("").send_sms(to_number: "+15551112222", from_number: "+15553334444",
-                    body: "Your appointment is confirmed.")
+    fr('').send_sms(to_number: '+15551112222', from_number: '+15553334444',
+                    body: 'Your appointment is confirmed.')
   },
   'send_sms.full' => lambda {
-    fr("").send_sms(to_number: "+15551112222", from_number: "+15553334444",
-                    body: "See attached.", media: ["https://ex.com/a.jpg"],
-                    tags: ["receipt", "vip"], region: "us")
+    fr('').send_sms(to_number: '+15551112222', from_number: '+15553334444',
+                    body: 'See attached.', media: ['https://ex.com/a.jpg'],
+                    tags: %w[receipt vip], region: 'us')
   },
 
   # ---- pay (full + helper-shaped prompts/parameters) ---------------------
   # Python: pay(payment_connector_url, …). Ruby requires keyword
   # payment_connector_url:; the wire values are identical.
-  'pay.minimal' => -> { fr("").pay(payment_connector_url: "https://pay.example.com/connector") },
+  'pay.minimal' => -> { fr('').pay(payment_connector_url: 'https://pay.example.com/connector') },
   'pay.full' => lambda {
-    fr("").pay(payment_connector_url: "https://pay.example.com/connector",
-               input_method: "dtmf", status_url: "https://ex.com/status",
-               payment_method: "credit-card", timeout: 7, max_attempts: 2,
-               security_code: false, postal_code: "90210", min_postal_code_length: 5,
-               token_type: "one-time", charge_amount: "9.99", currency: "usd",
-               language: "en-US", voice: "woman", description: "Order 42",
-               valid_card_types: "visa amex",
-               parameters: [{ "name" => "order_id", "value" => "42" }],
-               prompts: [{ "for" => "payment-card-number",
-                           "actions" => [{ "type" => "Say", "phrase" => "Enter your card number" }],
-                           "card_type" => "visa amex" }],
+    fr('').pay(payment_connector_url: 'https://pay.example.com/connector',
+               input_method: 'dtmf', status_url: 'https://ex.com/status',
+               payment_method: 'credit-card', timeout: 7, max_attempts: 2,
+               security_code: false, postal_code: '90210', min_postal_code_length: 5,
+               token_type: 'one-time', charge_amount: '9.99', currency: 'usd',
+               language: 'en-US', voice: 'woman', description: 'Order 42',
+               valid_card_types: 'visa amex',
+               parameters: [{ 'name' => 'order_id', 'value' => '42' }],
+               prompts: [{ 'for' => 'payment-card-number',
+                           'actions' => [{ 'type' => 'Say', 'phrase' => 'Enter your card number' }],
+                           'card_type' => 'visa amex' }],
                ai_response: PAY_AI_RESPONSE)
   },
-  'pay.postal_bool' => -> { fr("").pay(payment_connector_url: "https://pay.example.com/connector", postal_code: true) },
+  'pay.postal_bool' => -> { fr('').pay(payment_connector_url: 'https://pay.example.com/connector', postal_code: true) },
 
   # ---- record_call (incl. mp4 + each direction) --------------------------
-  'record_call.defaults' => -> { fr("").record_call },
-  'record_call.wav_speak' => -> { fr("").record_call(format: RF::WAV, direction: RD::SPEAK) },
-  'record_call.mp3_listen' => -> { fr("").record_call(format: RF::MP3, direction: RD::LISTEN) },
-  'record_call.mp4_both' => -> { fr("").record_call(format: RF::MP4, direction: RD::BOTH) },
+  'record_call.defaults' => -> { fr('').record_call },
+  'record_call.wav_speak' => -> { fr('').record_call(format: RF::WAV, direction: RD::SPEAK) },
+  'record_call.mp3_listen' => -> { fr('').record_call(format: RF::MP3, direction: RD::LISTEN) },
+  'record_call.mp4_both' => -> { fr('').record_call(format: RF::MP4, direction: RD::BOTH) },
   'record_call.full' => lambda {
-    fr("").record_call(control_id: "rec1", stereo: true, format: RF::MP3, direction: RD::BOTH,
-                       terminators: "#", beep: true, input_sensitivity: 30.0,
+    fr('').record_call(control_id: 'rec1', stereo: true, format: RF::MP3, direction: RD::BOTH,
+                       terminators: '#', beep: true, input_sensitivity: 30.0,
                        initial_timeout: 5.0, end_silence_timeout: 3.0, max_length: 120.0,
-                       status_url: "https://ex.com/rec")
+                       status_url: 'https://ex.com/rec')
   },
-  'stop_record_call.bare' => -> { fr("").stop_record_call },
-  'stop_record_call.id' => -> { fr("").stop_record_call(control_id: "rec1") },
+  'stop_record_call.bare' => -> { fr('').stop_record_call },
+  'stop_record_call.id' => -> { fr('').stop_record_call(control_id: 'rec1') },
 
   # ---- tap (each direction / codec) --------------------------------------
-  'tap.defaults' => -> { fr("").tap("rtp://10.0.0.1:5004") },
-  'tap.speak_pcma' => -> { fr("").tap("ws://ex.com/tap", direction: TD::SPEAK, codec: CDC::PCMA) },
-  'tap.hear_pcmu' => -> { fr("").tap("wss://ex.com/tap", direction: TD::HEAR, codec: CDC::PCMU) },
+  'tap.defaults' => -> { fr('').tap('rtp://10.0.0.1:5004') },
+  'tap.speak_pcma' => -> { fr('').tap('ws://ex.com/tap', direction: TD::SPEAK, codec: CDC::PCMA) },
+  'tap.hear_pcmu' => -> { fr('').tap('wss://ex.com/tap', direction: TD::HEAR, codec: CDC::PCMU) },
   'tap.both_full' => lambda {
-    fr("").tap("rtp://10.0.0.1:5004", control_id: "tap1", direction: TD::BOTH, codec: CDC::PCMA,
-               rtp_ptime: 40, status_url: "https://ex.com/tapstatus")
+    fr('').tap('rtp://10.0.0.1:5004', control_id: 'tap1', direction: TD::BOTH, codec: CDC::PCMA,
+                                      rtp_ptime: 40, status_url: 'https://ex.com/tapstatus')
   },
-  'stop_tap.bare' => -> { fr("").stop_tap },
-  'stop_tap.id' => -> { fr("").stop_tap(control_id: "tap1") },
+  'stop_tap.bare' => -> { fr('').stop_tap },
+  'stop_tap.id' => -> { fr('').stop_tap(control_id: 'tap1') },
 
   # ---- join_conference (simple + full) -----------------------------------
-  'join_conference.simple' => -> { fr("").join_conference("sales-floor") },
+  'join_conference.simple' => -> { fr('').join_conference('sales-floor') },
   'join_conference.full' => lambda {
-    fr("").join_conference("sales-floor", muted: true, beep: "onEnter", start_on_enter: false,
-                           end_on_exit: true, wait_url: "https://ex.com/hold", max_participants: 50,
-                           record: "record-from-start", region: "us-east", trim: "do-not-trim",
-                           coach: "call-123", status_callback_event: "start end join leave",
-                           status_callback: "https://ex.com/cb", status_callback_method: "GET",
-                           recording_status_callback: "https://ex.com/rcb",
-                           recording_status_callback_method: "GET",
-                           recording_status_callback_event: "in-progress completed")
+    fr('').join_conference('sales-floor', muted: true, beep: 'onEnter', start_on_enter: false,
+                                          end_on_exit: true, wait_url: 'https://ex.com/hold', max_participants: 50,
+                                          record: 'record-from-start', region: 'us-east', trim: 'do-not-trim',
+                                          coach: 'call-123', status_callback_event: 'start end join leave',
+                                          status_callback: 'https://ex.com/cb', status_callback_method: 'GET',
+                                          recording_status_callback: 'https://ex.com/rcb',
+                                          recording_status_callback_method: 'GET',
+                                          recording_status_callback_event: 'in-progress completed')
   },
 
   # ---- execute_rpc + the three rpc helpers -------------------------------
-  'execute_rpc.minimal' => -> { fr("").execute_rpc("ai_unhold") },
+  'execute_rpc.minimal' => -> { fr('').execute_rpc('ai_unhold') },
   'execute_rpc.full' => lambda {
-    fr("").execute_rpc("ai_message", params: { "role" => "system", "message_text" => "Hello" },
-                       call_id: "call-abc", node_id: "node-1")
+    fr('').execute_rpc('ai_message', params: { 'role' => 'system', 'message_text' => 'Hello' },
+                                     call_id: 'call-abc', node_id: 'node-1')
   },
   'rpc_dial' => lambda {
-    fr("").rpc_dial(to_number: "+15551234567", from_number: "+15559876543",
-                    dest_swml: "https://ex.com/call-agent")
+    fr('').rpc_dial(to_number: '+15551234567', from_number: '+15559876543',
+                    dest_swml: 'https://ex.com/call-agent')
   },
-  'rpc_ai_message' => -> { fr("").rpc_ai_message("call-abc", "Please take a message.") },
-  'rpc_ai_unhold' => -> { fr("").rpc_ai_unhold("call-abc") },
+  'rpc_ai_message' => -> { fr('').rpc_ai_message('call-abc', 'Please take a message.') },
+  'rpc_ai_unhold' => -> { fr('').rpc_ai_unhold('call-abc') },
 
   # ---- simulate_user_input -----------------------------------------------
-  'simulate_user_input' => -> { fr("").simulate_user_input("I'd like to pay my bill.") },
+  'simulate_user_input' => -> { fr('').simulate_user_input("I'd like to pay my bill.") },
 
   # ---- dynamic hints ------------------------------------------------------
   'add_dynamic_hints' => lambda {
-    fr("").add_dynamic_hints(["Cabby", { "pattern" => "cab bee", "replace" => "Cabby", "ignore_case" => true }])
+    fr('').add_dynamic_hints(['Cabby', { 'pattern' => 'cab bee', 'replace' => 'Cabby', 'ignore_case' => true }])
   },
-  'clear_dynamic_hints' => -> { fr("").clear_dynamic_hints },
+  'clear_dynamic_hints' => -> { fr('').clear_dynamic_hints },
 
   # ---- toggle_functions / functions-on-timeout ---------------------------
   'toggle_functions' => lambda {
-    fr("").toggle_functions([{ "function" => "transfer", "active" => false },
-                             { "function" => "lookup", "active" => true }])
+    fr('').toggle_functions([{ 'function' => 'transfer', 'active' => false },
+                             { 'function' => 'lookup', 'active' => true }])
   },
-  'functions_on_speaker_timeout.true' => -> { fr("").enable_functions_on_timeout },
-  'functions_on_speaker_timeout.false' => -> { fr("").enable_functions_on_timeout(false) },
+  'functions_on_speaker_timeout.true' => -> { fr('').enable_functions_on_timeout },
+  'functions_on_speaker_timeout.false' => -> { fr('').enable_functions_on_timeout(false) },
 
   # ---- extensive_data -----------------------------------------------------
-  'extensive_data.true' => -> { fr("").enable_extensive_data },
-  'extensive_data.false' => -> { fr("").enable_extensive_data(false) },
+  'extensive_data.true' => -> { fr('').enable_extensive_data },
+  'extensive_data.false' => -> { fr('').enable_extensive_data(false) },
 
   # ---- replace_in_history (str + bool branches) --------------------------
-  'replace_in_history.bool' => -> { fr("").replace_in_history },
-  'replace_in_history.str' => -> { fr("").replace_in_history("Summarized the order.") },
+  'replace_in_history.bool' => -> { fr('').replace_in_history },
+  'replace_in_history.str' => -> { fr('').replace_in_history('Summarized the order.') },
 
   # ---- settings -----------------------------------------------------------
-  'settings' => -> { fr("").update_settings({ "temperature" => 0.7, "max-tokens" => 256, "top-p" => 0.9 }) },
+  'settings' => -> { fr('').update_settings({ 'temperature' => 0.7, 'max-tokens' => 256, 'top-p' => 0.9 }) },
 
   # ---- speech timeouts ----------------------------------------------------
-  'end_of_speech_timeout' => -> { fr("").set_end_of_speech_timeout(800) },
-  'speech_event_timeout' => -> { fr("").set_speech_event_timeout(1200) },
+  'end_of_speech_timeout' => -> { fr('').set_end_of_speech_timeout(800) },
+  'speech_event_timeout' => -> { fr('').set_speech_event_timeout(1200) },
 
   # ---- execute_swml (dict + JSON-string + transfer) ----------------------
   'execute_swml.dict' => lambda {
-    fr("").execute_swml({ "version" => "1.0.0", "sections" => { "main" => [{ "answer" => {} }] } })
+    fr('').execute_swml({ 'version' => '1.0.0', 'sections' => { 'main' => [{ 'answer' => {} }] } })
   },
   'execute_swml.dict_transfer' => lambda {
-    fr("").execute_swml({ "version" => "1.0.0", "sections" => { "main" => [{ "answer" => {} }] } }, transfer: true)
+    fr('').execute_swml({ 'version' => '1.0.0', 'sections' => { 'main' => [{ 'answer' => {} }] } }, transfer: true)
   },
   'execute_swml.json_string' => lambda {
-    fr("").execute_swml('{"version": "1.0.0", "sections": {"main": [{"hangup": {}}]}}')
+    fr('').execute_swml('{"version": "1.0.0", "sections": {"main": [{"hangup": {}}]}}')
   }
 }.freeze
 

--- a/bin/emit-skills
+++ b/bin/emit-skills
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) 2025 SignalWire
+#
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+
+#
+# emit-skills — the Ruby port's SKILL-DUMP program for the cross-port
+# SKILL-CONTRACT differ (porting-sdk/scripts/diff_skill_contracts.py).
+#
+# The sibling of bin/emit-corpus, for built-in SKILLS rather than
+# FunctionResult. For each covered skill it looks up the skill's factory in the
+# registry, instantiates it with the canonical config from the shared corpus
+# (porting-sdk/scripts/skill_contract_corpus.py — the single source of truth),
+# runs setup + register_tools, and prints ONE JSON object mapping
+#
+#   skill-id -> [ { "name": ..., "parameters": {...} }, ... ]
+#
+# to stdout. The differ runs this program, parses that object, and structurally
+# compares each skill's tool contract against the Python reference (which
+# registers the same tools). The differ normalises both sides (flat vs wrapped
+# params, required list, enum order); this program emits each tool's :name +
+# :parameters verbatim. DESCRIPTIONS are not part of the compared contract.
+# Mirrors the Go reference dump (signalwire-go/cmd/emit-skills/main.go).
+#
+# CONTRACT (mirrors the per-port dump contract in the differ's --help):
+#   - The id set MUST equal corpus_ids() (the differ rejects a mismatch).
+#   - Only stdout carries the JSON object; all logs/errors go to stderr.
+#
+# Run from the signalwire-ruby repo root:
+#
+#   bin/emit-skills      (or:  ruby bin/emit-skills)
+
+require 'json'
+require 'open3'
+require_relative '../lib/signalwire'
+
+# Locate porting-sdk/scripts/skill_contract_corpus.py via $PORTING_SDK /
+# $PORTING_SDK_PATH or the sibling ../porting-sdk (the adjacency convention),
+# run it, and return its CORPUS array (each entry {id, skill, config}).
+def load_corpus
+  corpus_search_bases.each do |base|
+    script = File.join(base, 'scripts', 'skill_contract_corpus.py')
+    next unless File.exist?(script)
+
+    out, status = Open3.capture2('python3', script)
+    raise "running #{script} failed (exit #{status.exitstatus})" unless status.success?
+
+    return JSON.parse(out).fetch('corpus')
+  end
+  raise 'cannot locate porting-sdk/scripts/skill_contract_corpus.py ' \
+        '(set PORTING_SDK / PORTING_SDK_PATH or clone porting-sdk adjacent)'
+end
+
+# porting-sdk roots to probe, in order: explicit env overrides, then the
+# sibling ../porting-sdk adjacency convention.
+def corpus_search_bases
+  [ENV.fetch('PORTING_SDK', nil), ENV.fetch('PORTING_SDK_PATH', nil)].compact +
+    [File.expand_path('../../porting-sdk', __dir__)]
+end
+
+# Instantiate one covered skill with the corpus config, run its lifecycle, and
+# return the list of {name, parameters} contracts it registers.
+def contracts_for(entry)
+  skill_name = entry.fetch('skill')
+  config     = entry.fetch('config', {})
+
+  factory = SignalWire::Skills::SkillRegistry.get_factory(skill_name)
+  raise "no registered factory for covered skill #{skill_name.inspect}" if factory.nil?
+
+  # Every builtin factory block takes a single `params` hash (arity 1) and
+  # constructs the skill with no agent — the corpus config IS that params hash.
+  # No agent is needed to enumerate tool contracts.
+  skill = factory.call(config)
+
+  unless skill.setup
+    raise "skill #{skill_name.inspect} setup returned false with the corpus " \
+          'config — config drift between the corpus and the port.'
+  end
+
+  Array(skill.register_tools).map { |tool| tool_contract(tool) }
+end
+
+# Normalise one registered tool to the {name, parameters, required} contract the
+# differ compares. Skills register tools in one of two shapes:
+#   * handler tool  — { name:, description:, parameters:, required?:, handler: }
+#     where `parameters` is the flat {param => {type, ...}} map and `required` is
+#     an optional separate list (mirrors agent define_tool(parameters:, required:)).
+#   * DataMap tool  — { datamap: <serialized SWAIG function Hash> }, where the
+#     name lives under "function" and the WRAPPED param schema (with its own
+#     `required` array) under "parameters".
+# The differ doesn't care which implementation a skill uses — only
+# name/param-name/param-type/enum/required. It reads `required` either from the
+# wrapped schema or from this top-level key, so forward it for handler tools.
+def tool_contract(tool)
+  if tool.key?(:datamap)
+    dm = tool.fetch(:datamap)
+    { 'name' => dm.fetch('function'), 'parameters' => dm['parameters'] || {} }
+  else
+    contract = { 'name' => tool.fetch(:name), 'parameters' => tool[:parameters] || {} }
+    contract['required'] = Array(tool[:required]) if tool[:required]
+    contract
+  end
+end
+
+def main
+  # Ensure all built-in skill factories are registered before lookup.
+  SignalWire::Skills::SkillRegistry.register_builtins!
+
+  result = load_corpus.to_h { |entry| [entry.fetch('id'), contracts_for(entry)] }
+
+  puts JSON.generate(result)
+rescue StandardError => e
+  warn "emit-skills: #{e.message}"
+  exit 1
+end
+
+main if __FILE__ == $PROGRAM_NAME

--- a/bin/swaig-test
+++ b/bin/swaig-test
@@ -71,7 +71,7 @@ module SwaigTest
   # a shell session) never inherit leaked state.
   module RuntimeEnvIsolation
     def self.snapshot(keys = LAMBDA_SIMULATION_ENV_VARS)
-      keys.each_with_object({}) { |k, h| h[k] = ENV.fetch(k, nil) }
+      keys.to_h { |k| [k, ENV.fetch(k, nil)] }
     end
 
     def self.restore(snapshot)
@@ -245,7 +245,7 @@ module SwaigTest
       # ourselves against it.
       if @agent.respond_to?(:get_basic_auth_credentials)
         user, pass = @agent.get_basic_auth_credentials
-        return 'Basic ' + ["#{user}:#{pass}"].pack('m0').chomp if user && pass
+        return "Basic #{["#{user}:#{pass}"].pack('m0').chomp}" if user && pass
       end
       nil
     end
@@ -387,8 +387,8 @@ module SwaigTest
         exit 1
       end
 
-      actions = [@options[:dump_swml], @options[:list_tools], !!@options[:exec]].count(true)
-      if actions == 0
+      actions = action_count
+      if actions.zero?
         warn 'Error: specify one of --dump-swml, --list-tools, or --exec NAME'
         exit 1
       elsif actions > 1
@@ -459,11 +459,16 @@ module SwaigTest
         exit 1
       end
 
-      actions = [@options[:dump_swml], @options[:list_tools], !!@options[:exec]].count(true)
-      return unless actions > 1
+      return unless action_count > 1
 
       warn 'Error: specify at most one of --dump-swml, --list-tools, or --exec NAME'
       exit 1
+    end
+
+    # Number of mutually-exclusive output actions requested (--dump-swml,
+    # --list-tools, --exec). Used by the validators to enforce "exactly one".
+    def action_count
+      [@options[:dump_swml], @options[:list_tools], @options[:exec]].count { |v| v }
     end
 
     def parse_param_value(value)
@@ -492,7 +497,7 @@ module SwaigTest
       pass = parsed_uri.password
       return unless user && pass
 
-      'Basic ' + ["#{URI.decode_www_form_component(user)}:#{URI.decode_www_form_component(pass)}"].pack('m0')
+      "Basic #{["#{URI.decode_www_form_component(user)}:#{URI.decode_www_form_component(pass)}"].pack('m0')}"
     end
 
     def make_request(method, path, body: nil)
@@ -813,16 +818,15 @@ module SwaigTest
         service_subclass?(c, service_class) && !pre_existing.include?(c)
       end
 
-      # Sort by class name so output is deterministic when a file defines
-      # multiple subclasses; users can disambiguate by setting `SERVICE`.
-      candidate = newly_defined.sort_by { |c| c.name.to_s }.last
+      # Pick the highest class name so output is deterministic when a file
+      # defines multiple subclasses; users can disambiguate by setting `SERVICE`.
+      candidate = newly_defined.max_by { |c| c.name.to_s }
 
       # Fallback: if no NEW subclass was defined (e.g. running the same
       # file twice in the same process), pick any user subclass.
       candidate ||= ObjectSpace.each_object(Class)
                                .select { |c| service_subclass?(c, service_class) }
-                               .sort_by { |c| c.name.to_s }
-                               .last
+                               .max_by { |c| c.name.to_s }
 
       return nil unless candidate
 

--- a/bin/swaig-test
+++ b/bin/swaig-test
@@ -114,30 +114,10 @@ module SwaigTest
       return if @active
 
       @snapshot = RuntimeEnvIsolation.snapshot
-
-      # Clear conflicting env vars BEFORE applying presets so that a
-      # SWML_PROXY_URL_BASE set in the outer shell can't override the
-      # platform-derived base URL during the simulation.
-      ENV.delete('SWML_PROXY_URL_BASE')
-
-      preset_for_platform.each { |k, v| ENV[k] = v }
-      @overrides.each { |k, v| ENV[k] = v }
-
-      # Match Python: warn if SWML_PROXY_URL_BASE somehow survived (e.g.
-      # an override re-set it). A live warning here is far cheaper than
-      # silently generating the wrong webhook URLs.
-      if ENV['SWML_PROXY_URL_BASE'] && !ENV['SWML_PROXY_URL_BASE'].empty?
-        @io.puts "WARNING: SWML_PROXY_URL_BASE still set after simulation clear: #{ENV['SWML_PROXY_URL_BASE'].inspect}"
-      end
-
+      apply_environment
+      warn_if_proxy_base_survived
       @active = true
-
-      return unless @verbose
-
-      @io.puts "Activated #{@platform} environment simulation"
-      preset_for_platform.each_key do |k|
-        @io.puts "  #{k}: #{ENV.fetch(k, nil)}"
-      end
+      log_activation if @verbose
     end
 
     def deactivate
@@ -160,11 +140,99 @@ module SwaigTest
 
     private
 
+    def apply_environment
+      # Clear conflicting env vars BEFORE applying presets so that a
+      # SWML_PROXY_URL_BASE set in the outer shell can't override the
+      # platform-derived base URL during the simulation.
+      ENV.delete('SWML_PROXY_URL_BASE')
+
+      preset_for_platform.each { |k, v| ENV[k] = v }
+      @overrides.each { |k, v| ENV[k] = v }
+    end
+
+    def warn_if_proxy_base_survived
+      # Match Python: warn if SWML_PROXY_URL_BASE somehow survived (e.g.
+      # an override re-set it). A live warning here is far cheaper than
+      # silently generating the wrong webhook URLs.
+      return unless ENV['SWML_PROXY_URL_BASE'] && !ENV['SWML_PROXY_URL_BASE'].empty?
+
+      @io.puts "WARNING: SWML_PROXY_URL_BASE still set after simulation clear: #{ENV['SWML_PROXY_URL_BASE'].inspect}"
+    end
+
+    def log_activation
+      @io.puts "Activated #{@platform} environment simulation"
+      preset_for_platform.each_key do |k|
+        @io.puts "  #{k}: #{ENV.fetch(k, nil)}"
+      end
+    end
+
     def preset_for_platform
       case @platform
       when 'lambda' then LAMBDA_PRESETS
       else {} # unreachable — validated in CLI
       end
+    end
+  end
+
+  # Builds synthetic Lambda Function URL event hashes (the shape the
+  # SignalWire::Serverless::LambdaHandler expects). Stateless apart from the
+  # basic-auth header it injects into authenticated routes.
+  class LambdaEventBuilder
+    def initialize(auth_header)
+      @auth_header = auth_header
+    end
+
+    def build(method, path, body: nil, headers: nil)
+      base_headers = default_event_headers
+      base_headers.merge!(headers) if headers
+      apply_default_auth(base_headers, path)
+      assemble_event(method, path, base_headers, body)
+    end
+
+    private
+
+    def default_event_headers
+      { 'host' => default_host }
+    end
+
+    def default_host
+      from_url = ENV['AWS_LAMBDA_FUNCTION_URL']&.then { |u| URI.parse(u).host }
+      from_url ||
+        "#{ENV.fetch('AWS_LAMBDA_FUNCTION_NAME', nil)}.lambda-url.#{ENV.fetch('AWS_REGION', nil)}.on.aws"
+    end
+
+    def apply_default_auth(base_headers, path)
+      # Ensure auth is present for authenticated endpoints (SWML, swaig).
+      return if base_headers.key?('authorization') || path == '/health' || path == '/ready'
+
+      base_headers['authorization'] = @auth_header if @auth_header
+    end
+
+    def assemble_event(method, path, base_headers, body)
+      event = base_event(method, path, base_headers)
+      if body
+        event['body']            = body
+        event['isBase64Encoded'] = false
+      end
+      event
+    end
+
+    def base_event(method, path, base_headers)
+      {
+        'version' => '2.0',
+        'routeKey' => '$default',
+        'rawPath' => path,
+        'rawQueryString' => '',
+        'headers' => base_headers,
+        'requestContext' => request_context(method, path)
+      }
+    end
+
+    def request_context(method, path)
+      {
+        'http' => { 'method' => method, 'path' => path, 'protocol' => 'HTTP/1.1' },
+        'stage' => '$default'
+      }
     end
   end
 
@@ -181,7 +249,7 @@ module SwaigTest
     # parsed hash (the SWML document). Raises RuntimeError on non-2xx.
     def dump_swml
       route   = @agent.route == '/' ? '/' : @agent.route
-      event   = build_event('GET', route)
+      event   = event_builder.build('GET', route)
       resp    = @handler.call(event, nil)
       ensure_success!(resp, "dump-swml GET #{route}")
       decode_body(resp)
@@ -192,15 +260,8 @@ module SwaigTest
     def exec_tool(func_name, params)
       route = @agent.route == '/' ? '' : @agent.route
       path  = "#{route}/swaig"
-      body  = JSON.generate(
-        'function' => func_name,
-        'argument' => { 'parsed' => [params || {}] }
-      )
-      auth = basic_auth_header
-      headers = { 'content-type' => 'application/json' }
-      headers['authorization'] = auth if auth
-
-      event = build_event('POST', path, body: body, headers: headers)
+      body  = exec_body(func_name, params)
+      event = event_builder.build('POST', path, body: body, headers: exec_headers)
       resp  = @handler.call(event, nil)
       ensure_success!(resp, "exec POST #{path}")
       decode_body(resp)
@@ -208,35 +269,22 @@ module SwaigTest
 
     private
 
-    def build_event(method, path, body: nil, headers: nil)
-      base_headers = {
-        'host' => ENV['AWS_LAMBDA_FUNCTION_URL']&.then { |u| URI.parse(u).host } ||
-                  "#{ENV.fetch('AWS_LAMBDA_FUNCTION_NAME', nil)}.lambda-url.#{ENV.fetch('AWS_REGION', nil)}.on.aws"
-      }
-      base_headers.merge!(headers) if headers
+    def event_builder
+      @event_builder ||= LambdaEventBuilder.new(basic_auth_header)
+    end
 
-      # Ensure auth is present for authenticated endpoints (SWML, swaig).
-      unless base_headers.key?('authorization') || path == '/health' || path == '/ready'
-        auth = basic_auth_header
-        base_headers['authorization'] = auth if auth
-      end
+    def exec_body(func_name, params)
+      JSON.generate(
+        'function' => func_name,
+        'argument' => { 'parsed' => [params || {}] }
+      )
+    end
 
-      event = {
-        'version' => '2.0',
-        'routeKey' => '$default',
-        'rawPath' => path,
-        'rawQueryString' => '',
-        'headers' => base_headers,
-        'requestContext' => {
-          'http' => { 'method' => method, 'path' => path, 'protocol' => 'HTTP/1.1' },
-          'stage' => '$default'
-        }
-      }
-      if body
-        event['body']            = body
-        event['isBase64Encoded'] = false
-      end
-      event
+    def exec_headers
+      auth = basic_auth_header
+      headers = { 'content-type' => 'application/json' }
+      headers['authorization'] = auth if auth
+      headers
     end
 
     def basic_auth_header
@@ -264,223 +312,95 @@ module SwaigTest
     end
   end
 
-  class CLI
-    attr_reader :options
+  # Pure helpers for pulling SWAIG function definitions out of a rendered
+  # SWML document and rendering them for the user. No I/O state beyond
+  # writing to stdout via puts.
+  module SwmlFunctions
+    module_function
 
-    def initialize(argv = ARGV)
-      @options = {
-        url: nil,
-        agent_file: nil,
-        file: nil,
-        simulate_serverless: nil,
-        dump_swml: false,
-        list_tools: false,
-        exec: nil,
-        params: {},
-        raw: false,
-        verbose: false
-      }
-      parse_options(argv)
+    def extract_functions(swml)
+      sections = swml['sections'] || {}
+      main = sections['main'] || []
+      main.flat_map { |verb| functions_in_verb(verb) }
     end
 
-    def run
-      validate_options!
+    def functions_in_verb(verb)
+      return [] unless verb.is_a?(Hash) && verb.key?('ai')
 
-      if @options[:file]
-        run_in_process_file_mode
-      elsif @options[:simulate_serverless]
-        run_simulated_serverless
-      elsif @options[:dump_swml]
-        dump_swml
-      elsif @options[:list_tools]
-        list_tools
-      elsif @options[:exec]
-        exec_function
+      swaig = verb['ai']['SWAIG'] || {}
+      swaig['functions'] || []
+    end
+
+    # Accepts either JSON-Schema-shaped `{type:object, properties:{...}}` or
+    # the raw flat shape SWML::Service stores (`{name => {type, description}}`).
+    # Returns [properties_hash, required_array].
+    def extract_param_properties(params)
+      return [{}, []] unless params.is_a?(Hash)
+
+      if params['properties'].is_a?(Hash)
+        [params['properties'], Array(params['required']).map(&:to_s)]
+      elsif params['type'] == 'object'
+        [{}, []]
       else
-        warn 'Error: specify --dump-swml, --list-tools, or --exec NAME'
-        exit 1
+        # Flat shape — keys are parameter names, values are schema fragments.
+        [params.transform_keys(&:to_s), []]
       end
+    end
+
+    def render_functions_list(functions)
+      if functions.empty?
+        puts 'No SWAIG functions found.'
+        return
+      end
+      puts 'SWAIG Functions:'
+      puts '-' * 60
+      functions.each { |func| print_function(func) }
+    end
+
+    def print_function(func)
+      name = func['function'] || '(unnamed)'
+      desc = func['description'] || '(no description)'
+      puts "  #{name}"
+      puts "    #{desc}"
+
+      properties, required = extract_param_properties(func['parameters'])
+      print_function_parameters(properties, required) unless properties.empty?
+      puts ''
+    end
+
+    def print_function_parameters(properties, required)
+      puts '    Parameters:'
+      properties.each do |pname, pdef|
+        ptype = (pdef.is_a?(Hash) ? pdef['type'] : nil) || 'any'
+        pdesc = (pdef.is_a?(Hash) ? pdef['description'] : nil) || ''
+        req_marker = required.include?(pname.to_s) ? ' (required)' : ''
+        puts "      - #{pname}: #{ptype}#{req_marker} #{pdesc}".rstrip
+      end
+    end
+  end
+
+  # Transport layer for URL mode: turns (method, path, body) into a live
+  # Net::HTTP request against the configured --url, including auth derived
+  # from the URL's embedded credentials and optional verbose logging.
+  class HttpClient
+    def initialize(options)
+      @options = options
+    end
+
+    def request(method, path, body: nil)
+      uri = build_uri(path)
+      log_request(method, uri, body) if @options[:verbose]
+
+      http = build_http(uri)
+      req = build_request(method, uri, body)
+      req['Authorization'] = auth_header if auth_header
+
+      response = http.request(req)
+      log_response(response) if @options[:verbose]
+      response
     end
 
     private
-
-    def parse_options(argv)
-      parser = OptionParser.new do |opts|
-        opts.banner = 'Usage: swaig-test [agent_file] [options]'
-
-        opts.on('--url URL', 'Agent URL with embedded auth (http://user:pass@host:port/route)') do |v|
-          @options[:url] = v
-        end
-
-        opts.on('--simulate-serverless PLATFORM',
-                "Simulate the named serverless platform (loads agent file locally). Supported: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}") do |v|
-          @options[:simulate_serverless] = v
-        end
-
-        opts.on('--file PATH', '--example PATH',
-                'Load a SWML::Service subclass from PATH in-process and read its tool registry directly (no HTTP, no simulator). Required for --list-tools on a non-AgentBase Service.') do |v|
-          @options[:file] = v
-        end
-
-        opts.on('--dump-swml', 'GET SWML document and pretty-print it') do
-          @options[:dump_swml] = true
-        end
-
-        opts.on('--list-tools', 'List available SWAIG functions') do
-          @options[:list_tools] = true
-        end
-
-        opts.on('--exec NAME', 'Execute a SWAIG function by name') do |v|
-          @options[:exec] = v
-        end
-
-        opts.on('--param KEY=VALUE', 'Set a parameter (repeatable)') do |v|
-          key, value = v.split('=', 2)
-          if key && value
-            @options[:params][key] = parse_param_value(value)
-          else
-            warn "Warning: ignoring malformed --param '#{v}' (expected key=value)"
-          end
-        end
-
-        opts.on('--raw', 'Output compact JSON instead of pretty-printed') do
-          @options[:raw] = true
-        end
-
-        opts.on('--verbose', 'Show request/response details') do
-          @options[:verbose] = true
-        end
-
-        opts.on('-h', '--help', 'Show this help') do
-          puts opts
-          exit 0
-        end
-      end
-
-      remaining = parser.parse(argv)
-
-      # Any leftover positional argument is treated as an agent source
-      # file path. This is the only way to invoke file mode, so we keep
-      # it outside of validate_options! for clearer error messages.
-      if remaining.length > 1
-        warn "Error: at most one positional agent file may be given; got #{remaining.inspect}"
-        exit 1
-      elsif remaining.length == 1
-        @options[:agent_file] = remaining.first
-      end
-    end
-
-    def validate_options!
-      if @options[:file]
-        validate_file_mode_options!
-        return
-      end
-
-      if @options[:simulate_serverless]
-        validate_simulate_serverless_options!
-        return
-      end
-
-      # Classic URL mode from here down.
-      unless @options[:url]
-        warn 'Error: --url is required (or pass --file PATH for in-process file mode, or pass an agent file with --simulate-serverless PLATFORM)'
-        exit 1
-      end
-
-      actions = action_count
-      if actions.zero?
-        warn 'Error: specify one of --dump-swml, --list-tools, or --exec NAME'
-        exit 1
-      elsif actions > 1
-        warn 'Error: specify only one of --dump-swml, --list-tools, or --exec NAME'
-        exit 1
-      end
-    end
-
-    def validate_file_mode_options!
-      # In-process file mode is currently scoped to listing tools off the
-      # runtime registry, since that is the gap on non-AgentBase services.
-      # URL/simulator combinations are rejected to avoid ambiguous dispatch.
-      if @options[:url]
-        warn 'Error: --file and --url are mutually exclusive'
-        exit 1
-      end
-
-      if @options[:simulate_serverless]
-        warn 'Error: --file and --simulate-serverless are mutually exclusive'
-        exit 1
-      end
-
-      unless File.exist?(@options[:file])
-        warn "Error: file not found: #{@options[:file]}"
-        exit 1
-      end
-
-      unless @options[:list_tools]
-        warn 'Error: --file mode currently supports only --list-tools'
-        exit 1
-      end
-
-      return unless @options[:dump_swml] || @options[:exec]
-
-      warn 'Error: --file mode does not support --dump-swml or --exec (use --url or --simulate-serverless lambda for those)'
-      exit 1
-    end
-
-    def validate_simulate_serverless_options!
-      platform = @options[:simulate_serverless]
-
-      unless IMPLEMENTED_SERVERLESS_PLATFORMS.include?(platform)
-        if RECOGNISED_SERVERLESS_PLATFORMS.include?(platform)
-          warn "Error: --simulate-serverless #{platform.inspect} is not implemented in this SDK yet."
-          warn "       Phase 9 (serverless support) has only shipped for: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}."
-          warn "       Add the #{platform} handler adapter before enabling it here."
-        else
-          warn "Error: unknown serverless platform #{platform.inspect}."
-          warn "       Supported: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}."
-        end
-        exit 1
-      end
-
-      unless @options[:agent_file]
-        warn 'Error: --simulate-serverless requires a positional agent file argument'
-        warn "Usage: swaig-test AGENT_FILE --simulate-serverless #{platform} [--dump-swml | --exec NAME]"
-        exit 1
-      end
-
-      unless File.exist?(@options[:agent_file])
-        warn "Error: agent file not found: #{@options[:agent_file]}"
-        exit 1
-      end
-
-      # Simulated mode cannot combine with --url (different dispatch paths).
-      if @options[:url]
-        warn 'Error: --simulate-serverless and --url are mutually exclusive'
-        exit 1
-      end
-
-      return unless action_count > 1
-
-      warn 'Error: specify at most one of --dump-swml, --list-tools, or --exec NAME'
-      exit 1
-    end
-
-    # Number of mutually-exclusive output actions requested (--dump-swml,
-    # --list-tools, --exec). Used by the validators to enforce "exactly one".
-    def action_count
-      [@options[:dump_swml], @options[:list_tools], @options[:exec]].count { |v| v }
-    end
-
-    def parse_param_value(value)
-      case value
-      when 'true'  then true
-      when 'false' then false
-      when 'null', 'nil' then nil
-      when /\A-?\d+\z/ then value.to_i
-      when /\A-?\d+\.\d+\z/ then value.to_f
-      else value
-      end
-    end
 
     def parsed_uri
       @parsed_uri ||= URI.parse(@options[:url])
@@ -500,7 +420,7 @@ module SwaigTest
       "Basic #{["#{URI.decode_www_form_component(user)}:#{URI.decode_www_form_component(pass)}"].pack('m0')}"
     end
 
-    def make_request(method, path, body: nil)
+    def build_uri(path)
       full_path = base_path == '/' ? path : "#{base_path}#{path}"
       full_path = '/' if full_path.empty?
 
@@ -508,59 +428,56 @@ module SwaigTest
       uri.path = full_path
       uri.user = nil
       uri.password = nil
+      uri
+    end
 
-      if @options[:verbose]
-        warn ">> #{method.upcase} #{uri}"
-        warn '>> Authorization: Basic <redacted>' if auth_header
-        if body
-          warn '>> Content-Type: application/json'
-          warn ">> Body: #{body}"
-        end
-        warn ''
-      end
-
+    def build_http(uri)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = (uri.scheme == 'https')
       http.open_timeout = 10
       http.read_timeout = 30
+      http
+    end
 
+    def build_request(method, uri, body)
       if method == :get
-        req = Net::HTTP::Get.new(uri.request_uri)
+        Net::HTTP::Get.new(uri.request_uri)
       else
         req = Net::HTTP::Post.new(uri.request_uri)
         req.body = body
         req['Content-Type'] = 'application/json'
+        req
       end
-
-      req['Authorization'] = auth_header if auth_header
-
-      response = http.request(req)
-
-      if @options[:verbose]
-        warn "<< HTTP #{response.code} #{response.message}"
-        response.each_header { |k, v| warn "<< #{k}: #{v}" }
-        warn ''
-      end
-
-      response
     end
 
-    def format_json(data)
-      if @options[:raw]
-        JSON.generate(data)
-      else
-        JSON.pretty_generate(data)
+    def log_request(method, uri, body)
+      warn ">> #{method.upcase} #{uri}"
+      warn '>> Authorization: Basic <redacted>' if auth_header
+      if body
+        warn '>> Content-Type: application/json'
+        warn ">> Body: #{body}"
       end
+      warn ''
+    end
+
+    def log_response(response)
+      warn "<< HTTP #{response.code} #{response.message}"
+      response.each_header { |k, v| warn "<< #{k}: #{v}" }
+      warn ''
+    end
+  end
+
+  # URL mode: speaks HTTP to a live agent endpoint. Owns request building,
+  # response decoding, and the dump/list/exec actions over the wire.
+  class HttpInvoker
+    def initialize(options)
+      @options = options
+      @client  = HttpClient.new(options)
     end
 
     def dump_swml
       response = make_request(:get, '/')
-
-      unless response.is_a?(Net::HTTPSuccess)
-        warn "Error: HTTP #{response.code} #{response.message}"
-        warn response.body if @options[:verbose]
-        exit 1
-      end
+      handle_error_response(response) { |r| warn r.body if @options[:verbose] }
 
       data = JSON.parse(response.body)
       puts format_json(data)
@@ -572,69 +489,19 @@ module SwaigTest
 
     def list_tools
       response = make_request(:get, '/')
-
-      unless response.is_a?(Net::HTTPSuccess)
-        warn "Error: HTTP #{response.code} #{response.message}"
-        exit 1
-      end
+      handle_error_response(response)
 
       swml = JSON.parse(response.body)
-      functions = extract_functions(swml)
-
-      if functions.empty?
-        puts 'No SWAIG functions found.'
-        return
-      end
-
-      puts 'SWAIG Functions:'
-      puts '-' * 60
-      functions.each do |func|
-        name = func['function'] || '(unnamed)'
-        desc = func['description'] || '(no description)'
-        puts "  #{name}"
-        puts "    #{desc}"
-
-        params = func['parameters']
-        if params.is_a?(Hash) && params['properties'].is_a?(Hash) && !params['properties'].empty?
-          puts '    Parameters:'
-          params['properties'].each do |pname, pdef|
-            ptype = begin
-              pdef['type'] || 'any'
-            rescue StandardError
-              'any'
-            end
-            pdesc = begin
-              pdef['description'] || ''
-            rescue StandardError
-              ''
-            end
-            required = (params['required'] || []).include?(pname) ? ' (required)' : ''
-            puts "      - #{pname}: #{ptype}#{required} #{pdesc}"
-          end
-        end
-        puts ''
-      end
+      SwmlFunctions.render_functions_list(SwmlFunctions.extract_functions(swml))
     rescue JSON::ParserError => e
       warn "Error: invalid JSON response: #{e.message}"
       exit 1
     end
 
     def exec_function
-      func_name = @options[:exec]
-      payload = {
-        'function' => func_name,
-        'argument' => {
-          'parsed' => [@options[:params]]
-        }
-      }
-
+      payload = exec_payload(@options[:exec])
       response = make_request(:post, '/swaig', body: JSON.generate(payload))
-
-      unless response.is_a?(Net::HTTPSuccess)
-        warn "Error: HTTP #{response.code} #{response.message}"
-        warn response.body if @options[:verbose]
-        exit 1
-      end
+      handle_error_response(response) { |r| warn r.body if @options[:verbose] }
 
       data = JSON.parse(response.body)
       puts format_json(data)
@@ -643,150 +510,44 @@ module SwaigTest
       exit 1
     end
 
-    def extract_functions(swml)
-      functions = []
-
-      # Navigate the SWML structure to find AI → SWAIG → functions
-      sections = swml['sections'] || {}
-      main = sections['main'] || []
-
-      main.each do |verb|
-        next unless verb.is_a?(Hash) && verb.key?('ai')
-
-        ai = verb['ai']
-        swaig = ai['SWAIG'] || {}
-        funcs = swaig['functions'] || []
-        functions.concat(funcs)
-      end
-
-      functions
-    end
-
-    # --------------------------------------------------------------
-    # --simulate-serverless ... dispatch
-    # --------------------------------------------------------------
-
-    def run_simulated_serverless
-      require 'signalwire'
-
-      simulator = ServerlessSimulator.new(
-        @options[:simulate_serverless],
-        verbose: @options[:verbose]
-      )
-
-      simulator.with_simulation do
-        agent = load_agent_file(@options[:agent_file])
-        unless agent
-          warn "Error: agent file #{@options[:agent_file].inspect} did not expose an AGENT constant (expected SignalWire::AgentBase)."
-          exit 1
-        end
-
-        dispatcher = LambdaAdapterDispatcher.new(agent)
-
-        if @options[:dump_swml]
-          puts format_json(dispatcher.dump_swml)
-        elsif @options[:exec]
-          puts format_json(dispatcher.exec_tool(@options[:exec], @options[:params]))
-        elsif @options[:list_tools]
-          swml = dispatcher.dump_swml
-          render_functions_list(extract_functions(swml))
-        else
-          # No sub-action: render the SWML and print it (matches the porting-guide
-          # "render SWML and exit" default).
-          puts format_json(dispatcher.dump_swml)
-        end
-      end
-    end
-
-    def load_agent_file(path)
-      # Use load rather than require so repeated CLI invocations in the
-      # same process (tests) don't silently no-op.
-      absolute = File.expand_path(path)
-      load(absolute)
-
-      # Preferred convention: the agent file defines a top-level
-      # constant named AGENT. Fall back to any SignalWire::AgentBase
-      # instance at top-level for forgiveness.
-      if Object.const_defined?(:AGENT)
-        candidate = Object.const_get(:AGENT)
-        return candidate if candidate.is_a?(SignalWire::AgentBase)
-      end
-
-      Object.constants.each do |c|
-        next if c == :AGENT
-
-        value = Object.const_get(c)
-        return value if value.is_a?(SignalWire::AgentBase)
-      end
-
-      nil
-    end
-
-    def render_functions_list(functions)
-      if functions.empty?
-        puts 'No SWAIG functions found.'
-        return
-      end
-      puts 'SWAIG Functions:'
-      puts '-' * 60
-      functions.each do |func|
-        name = func['function'] || '(unnamed)'
-        desc = func['description'] || '(no description)'
-        puts "  #{name}"
-        puts "    #{desc}"
-
-        properties, required = extract_param_properties(func['parameters'])
-        unless properties.empty?
-          puts '    Parameters:'
-          properties.each do |pname, pdef|
-            ptype = (pdef.is_a?(Hash) ? pdef['type'] : nil) || 'any'
-            pdesc = (pdef.is_a?(Hash) ? pdef['description'] : nil) || ''
-            req_marker = required.include?(pname.to_s) ? ' (required)' : ''
-            puts "      - #{pname}: #{ptype}#{req_marker} #{pdesc}".rstrip
-          end
-        end
-        puts ''
-      end
-    end
-
-    # Accepts either JSON-Schema-shaped `{type:object, properties:{...}}` or
-    # the raw flat shape SWML::Service stores (`{name => {type, description}}`).
-    # Returns [properties_hash, required_array].
-    def extract_param_properties(params)
-      return [{}, []] unless params.is_a?(Hash)
-
-      if params['properties'].is_a?(Hash)
-        [params['properties'], Array(params['required']).map(&:to_s)]
-      elsif params['type'] == 'object'
-        [{}, []]
+    def format_json(data)
+      if @options[:raw]
+        JSON.generate(data)
       else
-        # Flat shape — keys are parameter names, values are schema fragments.
-        [params.transform_keys(&:to_s), []]
+        JSON.pretty_generate(data)
       end
     end
 
-    # --------------------------------------------------------------
-    # --file ... --list-tools dispatch (in-process, no HTTP)
-    # --------------------------------------------------------------
-    #
-    # Loads PATH with Kernel#load (so re-loads in the same process work
-    # cleanly), discovers a `SignalWire::SWML::Service` subclass, instantiates
-    # it (or reuses a top-level instance the script already exposed), and
-    # reads the runtime tool registry directly. This is the only path that
-    # surfaces SWAIG tools registered on a non-AgentBase Service, since URL
-    # mode looks for them in rendered SWML and they aren't there for plain
-    # Service subclasses (`render_main_swml` returns the document only).
-    def run_in_process_file_mode
-      require 'signalwire'
+    private
 
-      service = load_service_from_file(@options[:file])
-      unless service
-        warn "Error: file #{@options[:file].inspect} did not expose a SignalWire::SWML::Service subclass."
-        exit 1
-      end
+    def exec_payload(func_name)
+      {
+        'function' => func_name,
+        'argument' => {
+          'parsed' => [@options[:params]]
+        }
+      }
+    end
 
-      tools = collect_runtime_tools(service)
-      render_functions_list(tools)
+    def handle_error_response(response)
+      return if response.is_a?(Net::HTTPSuccess)
+
+      warn "Error: HTTP #{response.code} #{response.message}"
+      yield response if block_given?
+      exit 1
+    end
+
+    def make_request(method, path, body: nil)
+      @client.request(method, path, body: body)
+    end
+  end
+
+  # In-process file mode: loads an agent/service script with Kernel#load,
+  # discovers the user's SWML::Service subclass, instantiates it, and reads
+  # the runtime tool registry directly (no HTTP, no simulator).
+  class ServiceLoader
+    def initialize(options)
+      @options = options
     end
 
     # Find a user-defined SWML::Service subclass and return an instance.
@@ -796,27 +557,69 @@ module SwaigTest
     #   2. The most recently defined Service subclass that ISN'T
     #      SignalWire::SWML::Service or SignalWire::AgentBase itself.
     def load_service_from_file(path)
-      absolute = File.expand_path(path)
+      service_class = SignalWire::SWML::Service
 
       # Snapshot the existing Service subclasses so we can pick the one
       # the file just defined, instead of accidentally grabbing a class
       # left over from earlier requires (e.g. AgentBase).
-      service_class = SignalWire::SWML::Service
-      pre_existing = ObjectSpace.each_object(Class).select { |c| service_subclass?(c, service_class) }.to_set
+      pre_existing = subclasses_of(service_class).to_set
 
-      load(absolute)
+      load(File.expand_path(path))
 
-      # Top-level instance fallback (some scripts assign a global).
+      resolve_service(service_class, pre_existing)
+    rescue StandardError => e
+      report_load_error(path, e)
+    end
+
+    # Read the runtime tool registry off a Service instance. Service
+    # exposes `define_tools` (the merged definition list across @tools and
+    # @swaig_functions). That's the source of truth — we use it instead
+    # of poking @tools directly so AgentBase / future subclasses that
+    # override the accessor still work.
+    def collect_runtime_tools(service)
+      if service.respond_to?(:define_tools)
+        Array(service.define_tools).map { |d| stringify_tool(d) }
+      elsif service.instance_variable_defined?(:@tools)
+        service.instance_variable_get(:@tools).values.map { |t| stringify_tool(t[:definition]) }
+      else
+        []
+      end
+    end
+
+    private
+
+    def resolve_service(service_class, pre_existing)
+      candidate = top_level_service_instance(service_class) ||
+                  select_candidate(service_class, pre_existing)
+      return candidate if candidate.is_a?(service_class)
+      return nil unless candidate
+
+      instantiate_service(candidate)
+    end
+
+    def report_load_error(path, error)
+      warn "Error loading #{path}: #{error.class}: #{error.message}"
+      warn error.backtrace.first(8).join("\n") if @options[:verbose]
+      exit 1
+    end
+
+    def subclasses_of(service_class)
+      ObjectSpace.each_object(Class).select { |c| service_subclass?(c, service_class) }
+    end
+
+    # Top-level instance fallback (some scripts assign a global).
+    def top_level_service_instance(service_class)
       %i[SERVICE AGENT].each do |name|
-        if Object.const_defined?(name)
-          val = Object.const_get(name)
-          return val if val.is_a?(service_class)
-        end
-      end
+        next unless Object.const_defined?(name)
 
-      newly_defined = ObjectSpace.each_object(Class).select do |c|
-        service_subclass?(c, service_class) && !pre_existing.include?(c)
+        val = Object.const_get(name)
+        return val if val.is_a?(service_class)
       end
+      nil
+    end
+
+    def select_candidate(service_class, pre_existing)
+      newly_defined = subclasses_of(service_class).reject { |c| pre_existing.include?(c) }
 
       # Pick the highest class name so output is deterministic when a file
       # defines multiple subclasses; users can disambiguate by setting `SERVICE`.
@@ -824,17 +627,7 @@ module SwaigTest
 
       # Fallback: if no NEW subclass was defined (e.g. running the same
       # file twice in the same process), pick any user subclass.
-      candidate ||= ObjectSpace.each_object(Class)
-                               .select { |c| service_subclass?(c, service_class) }
-                               .max_by { |c| c.name.to_s }
-
-      return nil unless candidate
-
-      instantiate_service(candidate)
-    rescue StandardError => e
-      warn "Error loading #{path}: #{e.class}: #{e.message}"
-      warn e.backtrace.first(8).join("\n") if @options[:verbose]
-      exit 1
+      candidate || subclasses_of(service_class).max_by { |c| c.name.to_s }
     end
 
     def service_subclass?(klass, service_class)
@@ -859,25 +652,417 @@ module SwaigTest
       end
     end
 
-    # Read the runtime tool registry off a Service instance. Service
-    # exposes `define_tools` (the merged definition list across @tools and
-    # @swaig_functions). That's the source of truth — we use it instead
-    # of poking @tools directly so AgentBase / future subclasses that
-    # override the accessor still work.
-    def collect_runtime_tools(service)
-      if service.respond_to?(:define_tools)
-        Array(service.define_tools).map { |d| stringify_tool(d) }
-      elsif service.instance_variable_defined?(:@tools)
-        service.instance_variable_get(:@tools).values.map { |t| stringify_tool(t[:definition]) }
-      else
-        []
-      end
-    end
-
     def stringify_tool(defn)
       return {} unless defn.is_a?(Hash)
 
       defn.transform_keys(&:to_s)
+    end
+  end
+
+  # Builds the OptionParser and mutates the shared options hash. Extracted
+  # from CLI so the parser definition (a long block) lives on its own.
+  class OptionsParser
+    def initialize(options)
+      @options = options
+    end
+
+    def parse(argv)
+      remaining = build_parser.parse(argv)
+      assign_positional_agent_file(remaining)
+    end
+
+    private
+
+    def build_parser
+      OptionParser.new do |opts|
+        opts.banner = 'Usage: swaig-test [agent_file] [options]'
+        register_mode_options(opts)
+        register_action_options(opts)
+        register_output_options(opts)
+      end
+    end
+
+    def register_mode_options(opts)
+      register_url_option(opts)
+      register_simulate_option(opts)
+      register_file_option(opts)
+    end
+
+    def register_url_option(opts)
+      opts.on('--url URL', 'Agent URL with embedded auth (http://user:pass@host:port/route)') do |v|
+        @options[:url] = v
+      end
+    end
+
+    def register_simulate_option(opts)
+      opts.on('--simulate-serverless PLATFORM',
+              'Simulate the named serverless platform (loads agent file locally). ' \
+              "Supported: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}") do |v|
+        @options[:simulate_serverless] = v
+      end
+    end
+
+    def register_file_option(opts)
+      opts.on('--file PATH', '--example PATH',
+              'Load a SWML::Service subclass from PATH in-process and read its tool registry ' \
+              'directly (no HTTP, no simulator). Required for --list-tools on a non-AgentBase Service.') do |v|
+        @options[:file] = v
+      end
+    end
+
+    def register_action_options(opts)
+      opts.on('--dump-swml', 'GET SWML document and pretty-print it') do
+        @options[:dump_swml] = true
+      end
+      opts.on('--list-tools', 'List available SWAIG functions') do
+        @options[:list_tools] = true
+      end
+      opts.on('--exec NAME', 'Execute a SWAIG function by name') do |v|
+        @options[:exec] = v
+      end
+    end
+
+    def register_output_options(opts)
+      opts.on('--param KEY=VALUE', 'Set a parameter (repeatable)') { |v| handle_param_flag(v) }
+      opts.on('--raw', 'Output compact JSON instead of pretty-printed') { @options[:raw] = true }
+      opts.on('--verbose', 'Show request/response details') { @options[:verbose] = true }
+      opts.on('-h', '--help', 'Show this help') do
+        puts opts
+        exit 0
+      end
+    end
+
+    def handle_param_flag(value)
+      key, val = value.split('=', 2)
+      if key && val
+        @options[:params][key] = parse_param_value(val)
+      else
+        warn "Warning: ignoring malformed --param '#{value}' (expected key=value)"
+      end
+    end
+
+    def parse_param_value(value)
+      case value
+      when 'true'  then true
+      when 'false' then false
+      when 'null', 'nil' then nil
+      when /\A-?\d+\z/ then value.to_i
+      when /\A-?\d+\.\d+\z/ then value.to_f
+      else value
+      end
+    end
+
+    def assign_positional_agent_file(remaining)
+      # Any leftover positional argument is treated as an agent source
+      # file path. This is the only way to invoke file mode, so we keep
+      # it outside of validation for clearer error messages.
+      if remaining.length > 1
+        warn "Error: at most one positional agent file may be given; got #{remaining.inspect}"
+        exit 1
+      elsif remaining.length == 1
+        @options[:agent_file] = remaining.first
+      end
+    end
+  end
+
+  # Validates the parsed options for the selected mode and exits with a
+  # mode-specific error message on any conflict. Extracted from CLI to keep
+  # the per-mode guard logic together and the CLI class small.
+  # Validates the --simulate-serverless option set. Extracted from
+  # OptionsValidator because the platform/agent-file guards form a cohesive
+  # cluster with their own error messages.
+  class SimulateServerlessValidator
+    def initialize(options)
+      @options = options
+    end
+
+    def validate!
+      platform = @options[:simulate_serverless]
+      reject_unimplemented_platform!(platform)
+      reject_missing_agent_file!(platform)
+      reject_url_conflict!
+      reject_multiple_actions!
+    end
+
+    private
+
+    def reject_unimplemented_platform!(platform)
+      return if IMPLEMENTED_SERVERLESS_PLATFORMS.include?(platform)
+
+      if RECOGNISED_SERVERLESS_PLATFORMS.include?(platform)
+        warn "Error: --simulate-serverless #{platform.inspect} is not implemented in this SDK yet."
+        warn "       Phase 9 (serverless support) has only shipped for: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}."
+        warn "       Add the #{platform} handler adapter before enabling it here."
+      else
+        warn "Error: unknown serverless platform #{platform.inspect}."
+        warn "       Supported: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}."
+      end
+      exit 1
+    end
+
+    def reject_missing_agent_file!(platform)
+      unless @options[:agent_file]
+        warn 'Error: --simulate-serverless requires a positional agent file argument'
+        warn "Usage: swaig-test AGENT_FILE --simulate-serverless #{platform} [--dump-swml | --exec NAME]"
+        exit 1
+      end
+      return if File.exist?(@options[:agent_file])
+
+      warn "Error: agent file not found: #{@options[:agent_file]}"
+      exit 1
+    end
+
+    def reject_url_conflict!
+      # Simulated mode cannot combine with --url (different dispatch paths).
+      return unless @options[:url]
+
+      warn 'Error: --simulate-serverless and --url are mutually exclusive'
+      exit 1
+    end
+
+    def reject_multiple_actions!
+      return unless action_count > 1
+
+      warn 'Error: specify at most one of --dump-swml, --list-tools, or --exec NAME'
+      exit 1
+    end
+
+    def action_count
+      [@options[:dump_swml], @options[:list_tools], @options[:exec]].count { |v| v }
+    end
+  end
+
+  class OptionsValidator
+    def initialize(options)
+      @options = options
+    end
+
+    def validate!
+      if @options[:file]
+        validate_file_mode!
+      elsif @options[:simulate_serverless]
+        validate_simulate_serverless!
+      else
+        validate_url_mode!
+      end
+    end
+
+    private
+
+    def validate_url_mode!
+      # Classic URL mode from here down.
+      unless @options[:url]
+        warn 'Error: --url is required (or pass --file PATH for in-process file mode, ' \
+             'or pass an agent file with --simulate-serverless PLATFORM)'
+        exit 1
+      end
+      reject_url_action_count!
+    end
+
+    def reject_url_action_count!
+      actions = action_count
+      if actions.zero?
+        warn 'Error: specify one of --dump-swml, --list-tools, or --exec NAME'
+        exit 1
+      elsif actions > 1
+        warn 'Error: specify only one of --dump-swml, --list-tools, or --exec NAME'
+        exit 1
+      end
+    end
+
+    def validate_file_mode!
+      # In-process file mode is currently scoped to listing tools off the
+      # runtime registry, since that is the gap on non-AgentBase services.
+      # URL/simulator combinations are rejected to avoid ambiguous dispatch.
+      reject_file_mode_conflicts!
+      reject_missing_file!
+      reject_unsupported_file_actions!
+    end
+
+    def reject_file_mode_conflicts!
+      if @options[:url]
+        warn 'Error: --file and --url are mutually exclusive'
+        exit 1
+      end
+      return unless @options[:simulate_serverless]
+
+      warn 'Error: --file and --simulate-serverless are mutually exclusive'
+      exit 1
+    end
+
+    def reject_missing_file!
+      return if File.exist?(@options[:file])
+
+      warn "Error: file not found: #{@options[:file]}"
+      exit 1
+    end
+
+    def reject_unsupported_file_actions!
+      unless @options[:list_tools]
+        warn 'Error: --file mode currently supports only --list-tools'
+        exit 1
+      end
+      return unless @options[:dump_swml] || @options[:exec]
+
+      warn 'Error: --file mode does not support --dump-swml or --exec ' \
+           '(use --url or --simulate-serverless lambda for those)'
+      exit 1
+    end
+
+    def validate_simulate_serverless!
+      SimulateServerlessValidator.new(@options).validate!
+    end
+
+    # Number of mutually-exclusive output actions requested (--dump-swml,
+    # --list-tools, --exec). Used to enforce "exactly one".
+    def action_count
+      [@options[:dump_swml], @options[:list_tools], @options[:exec]].count { |v| v }
+    end
+  end
+
+  class CLI
+    attr_reader :options
+
+    def initialize(argv = ARGV)
+      @options = default_options
+      OptionsParser.new(@options).parse(argv)
+    end
+
+    def run
+      OptionsValidator.new(@options).validate!
+
+      if @options[:file]
+        run_in_process_file_mode
+      elsif @options[:simulate_serverless]
+        run_simulated_serverless
+      else
+        run_url_mode
+      end
+    end
+
+    private
+
+    def default_options
+      {
+        url: nil, agent_file: nil, file: nil, simulate_serverless: nil,
+        dump_swml: false, list_tools: false, exec: nil,
+        params: {}, raw: false, verbose: false
+      }
+    end
+
+    def run_url_mode
+      if @options[:dump_swml]
+        http_invoker.dump_swml
+      elsif @options[:list_tools]
+        http_invoker.list_tools
+      elsif @options[:exec]
+        http_invoker.exec_function
+      else
+        warn 'Error: specify --dump-swml, --list-tools, or --exec NAME'
+        exit 1
+      end
+    end
+
+    def http_invoker
+      @http_invoker ||= HttpInvoker.new(@options)
+    end
+
+    # --------------------------------------------------------------
+    # --simulate-serverless ... dispatch
+    # --------------------------------------------------------------
+
+    def run_simulated_serverless
+      require 'signalwire'
+
+      simulator = ServerlessSimulator.new(@options[:simulate_serverless], verbose: @options[:verbose])
+      simulator.with_simulation do
+        agent = require_agent_file!
+        dispatch_simulated_action(LambdaAdapterDispatcher.new(agent))
+      end
+    end
+
+    def require_agent_file!
+      agent = load_agent_file(@options[:agent_file])
+      return agent if agent
+
+      warn "Error: agent file #{@options[:agent_file].inspect} did not expose an AGENT constant " \
+           '(expected SignalWire::AgentBase).'
+      exit 1
+    end
+
+    def dispatch_simulated_action(dispatcher)
+      if @options[:dump_swml]
+        print_json(dispatcher.dump_swml)
+      elsif @options[:exec]
+        print_json(dispatcher.exec_tool(@options[:exec], @options[:params]))
+      elsif @options[:list_tools]
+        render_dispatcher_tools(dispatcher)
+      else
+        # No sub-action: render the SWML and print it (matches the porting-guide
+        # "render SWML and exit" default).
+        print_json(dispatcher.dump_swml)
+      end
+    end
+
+    def print_json(data)
+      puts http_invoker.format_json(data)
+    end
+
+    def render_dispatcher_tools(dispatcher)
+      swml = dispatcher.dump_swml
+      SwmlFunctions.render_functions_list(SwmlFunctions.extract_functions(swml))
+    end
+
+    def load_agent_file(path)
+      # Use load rather than require so repeated CLI invocations in the
+      # same process (tests) don't silently no-op.
+      load(File.expand_path(path))
+
+      named_agent_constant || discovered_agent
+    end
+
+    def named_agent_constant
+      # Preferred convention: the agent file defines a top-level
+      # constant named AGENT. Fall back to any SignalWire::AgentBase
+      # instance at top-level for forgiveness.
+      return nil unless Object.const_defined?(:AGENT)
+
+      candidate = Object.const_get(:AGENT)
+      candidate if candidate.is_a?(SignalWire::AgentBase)
+    end
+
+    def discovered_agent
+      Object.constants.each do |c|
+        next if c == :AGENT
+
+        value = Object.const_get(c)
+        return value if value.is_a?(SignalWire::AgentBase)
+      end
+      nil
+    end
+
+    # --------------------------------------------------------------
+    # --file ... --list-tools dispatch (in-process, no HTTP)
+    # --------------------------------------------------------------
+    #
+    # Loads PATH with Kernel#load (so re-loads in the same process work
+    # cleanly), discovers a `SignalWire::SWML::Service` subclass, instantiates
+    # it (or reuses a top-level instance the script already exposed), and
+    # reads the runtime tool registry directly. This is the only path that
+    # surfaces SWAIG tools registered on a non-AgentBase Service, since URL
+    # mode looks for them in rendered SWML and they aren't there for plain
+    # Service subclasses (`render_main_swml` returns the document only).
+    def run_in_process_file_mode
+      require 'signalwire'
+
+      loader = ServiceLoader.new(@options)
+      service = loader.load_service_from_file(@options[:file])
+      unless service
+        warn "Error: file #{@options[:file].inspect} did not expose a SignalWire::SWML::Service subclass."
+        exit 1
+      end
+
+      SwmlFunctions.render_functions_list(loader.collect_runtime_tools(service))
     end
   end
 end

--- a/bin/swaig-test
+++ b/bin/swaig-test
@@ -71,7 +71,7 @@ module SwaigTest
   # a shell session) never inherit leaked state.
   module RuntimeEnvIsolation
     def self.snapshot(keys = LAMBDA_SIMULATION_ENV_VARS)
-      keys.each_with_object({}) { |k, h| h[k] = ENV[k] }
+      keys.each_with_object({}) { |k, h| h[k] = ENV.fetch(k, nil) }
     end
 
     def self.restore(snapshot)
@@ -94,9 +94,9 @@ module SwaigTest
   class ServerlessSimulator
     LAMBDA_PRESETS = {
       'AWS_LAMBDA_FUNCTION_NAME' => 'test-agent-function',
-      'LAMBDA_TASK_ROOT'         => '/var/task',
-      'AWS_REGION'               => 'us-east-1',
-      '_HANDLER'                 => 'lambda_function.handler'
+      'LAMBDA_TASK_ROOT' => '/var/task',
+      'AWS_REGION' => 'us-east-1',
+      '_HANDLER' => 'lambda_function.handler'
     }.freeze
 
     attr_reader :platform, :overrides
@@ -136,12 +136,13 @@ module SwaigTest
 
       @io.puts "Activated #{@platform} environment simulation"
       preset_for_platform.each_key do |k|
-        @io.puts "  #{k}: #{ENV[k]}"
+        @io.puts "  #{k}: #{ENV.fetch(k, nil)}"
       end
     end
 
     def deactivate
       return unless @active
+
       RuntimeEnvIsolation.restore(@snapshot) if @snapshot
       @snapshot = nil
       @active   = false
@@ -162,7 +163,7 @@ module SwaigTest
     def preset_for_platform
       case @platform
       when 'lambda' then LAMBDA_PRESETS
-      else {}  # unreachable — validated in CLI
+      else {} # unreachable — validated in CLI
       end
     end
   end
@@ -195,7 +196,7 @@ module SwaigTest
         'function' => func_name,
         'argument' => { 'parsed' => [params || {}] }
       )
-      auth  = basic_auth_header
+      auth = basic_auth_header
       headers = { 'content-type' => 'application/json' }
       headers['authorization'] = auth if auth
 
@@ -210,7 +211,7 @@ module SwaigTest
     def build_event(method, path, body: nil, headers: nil)
       base_headers = {
         'host' => ENV['AWS_LAMBDA_FUNCTION_URL']&.then { |u| URI.parse(u).host } ||
-                  "#{ENV['AWS_LAMBDA_FUNCTION_NAME']}.lambda-url.#{ENV['AWS_REGION']}.on.aws"
+                  "#{ENV.fetch('AWS_LAMBDA_FUNCTION_NAME', nil)}.lambda-url.#{ENV.fetch('AWS_REGION', nil)}.on.aws"
       }
       base_headers.merge!(headers) if headers
 
@@ -221,13 +222,13 @@ module SwaigTest
       end
 
       event = {
-        'version'        => '2.0',
-        'routeKey'       => '$default',
-        'rawPath'        => path,
+        'version' => '2.0',
+        'routeKey' => '$default',
+        'rawPath' => path,
         'rawQueryString' => '',
-        'headers'        => base_headers,
+        'headers' => base_headers,
         'requestContext' => {
-          'http'  => { 'method' => method, 'path' => path, 'protocol' => 'HTTP/1.1' },
+          'http' => { 'method' => method, 'path' => path, 'protocol' => 'HTTP/1.1' },
           'stage' => '$default'
         }
       }
@@ -244,7 +245,7 @@ module SwaigTest
       # ourselves against it.
       if @agent.respond_to?(:get_basic_auth_credentials)
         user, pass = @agent.get_basic_auth_credentials
-        return "Basic " + ["#{user}:#{pass}"].pack('m0').chomp if user && pass
+        return 'Basic ' + ["#{user}:#{pass}"].pack('m0').chomp if user && pass
       end
       nil
     end
@@ -252,6 +253,7 @@ module SwaigTest
     def ensure_success!(resp, description)
       status = resp['statusCode'].to_i
       return if status >= 200 && status < 300
+
       raise "Simulator: #{description} returned HTTP #{status}: #{resp['body']}"
     end
 
@@ -267,16 +269,16 @@ module SwaigTest
 
     def initialize(argv = ARGV)
       @options = {
-        url:                 nil,
-        agent_file:          nil,
-        file:                nil,
+        url: nil,
+        agent_file: nil,
+        file: nil,
         simulate_serverless: nil,
-        dump_swml:           false,
-        list_tools:          false,
-        exec:                nil,
-        params:              {},
-        raw:                 false,
-        verbose:             false
+        dump_swml: false,
+        list_tools: false,
+        exec: nil,
+        params: {},
+        raw: false,
+        verbose: false
       }
       parse_options(argv)
     end
@@ -295,7 +297,7 @@ module SwaigTest
       elsif @options[:exec]
         exec_function
       else
-        $stderr.puts "Error: specify --dump-swml, --list-tools, or --exec NAME"
+        warn 'Error: specify --dump-swml, --list-tools, or --exec NAME'
         exit 1
       end
     end
@@ -304,52 +306,52 @@ module SwaigTest
 
     def parse_options(argv)
       parser = OptionParser.new do |opts|
-        opts.banner = "Usage: swaig-test [agent_file] [options]"
+        opts.banner = 'Usage: swaig-test [agent_file] [options]'
 
-        opts.on("--url URL", "Agent URL with embedded auth (http://user:pass@host:port/route)") do |v|
+        opts.on('--url URL', 'Agent URL with embedded auth (http://user:pass@host:port/route)') do |v|
           @options[:url] = v
         end
 
-        opts.on("--simulate-serverless PLATFORM",
+        opts.on('--simulate-serverless PLATFORM',
                 "Simulate the named serverless platform (loads agent file locally). Supported: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}") do |v|
           @options[:simulate_serverless] = v
         end
 
-        opts.on("--file PATH", "--example PATH",
-                "Load a SWML::Service subclass from PATH in-process and read its tool registry directly (no HTTP, no simulator). Required for --list-tools on a non-AgentBase Service.") do |v|
+        opts.on('--file PATH', '--example PATH',
+                'Load a SWML::Service subclass from PATH in-process and read its tool registry directly (no HTTP, no simulator). Required for --list-tools on a non-AgentBase Service.') do |v|
           @options[:file] = v
         end
 
-        opts.on("--dump-swml", "GET SWML document and pretty-print it") do
+        opts.on('--dump-swml', 'GET SWML document and pretty-print it') do
           @options[:dump_swml] = true
         end
 
-        opts.on("--list-tools", "List available SWAIG functions") do
+        opts.on('--list-tools', 'List available SWAIG functions') do
           @options[:list_tools] = true
         end
 
-        opts.on("--exec NAME", "Execute a SWAIG function by name") do |v|
+        opts.on('--exec NAME', 'Execute a SWAIG function by name') do |v|
           @options[:exec] = v
         end
 
-        opts.on("--param KEY=VALUE", "Set a parameter (repeatable)") do |v|
+        opts.on('--param KEY=VALUE', 'Set a parameter (repeatable)') do |v|
           key, value = v.split('=', 2)
           if key && value
             @options[:params][key] = parse_param_value(value)
           else
-            $stderr.puts "Warning: ignoring malformed --param '#{v}' (expected key=value)"
+            warn "Warning: ignoring malformed --param '#{v}' (expected key=value)"
           end
         end
 
-        opts.on("--raw", "Output compact JSON instead of pretty-printed") do
+        opts.on('--raw', 'Output compact JSON instead of pretty-printed') do
           @options[:raw] = true
         end
 
-        opts.on("--verbose", "Show request/response details") do
+        opts.on('--verbose', 'Show request/response details') do
           @options[:verbose] = true
         end
 
-        opts.on("-h", "--help", "Show this help") do
+        opts.on('-h', '--help', 'Show this help') do
           puts opts
           exit 0
         end
@@ -361,7 +363,7 @@ module SwaigTest
       # file path. This is the only way to invoke file mode, so we keep
       # it outside of validate_options! for clearer error messages.
       if remaining.length > 1
-        $stderr.puts "Error: at most one positional agent file may be given; got #{remaining.inspect}"
+        warn "Error: at most one positional agent file may be given; got #{remaining.inspect}"
         exit 1
       elsif remaining.length == 1
         @options[:agent_file] = remaining.first
@@ -381,16 +383,16 @@ module SwaigTest
 
       # Classic URL mode from here down.
       unless @options[:url]
-        $stderr.puts "Error: --url is required (or pass --file PATH for in-process file mode, or pass an agent file with --simulate-serverless PLATFORM)"
+        warn 'Error: --url is required (or pass --file PATH for in-process file mode, or pass an agent file with --simulate-serverless PLATFORM)'
         exit 1
       end
 
       actions = [@options[:dump_swml], @options[:list_tools], !!@options[:exec]].count(true)
       if actions == 0
-        $stderr.puts "Error: specify one of --dump-swml, --list-tools, or --exec NAME"
+        warn 'Error: specify one of --dump-swml, --list-tools, or --exec NAME'
         exit 1
       elsif actions > 1
-        $stderr.puts "Error: specify only one of --dump-swml, --list-tools, or --exec NAME"
+        warn 'Error: specify only one of --dump-swml, --list-tools, or --exec NAME'
         exit 1
       end
     end
@@ -400,29 +402,29 @@ module SwaigTest
       # runtime registry, since that is the gap on non-AgentBase services.
       # URL/simulator combinations are rejected to avoid ambiguous dispatch.
       if @options[:url]
-        $stderr.puts "Error: --file and --url are mutually exclusive"
+        warn 'Error: --file and --url are mutually exclusive'
         exit 1
       end
 
       if @options[:simulate_serverless]
-        $stderr.puts "Error: --file and --simulate-serverless are mutually exclusive"
+        warn 'Error: --file and --simulate-serverless are mutually exclusive'
         exit 1
       end
 
       unless File.exist?(@options[:file])
-        $stderr.puts "Error: file not found: #{@options[:file]}"
+        warn "Error: file not found: #{@options[:file]}"
         exit 1
       end
 
       unless @options[:list_tools]
-        $stderr.puts "Error: --file mode currently supports only --list-tools"
+        warn 'Error: --file mode currently supports only --list-tools'
         exit 1
       end
 
-      if @options[:dump_swml] || @options[:exec]
-        $stderr.puts "Error: --file mode does not support --dump-swml or --exec (use --url or --simulate-serverless lambda for those)"
-        exit 1
-      end
+      return unless @options[:dump_swml] || @options[:exec]
+
+      warn 'Error: --file mode does not support --dump-swml or --exec (use --url or --simulate-serverless lambda for those)'
+      exit 1
     end
 
     def validate_simulate_serverless_options!
@@ -430,38 +432,38 @@ module SwaigTest
 
       unless IMPLEMENTED_SERVERLESS_PLATFORMS.include?(platform)
         if RECOGNISED_SERVERLESS_PLATFORMS.include?(platform)
-          $stderr.puts "Error: --simulate-serverless #{platform.inspect} is not implemented in this SDK yet."
-          $stderr.puts "       Phase 9 (serverless support) has only shipped for: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}."
-          $stderr.puts "       Add the #{platform} handler adapter before enabling it here."
+          warn "Error: --simulate-serverless #{platform.inspect} is not implemented in this SDK yet."
+          warn "       Phase 9 (serverless support) has only shipped for: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}."
+          warn "       Add the #{platform} handler adapter before enabling it here."
         else
-          $stderr.puts "Error: unknown serverless platform #{platform.inspect}."
-          $stderr.puts "       Supported: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}."
+          warn "Error: unknown serverless platform #{platform.inspect}."
+          warn "       Supported: #{IMPLEMENTED_SERVERLESS_PLATFORMS.join(', ')}."
         end
         exit 1
       end
 
       unless @options[:agent_file]
-        $stderr.puts "Error: --simulate-serverless requires a positional agent file argument"
-        $stderr.puts "Usage: swaig-test AGENT_FILE --simulate-serverless #{platform} [--dump-swml | --exec NAME]"
+        warn 'Error: --simulate-serverless requires a positional agent file argument'
+        warn "Usage: swaig-test AGENT_FILE --simulate-serverless #{platform} [--dump-swml | --exec NAME]"
         exit 1
       end
 
       unless File.exist?(@options[:agent_file])
-        $stderr.puts "Error: agent file not found: #{@options[:agent_file]}"
+        warn "Error: agent file not found: #{@options[:agent_file]}"
         exit 1
       end
 
       # Simulated mode cannot combine with --url (different dispatch paths).
       if @options[:url]
-        $stderr.puts "Error: --simulate-serverless and --url are mutually exclusive"
+        warn 'Error: --simulate-serverless and --url are mutually exclusive'
         exit 1
       end
 
       actions = [@options[:dump_swml], @options[:list_tools], !!@options[:exec]].count(true)
-      if actions > 1
-        $stderr.puts "Error: specify at most one of --dump-swml, --list-tools, or --exec NAME"
-        exit 1
-      end
+      return unless actions > 1
+
+      warn 'Error: specify at most one of --dump-swml, --list-tools, or --exec NAME'
+      exit 1
     end
 
     def parse_param_value(value)
@@ -488,11 +490,9 @@ module SwaigTest
     def auth_header
       user = parsed_uri.user
       pass = parsed_uri.password
-      if user && pass
-        "Basic " + ["#{URI.decode_www_form_component(user)}:#{URI.decode_www_form_component(pass)}"].pack('m0')
-      else
-        nil
-      end
+      return unless user && pass
+
+      'Basic ' + ["#{URI.decode_www_form_component(user)}:#{URI.decode_www_form_component(pass)}"].pack('m0')
     end
 
     def make_request(method, path, body: nil)
@@ -505,13 +505,13 @@ module SwaigTest
       uri.password = nil
 
       if @options[:verbose]
-        $stderr.puts ">> #{method.upcase} #{uri}"
-        $stderr.puts ">> Authorization: Basic <redacted>" if auth_header
+        warn ">> #{method.upcase} #{uri}"
+        warn '>> Authorization: Basic <redacted>' if auth_header
         if body
-          $stderr.puts ">> Content-Type: application/json"
-          $stderr.puts ">> Body: #{body}"
+          warn '>> Content-Type: application/json'
+          warn ">> Body: #{body}"
         end
-        $stderr.puts ""
+        warn ''
       end
 
       http = Net::HTTP.new(uri.host, uri.port)
@@ -532,9 +532,9 @@ module SwaigTest
       response = http.request(req)
 
       if @options[:verbose]
-        $stderr.puts "<< HTTP #{response.code} #{response.message}"
-        response.each_header { |k, v| $stderr.puts "<< #{k}: #{v}" }
-        $stderr.puts ""
+        warn "<< HTTP #{response.code} #{response.message}"
+        response.each_header { |k, v| warn "<< #{k}: #{v}" }
+        warn ''
       end
 
       response
@@ -552,16 +552,16 @@ module SwaigTest
       response = make_request(:get, '/')
 
       unless response.is_a?(Net::HTTPSuccess)
-        $stderr.puts "Error: HTTP #{response.code} #{response.message}"
-        $stderr.puts response.body if @options[:verbose]
+        warn "Error: HTTP #{response.code} #{response.message}"
+        warn response.body if @options[:verbose]
         exit 1
       end
 
       data = JSON.parse(response.body)
       puts format_json(data)
     rescue JSON::ParserError => e
-      $stderr.puts "Error: invalid JSON response: #{e.message}"
-      $stderr.puts response.body if @options[:verbose]
+      warn "Error: invalid JSON response: #{e.message}"
+      warn response.body if @options[:verbose]
       exit 1
     end
 
@@ -569,7 +569,7 @@ module SwaigTest
       response = make_request(:get, '/')
 
       unless response.is_a?(Net::HTTPSuccess)
-        $stderr.puts "Error: HTTP #{response.code} #{response.message}"
+        warn "Error: HTTP #{response.code} #{response.message}"
         exit 1
       end
 
@@ -577,12 +577,12 @@ module SwaigTest
       functions = extract_functions(swml)
 
       if functions.empty?
-        puts "No SWAIG functions found."
+        puts 'No SWAIG functions found.'
         return
       end
 
-      puts "SWAIG Functions:"
-      puts "-" * 60
+      puts 'SWAIG Functions:'
+      puts '-' * 60
       functions.each do |func|
         name = func['function'] || '(unnamed)'
         desc = func['description'] || '(no description)'
@@ -591,18 +591,26 @@ module SwaigTest
 
         params = func['parameters']
         if params.is_a?(Hash) && params['properties'].is_a?(Hash) && !params['properties'].empty?
-          puts "    Parameters:"
+          puts '    Parameters:'
           params['properties'].each do |pname, pdef|
-            ptype = pdef['type'] || 'any' rescue 'any'
-            pdesc = pdef['description'] || '' rescue ''
+            ptype = begin
+              pdef['type'] || 'any'
+            rescue StandardError
+              'any'
+            end
+            pdesc = begin
+              pdef['description'] || ''
+            rescue StandardError
+              ''
+            end
             required = (params['required'] || []).include?(pname) ? ' (required)' : ''
             puts "      - #{pname}: #{ptype}#{required} #{pdesc}"
           end
         end
-        puts ""
+        puts ''
       end
     rescue JSON::ParserError => e
-      $stderr.puts "Error: invalid JSON response: #{e.message}"
+      warn "Error: invalid JSON response: #{e.message}"
       exit 1
     end
 
@@ -618,15 +626,15 @@ module SwaigTest
       response = make_request(:post, '/swaig', body: JSON.generate(payload))
 
       unless response.is_a?(Net::HTTPSuccess)
-        $stderr.puts "Error: HTTP #{response.code} #{response.message}"
-        $stderr.puts response.body if @options[:verbose]
+        warn "Error: HTTP #{response.code} #{response.message}"
+        warn response.body if @options[:verbose]
         exit 1
       end
 
       data = JSON.parse(response.body)
       puts format_json(data)
     rescue JSON::ParserError => e
-      $stderr.puts "Error: invalid JSON response: #{e.message}"
+      warn "Error: invalid JSON response: #{e.message}"
       exit 1
     end
 
@@ -638,12 +646,12 @@ module SwaigTest
       main = sections['main'] || []
 
       main.each do |verb|
-        if verb.is_a?(Hash) && verb.key?('ai')
-          ai = verb['ai']
-          swaig = ai['SWAIG'] || {}
-          funcs = swaig['functions'] || []
-          functions.concat(funcs)
-        end
+        next unless verb.is_a?(Hash) && verb.key?('ai')
+
+        ai = verb['ai']
+        swaig = ai['SWAIG'] || {}
+        funcs = swaig['functions'] || []
+        functions.concat(funcs)
       end
 
       functions
@@ -664,7 +672,7 @@ module SwaigTest
       simulator.with_simulation do
         agent = load_agent_file(@options[:agent_file])
         unless agent
-          $stderr.puts "Error: agent file #{@options[:agent_file].inspect} did not expose an AGENT constant (expected SignalWire::AgentBase)."
+          warn "Error: agent file #{@options[:agent_file].inspect} did not expose an AGENT constant (expected SignalWire::AgentBase)."
           exit 1
         end
 
@@ -701,6 +709,7 @@ module SwaigTest
 
       Object.constants.each do |c|
         next if c == :AGENT
+
         value = Object.const_get(c)
         return value if value.is_a?(SignalWire::AgentBase)
       end
@@ -710,11 +719,11 @@ module SwaigTest
 
     def render_functions_list(functions)
       if functions.empty?
-        puts "No SWAIG functions found."
+        puts 'No SWAIG functions found.'
         return
       end
-      puts "SWAIG Functions:"
-      puts "-" * 60
+      puts 'SWAIG Functions:'
+      puts '-' * 60
       functions.each do |func|
         name = func['function'] || '(unnamed)'
         desc = func['description'] || '(no description)'
@@ -723,7 +732,7 @@ module SwaigTest
 
         properties, required = extract_param_properties(func['parameters'])
         unless properties.empty?
-          puts "    Parameters:"
+          puts '    Parameters:'
           properties.each do |pname, pdef|
             ptype = (pdef.is_a?(Hash) ? pdef['type'] : nil) || 'any'
             pdesc = (pdef.is_a?(Hash) ? pdef['description'] : nil) || ''
@@ -731,7 +740,7 @@ module SwaigTest
             puts "      - #{pname}: #{ptype}#{req_marker} #{pdesc}".rstrip
           end
         end
-        puts ""
+        puts ''
       end
     end
 
@@ -740,6 +749,7 @@ module SwaigTest
     # Returns [properties_hash, required_array].
     def extract_param_properties(params)
       return [{}, []] unless params.is_a?(Hash)
+
       if params['properties'].is_a?(Hash)
         [params['properties'], Array(params['required']).map(&:to_s)]
       elsif params['type'] == 'object'
@@ -766,7 +776,7 @@ module SwaigTest
 
       service = load_service_from_file(@options[:file])
       unless service
-        $stderr.puts "Error: file #{@options[:file].inspect} did not expose a SignalWire::SWML::Service subclass."
+        warn "Error: file #{@options[:file].inspect} did not expose a SignalWire::SWML::Service subclass."
         exit 1
       end
 
@@ -810,16 +820,16 @@ module SwaigTest
       # Fallback: if no NEW subclass was defined (e.g. running the same
       # file twice in the same process), pick any user subclass.
       candidate ||= ObjectSpace.each_object(Class)
-                    .select { |c| service_subclass?(c, service_class) }
-                    .sort_by { |c| c.name.to_s }
-                    .last
+                               .select { |c| service_subclass?(c, service_class) }
+                               .sort_by { |c| c.name.to_s }
+                               .last
 
       return nil unless candidate
 
       instantiate_service(candidate)
     rescue StandardError => e
-      $stderr.puts "Error loading #{path}: #{e.class}: #{e.message}"
-      $stderr.puts e.backtrace.first(8).join("\n") if @options[:verbose]
+      warn "Error loading #{path}: #{e.class}: #{e.message}"
+      warn e.backtrace.first(8).join("\n") if @options[:verbose]
       exit 1
     end
 
@@ -827,6 +837,7 @@ module SwaigTest
       return false unless klass.is_a?(Class)
       return false if klass == service_class
       return false if defined?(SignalWire::AgentBase) && klass == SignalWire::AgentBase
+
       klass.ancestors.include?(service_class)
     rescue StandardError
       false
@@ -861,12 +872,11 @@ module SwaigTest
 
     def stringify_tool(defn)
       return {} unless defn.is_a?(Hash)
+
       defn.transform_keys(&:to_s)
     end
   end
 end
 
 # Run when invoked directly
-if __FILE__ == $PROGRAM_NAME
-  SwaigTest::CLI.new.run
-end
+SwaigTest::CLI.new.run if __FILE__ == $PROGRAM_NAME

--- a/lib/signalwire/skills/builtin/spider.rb
+++ b/lib/signalwire/skills/builtin/spider.rb
@@ -67,6 +67,7 @@ module SignalWire
             name: "#{@tool_prefix}scrape_url",
             description: 'Extract text content from a single web page',
             parameters: { 'url' => { 'type' => 'string', 'description' => 'The URL to scrape' } },
+            required: ['url'],
             handler: method(:handle_scrape)
           }
         end
@@ -76,6 +77,7 @@ module SignalWire
             name: "#{@tool_prefix}crawl_site",
             description: 'Crawl multiple pages starting from a URL',
             parameters: { 'start_url' => { 'type' => 'string', 'description' => 'Starting URL for the crawl' } },
+            required: ['start_url'],
             handler: method(:handle_crawl)
           }
         end
@@ -85,6 +87,7 @@ module SignalWire
             name: "#{@tool_prefix}extract_structured_data",
             description: 'Extract specific data from a web page using selectors',
             parameters: { 'url' => { 'type' => 'string', 'description' => 'The URL to scrape' } },
+            required: ['url'],
             handler: method(:handle_extract)
           }
         end

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -15,6 +15,7 @@
 #   8. lint gate                          — rubocop, zero offenses (the burndown floor)
 #   9. doc-audit gate                     — porting-sdk audit_docs.py
 #  10. surface-diff gate                  — porting-sdk diff_port_surface.py
+#  11. skill-contract gate                — porting-sdk diff_skill_contracts.py
 
 set -u
 set -o pipefail
@@ -201,6 +202,20 @@ surface_diff_gate() {
 }
 run_gate "SURFACE-DIFF" "diff_port_surface vs python reference" \
     surface_diff_gate
+
+# Gate 11: SKILL-CONTRACT — the surface/drift/emission gates see signatures +
+# symbol names + FunctionResult.to_dict(); NONE sees a built-in skill's SWAIG
+# tool contract ({name, parameters, required, enum} each skill registers). This
+# differ closes that gap: it builds the Python oracle by instantiating each
+# covered reference skill, runs the Ruby skill-dump program (bin/emit-skills,
+# which reads the SAME shared corpus), and structurally compares the two.
+# DESCRIPTIONS + implementation (handler vs DataMap) are not compared — only
+# name/param-name/param-type/enum/required. Mirrors the go/dotnet SKILL-CONTRACT
+# gate. Same prereqs as EMISSION (signalwire-python adjacent; no network).
+run_gate "SKILL-CONTRACT" "diff_skill_contracts vs python reference" \
+    python3 "$PORTING_SDK_DIR/scripts/diff_skill_contracts.py" \
+        --dump-cmd "bundle exec ruby bin/emit-skills" \
+        --port-repo "$PORT_ROOT"
 
 if [ -z "$FAILED_GATES" ]; then
     echo "==> CI PASS"

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -11,6 +11,10 @@
 #   4. surface-fresh gate                 — porting-sdk check_surface_freshness.py
 #   5. no-cheat gate                      — porting-sdk audit_no_cheat_tests.py
 #   6. emission gate                      — porting-sdk diff_port_emission.py
+#   7. fmt gate                           — rubocop (local: --autocorrect; CI: check)
+#   8. lint gate                          — rubocop, zero offenses (the burndown floor)
+#   9. doc-audit gate                     — porting-sdk audit_docs.py
+#  10. surface-diff gate                  — porting-sdk diff_port_surface.py
 
 set -u
 set -o pipefail
@@ -116,7 +120,61 @@ run_gate "EMISSION" "diff_port_emission vs python oracle" \
     python3 "$PORTING_SDK_DIR/scripts/diff_port_emission.py" \
         --dump-cmd "ruby bin/emit-corpus"
 
-# Gate 7: surface-diff — diff the port's public surface against the Python
+# Gate 7: FMT — the language format gate (ruby: rubocop). RuboCop is both
+# formatter and linter; here it wears the "format" face. Source-style only and
+# proven surface/emission-neutral (a reformat leaves port_signatures.json +
+# port_surface.json byte-identical, and EMISSION 81/81 — verified during the
+# burndown). Mirrors the go/ts FMT shape:
+#   * LOCAL ($CI unset)  → `rubocop --autocorrect`: reformats your working tree
+#     in place so you never hand-run it; notes if it changed files.
+#   * CI ($CI=true)      → `rubocop` (read-only): FAILS if any offense reached CI.
+# lib/ + tests/ were burned to zero earlier; the bin/ tooling + Gemfile/gemspec
+# were brought to zero in the FMT/LINT rollout.
+fmt_gate() {
+    if [ -n "${CI:-}" ]; then
+        bundle exec rubocop
+    else
+        bundle exec rubocop --autocorrect >/dev/null
+        if ! git diff --quiet 2>/dev/null; then
+            echo "    (FMT auto-applied formatting to your working tree — review & stage)"
+        fi
+        # A residual offense rubocop can't autocorrect must still fail the gate.
+        bundle exec rubocop
+    fi
+}
+run_gate "FMT" "rubocop (local: --autocorrect; CI: check)" fmt_gate
+
+# Gate 8: LINT — the language lint gate (ruby: rubocop, zero offenses). This is
+# the blocking quality floor: the full cop set in .rubocop.yml burned to zero by
+# hand (the whole-cop DISABLE list there is short + justified — a cop is off ONLY
+# when obeying it would change the SWAIG wire bytes / rename a wire token, or
+# fights faithful Python-reference parity; type/shape + naming idiom is NEVER
+# suppressed — idiom wins and the cross-port DRIFT checker is taught the
+# equivalence). Mirrors the go golangci / rust clippy blocking-lint gate.
+#
+# Inline `# rubocop:disable Cop` directives ARE allowed when site-scoped (a
+# disable/enable pair, or a same-line disable) and carry a rationale — that's the
+# preferred form over turning a whole cop off. The honesty guard against a
+# disable that hides a real offense is rubocop's OWN Lint/RedundantCopDisable
+# Directive cop (enabled): it fails the run if any disable suppresses a non-
+# offense, so a gratuitous/over-broad disable can't pass this gate. No hand-rolled
+# grep guard — it can't tell a justified site-disable from a blanket one, and a
+# naive one wrongly fails wire-critical paired disables in lib/.
+run_gate "LINT" "rubocop zero offenses (lint gate)" \
+    bundle exec rubocop
+
+# Gate 9: DOC-AUDIT — every method/class referenced in docs/ + examples/ fenced
+# code blocks must resolve to a real symbol in the port surface (catches
+# phantom-API doc promises). Uses the committed port_surface.json (the
+# SURFACE-FRESH gate above already proved it is fresh) + DOC_AUDIT_IGNORE.md for
+# intentional non-symbol references.
+run_gate "DOC-AUDIT" "audit_docs vs port_surface.json" \
+    python3 "$PORTING_SDK_DIR/scripts/audit_docs.py" \
+        --root "$PORT_ROOT" \
+        --surface "$PORT_ROOT/port_surface.json" \
+        --ignore "$PORT_ROOT/DOC_AUDIT_IGNORE.md"
+
+# Gate 10: surface-diff — diff the port's public surface against the Python
 # reference (omissions + additions). The signature DRIFT gate (Layer A) checks
 # method *signatures*; this checks surface *membership* — it catches public
 # symbols the port has that Python doesn't (e.g. helpers leaked onto the surface

--- a/signalwire-sdk.gemspec
+++ b/signalwire-sdk.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '>= 1.80'
   s.add_development_dependency 'rubocop-minitest', '>= 0.38'
   s.add_development_dependency 'rubocop-performance', '>= 1.25'
+  s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/signalwire-sdk.gemspec
+++ b/signalwire-sdk.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'lib/signalwire/version'
 
 # Published as `signalwire-sdk` on RubyGems because the `signalwire`
@@ -9,7 +11,8 @@ Gem::Specification.new do |s|
   s.name        = 'signalwire-sdk'
   s.version     = SignalWire::VERSION
   s.summary     = 'SignalWire AI Agents SDK'
-  s.description = 'A Ruby framework for building, deploying, and managing AI agents as microservices that interact with the SignalWire platform.'
+  s.description = 'A Ruby framework for building, deploying, and managing AI agents ' \
+                  'as microservices that interact with the SignalWire platform.'
   s.authors     = ['SignalWire']
   s.email       = 'support@signalwire.com'
   s.homepage    = 'https://github.com/signalwire/signalwire-ruby'
@@ -27,13 +30,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'webrick', '>= 1.7'
   s.add_dependency 'websocket-client-simple', '>= 0.8'
 
-  # Development dependencies
-  s.add_development_dependency 'minitest', '>= 5.0'
-  s.add_development_dependency 'rack-test', '>= 2.0'
-  s.add_development_dependency 'rake', '>= 13.0'
-  # Lint/format quality floor (FMT + LINT gates in scripts/run-ci.sh).
-  s.add_development_dependency 'rubocop', '>= 1.80'
-  s.add_development_dependency 'rubocop-minitest', '>= 0.38'
-  s.add_development_dependency 'rubocop-performance', '>= 1.25'
+  # Development dependencies are declared in the Gemfile (not here), per
+  # RuboCop's Gemspec/DevelopmentDependencies: keeping them out of the gemspec
+  # avoids imposing the test/lint toolchain on consumers who install the gem.
   s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Brings signalwire-ruby from a partial gate set (7 gates) to the **full 11-gate set**, matching go/rust/dotnet/typescript. Adds the four missing gates in the locked order: **FMT → LINT → DOC-AUDIT → SURFACE-DIFF (already present) → SKILL-CONTRACT**.

## What landed (5 commits)

1. **`d4e2595` FMT burndown step 1** — rubocop safe-autocorrect on the build/CLI files outside the prior `lib/`+`tests/` burndown (bin/emit-corpus, bin/swaig-test, gemspec). Mechanical, behavior-preserving. 431 → 68 offenses.
2. **`a875202` LINT residue (judgment)** — moved dev-deps gemspec → Gemfile (the `Gemspec/DevelopmentDependencies` fix), frozen-string comments, and the unsafe-autocorrect-class fixes in swaig-test (each reviewed for behavior-equivalence).
3. **`bae05f9` swaig-test refactor** — decomposed the 455-line `CLI` class + oversized methods into cohesive collaborators so rubocop's `Metrics/*` cops pass with **zero disables and zero excludes**. Behavior-preserving (verified by diffing old-vs-new across 14 invocation paths + the `--file --list-tools` functional path: identical stdout/stderr/exit code).
4. **`5e430e3` wire FMT/LINT/DOC-AUDIT** into run-ci.sh.
5. **`0316ebc` SKILL-CONTRACT** — new `bin/emit-skills` emitter (sibling of bin/emit-corpus) + a **real parity fix it caught**.

## Notable: the LINT "burned to zero" claim was false

`.rubocop.yml`'s header claimed a clean burndown, but there were 431 live offenses. `lib/` and `tests/` (the audited surface) genuinely *were* zero — all 431 were in build/CLI files the gate never covered. Cleared honestly: no cop disables, no per-file excludes, full refactor. The LINT gate relies on rubocop's own `Lint/RedundantCopDisableDirective` (already enabled) as the disable-honesty guard rather than a hand-rolled grep (which wrongly failed the wire-critical paired disable/enable blocks in `lib/`).

## Notable: SKILL-CONTRACT caught a real spider parity bug

On first run the gate flagged that the ruby `spider` skill declared `url`/`start_url` params but **not as required**, while the Python reference uses `define_tool(..., required=["url"])`. Fixed the port (added `required: [...]` to the three tool defs) and verified it flows through `define_tool` into the actual SWAIG **wire schema** (`"required":["url"]`), so this fixes the emitted contract, not just the gate. 13/13 covered skills now match the oracle.

## Verification

- Full `bash scripts/run-ci.sh` → **all 11 gates PASS**, both local and `CI=true`.
- Burndown proven audit-neutral: `port_signatures.json` + `port_surface.json` byte-identical, EMISSION 81/81.
- Full test suite: 1798 runs, 0 failures. swaig-test CLI + spider unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)