### PR TITLE
fix(agent): behavior parity bundle (#191/#185/#182/#183)

### DIFF
--- a/lib/signalwire/agent/agent_base.rb
+++ b/lib/signalwire/agent/agent_base.rb
@@ -379,14 +379,12 @@ module SignalWire
 
     # Add a subsection under a parent section.
     def prompt_add_subsection(parent_title, title, body = nil, bullets: nil)
-      parent = @pom_sections.find { |s| s['title'] == parent_title }
-      if parent
-        parent['subsections'] ||= []
-        sub = { 'title' => title }
-        sub['body']    = body    if body
-        sub['bullets'] = bullets if bullets
-        parent['subsections'] << sub
-      end
+      parent = find_or_create_section(parent_title)
+      parent['subsections'] ||= []
+      sub = { 'title' => title }
+      sub['body']    = body    if body
+      sub['bullets'] = bullets if bullets
+      parent['subsections'] << sub
       self
     end
 
@@ -1125,8 +1123,26 @@ module SignalWire
     end
 
     def set_function_includes(includes)
-      @function_includes = includes.dup if includes.is_a?(Array)
+      return self unless includes.is_a?(Array)
+
+      valid, dropped = includes.partition { |inc| valid_function_include?(inc) }
+      dropped.each { |inc| warn_dropped_function_include(inc) }
+      @function_includes = valid
       self
+    end
+
+    # An include is valid when it is a Hash carrying a truthy +url+ and a
+    # +functions+ array (mirrors TS setFunctionIncludes' per-entry filter).
+    def valid_function_include?(inc)
+      inc.is_a?(Hash) && inc['url'] && inc['functions'].is_a?(Array)
+    end
+
+    def warn_dropped_function_include(inc)
+      @logger.warn(
+        "invalid_function_include_dropped: #{inc.inspect}. " \
+        'set_function_includes entries must be a Hash with a "url" ' \
+        'and a "functions" array; this entry was dropped.'
+      )
     end
 
     def set_prompt_llm_params(**params)
@@ -1859,8 +1875,11 @@ module SignalWire
 
     def add_ai_prompt(config)
       prompt = get_prompt
+      if prompt.nil? || (prompt.respond_to?(:empty?) && prompt.empty?)
+        # Match TS: emit the default fallback prompt rather than omitting it.
+        prompt = "You are #{@name}, a helpful AI assistant."
+      end
       key = prompt.is_a?(Array) ? 'pom' : 'text'
-      return if prompt.nil? || prompt.empty?
 
       prompt_obj = { key => prompt }
       prompt_obj.merge!(@prompt_llm_params) unless @prompt_llm_params.empty?
@@ -2184,12 +2203,39 @@ module SignalWire
     end
 
     def invoke_summary_callback(request_data)
-      post_prompt_data = request_data['post_prompt_data']
-      summary = nil
-      summary = post_prompt_data['parsed'] || post_prompt_data['raw'] if post_prompt_data.is_a?(Hash)
+      summary = find_summary_in_post_data(request_data)
       @summary_callback.call(summary, request_data)
     rescue StandardError => e
       @logger.error "Post-prompt callback error: #{e.message}"
+    end
+
+    # Locate the summary in the post-prompt payload. Mirrors the extraction
+    # order used by the Python and TS ports:
+    #   1. top-level "summary" key
+    #   2. post_prompt_data["parsed"][0] (when parsed is a non-empty array)
+    #   3. post_prompt_data["raw"] (JSON-parsed when possible, else raw)
+    def find_summary_in_post_data(body)
+      return nil unless body.is_a?(Hash)
+      return body['summary'] if body['summary']
+
+      ppd = body['post_prompt_data']
+      ppd.is_a?(Hash) ? summary_from_post_prompt_data(ppd) : nil
+    end
+
+    # Second/third tiers of the summary lookup: parsed[0] then raw
+    # (JSON-parsed when possible, else the raw string).
+    def summary_from_post_prompt_data(ppd)
+      parsed = ppd['parsed']
+      return parsed[0] if parsed.is_a?(Array) && !parsed.empty?
+
+      raw = ppd['raw']
+      return nil unless raw
+
+      begin
+        JSON.parse(raw)
+      rescue StandardError
+        raw
+      end
     end
 
     # Handle debug events.
@@ -2307,5 +2353,7 @@ module SignalWire
     private :secure_token_ok?, :sym_or_str, :verb_entries, :warn_unexpected_function_result
     private :warn_unknown_filler_name, :warn_unknown_filler_names, :webrick_opts
     private :answer_entry, :record_call_entry, :webrick_handler
+    private :valid_function_include?, :warn_dropped_function_include, :find_summary_in_post_data
+    private :summary_from_post_prompt_data
   end
 end

--- a/tests/agent_test.rb
+++ b/tests/agent_test.rb
@@ -1208,8 +1208,10 @@ class AgentRackTest < Minitest::Test
   # --- post_prompt ---
 
   def test_post_prompt_endpoint
+    # `parsed` is an array per the canonical wire shape; the summary is
+    # parsed[0] (matches the Python/TS extraction order: summary -> parsed[0] -> raw).
     post_json('/post_prompt', { 'post_prompt_data' => { 'raw' => 'Summary text',
-                                                        'parsed' => { 'summary' => 'Short' } } })
+                                                        'parsed' => [{ 'summary' => 'Short' }] } })
 
     assert_equal 200, last_response.status
     # Callback should have been called

--- a/tests/behavior_bundle_test.rb
+++ b/tests/behavior_bundle_test.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+ENV['SIGNALWIRE_LOG_MODE'] = 'off'
+
+require_relative '../lib/signalwire'
+
+# Regression tests for the behavior-parity bundle (#191/#185/#182/#183).
+# Each fix is verified against the TypeScript reference behavior (and Python
+# for #183's extraction order).
+
+# Captures warn() calls so the #191 drop-warning can be asserted even when
+# SIGNALWIRE_LOG_MODE=off would otherwise suppress output.
+class CapturingLogger
+  attr_reader :warnings
+
+  def initialize
+    @warnings = []
+  end
+
+  def warn(msg)
+    @warnings << msg
+  end
+
+  def info(_msg); end
+  def debug(_msg); end
+  def error(_msg); end
+end
+
+# --- #191: set_function_includes drops invalid entries and warns per drop ---
+class FunctionIncludesDropFilterTest < Minitest::Test
+  def setup
+    @agent = SignalWire::AgentBase.new
+    @logger = CapturingLogger.new
+    @agent.instance_variable_set(:@logger, @logger)
+  end
+
+  def ai_block
+    @agent.render_swml['sections']['main'].find { |v| v.key?('ai') }['ai']
+  end
+
+  # A valid entry plus four invalid shapes (no url, no functions, non-array
+  # functions, not a hash).
+  def mixed_includes
+    [
+      { 'url' => 'https://good.com', 'functions' => %w[f1 f2] },
+      { 'functions' => ['f3'] },
+      { 'url' => 'https://nofuncs.com' },
+      { 'url' => 'https://badfuncs.com', 'functions' => 'f4' },
+      'not-a-hash'
+    ]
+  end
+
+  def test_drops_entries_missing_url_or_functions
+    @agent.set_function_includes(mixed_includes)
+    includes = ai_block['SWAIG']['includes']
+
+    assert_equal 1, includes.length
+    assert_equal 'https://good.com', includes[0]['url']
+  end
+
+  def test_warns_once_per_dropped_entry
+    @agent.set_function_includes(
+      [
+        { 'url' => 'https://good.com', 'functions' => ['f1'] },
+        { 'functions' => ['f3'] },
+        { 'url' => 'https://nofuncs.com' }
+      ]
+    )
+
+    assert_equal 2, @logger.warnings.length
+    assert(@logger.warnings.all? { |w| w.include?('invalid_function_include_dropped') })
+  end
+
+  def test_keeps_all_valid_entries
+    @agent.set_function_includes(
+      [
+        { 'url' => 'https://a.com', 'functions' => ['f1'] },
+        { 'url' => 'https://b.com', 'functions' => [] }
+      ]
+    )
+
+    assert_equal 2, @agent.render_swml['sections']['main']
+                          .find { |v| v.key?('ai') }['ai']['SWAIG']['includes'].length
+    assert_empty @logger.warnings
+  end
+end
+
+# --- #185: empty prompt falls back to the default assistant prompt ---
+class DefaultPromptFallbackTest < Minitest::Test
+  def ai_block(agent)
+    agent.render_swml['sections']['main'].find { |v| v.key?('ai') }['ai']
+  end
+
+  def test_empty_prompt_emits_fallback_text
+    agent = SignalWire::AgentBase.new(name: 'helper')
+    prompt = ai_block(agent)['prompt']
+
+    refute_nil prompt
+    assert_equal 'You are helper, a helpful AI assistant.', prompt['text']
+  end
+
+  def test_explicit_prompt_is_not_overridden
+    agent = SignalWire::AgentBase.new(name: 'helper')
+    agent.set_prompt_text('Custom prompt')
+
+    assert_equal 'Custom prompt', ai_block(agent)['prompt']['text']
+  end
+end
+
+# --- #182: prompt_add_subsection auto-creates a missing parent section ---
+class SubsectionAutoCreateTest < Minitest::Test
+  def setup
+    @agent = SignalWire::AgentBase.new
+  end
+
+  def test_auto_creates_missing_parent
+    @agent.prompt_add_subsection('Ghost', 'Sub', 'Sub body', bullets: %w[a b])
+    parent = @agent.get_prompt.find { |s| s['title'] == 'Ghost' }
+
+    refute_nil parent, 'parent section should be auto-created'
+    assert_equal([{ 'title' => 'Sub', 'body' => 'Sub body', 'bullets' => %w[a b] }],
+                 parent['subsections'])
+  end
+
+  def test_existing_parent_still_used
+    @agent.prompt_add_section('Main', 'Top body')
+    @agent.prompt_add_subsection('Main', 'Sub', 'Sub body')
+    prompt = @agent.get_prompt
+
+    assert_equal 1, prompt.length
+    assert_equal 1, prompt[0]['subsections'].length
+  end
+end
+
+# --- #183: on_summary extraction order (summary -> parsed[0] -> raw) ---
+class SummaryExtractionOrderTest < Minitest::Test
+  def setup
+    @agent = SignalWire::AgentBase.new
+    @received = nil
+    @agent.on_summary { |summary, _raw| @received = summary }
+  end
+
+  def test_prefers_top_level_summary_key
+    @agent.send(
+      :invoke_summary_callback,
+      {
+        'summary' => { 'top' => 'level' },
+        'post_prompt_data' => { 'parsed' => [{ 'p' => 1 }], 'raw' => '{"r":2}' }
+      }
+    )
+
+    assert_equal({ 'top' => 'level' }, @received)
+  end
+
+  def test_falls_back_to_first_parsed_element
+    @agent.send(
+      :invoke_summary_callback,
+      { 'post_prompt_data' => { 'parsed' => [{ 'first' => 1 }, { 'second' => 2 }], 'raw' => '{"r":2}' } }
+    )
+
+    assert_equal({ 'first' => 1 }, @received)
+  end
+
+  def test_falls_back_to_raw_json_parsed
+    @agent.send(
+      :invoke_summary_callback,
+      { 'post_prompt_data' => { 'raw' => '{"r":2}' } }
+    )
+
+    assert_equal({ 'r' => 2 }, @received)
+  end
+
+  def test_raw_returned_as_string_when_not_json
+    @agent.send(
+      :invoke_summary_callback,
+      { 'post_prompt_data' => { 'raw' => 'plain text summary' } }
+    )
+
+    assert_equal 'plain text summary', @received
+  end
+
+  def test_empty_parsed_array_falls_through_to_raw
+    @agent.send(
+      :invoke_summary_callback,
+      { 'post_prompt_data' => { 'parsed' => [], 'raw' => 'fallback' } }
+    )
+
+    assert_equal 'fallback', @received
+  end
+
+  def test_nil_when_nothing_present
+    @agent.send(:invoke_summary_callback, { 'post_prompt_data' => {} })
+
+    assert_nil @received
+  end
+end

--- a/tests/pom_builder_test.rb
+++ b/tests/pom_builder_test.rb
@@ -101,11 +101,17 @@ class PomBuilderTest < Minitest::Test
   end
 
   def test_subsection_to_nonexistent_parent
+    # Reference behavior (TS): the missing parent section is auto-created,
+    # then the subsection is attached under it.
     @agent.prompt_add_section('A', 'Body A')
     @agent.prompt_add_subsection('B', 'Sub', 'Body')
     prompt = @agent.get_prompt
 
-    assert_equal 1, prompt.length
-    refute prompt[0].key?('subsections')
+    assert_equal 2, prompt.length
+    parent_b = prompt.find { |s| s['title'] == 'B' }
+
+    refute_nil parent_b
+    assert_equal 1, parent_b['subsections'].length
+    assert_equal 'Sub', parent_b['subsections'][0]['title']
   end
 end


### PR DESCRIPTION
## Summary

Ruby behavior-fix bundle (task #42). Aligns four `AgentBase` behaviors to the **TypeScript** reference (the clean port), plus **Python** for #183's extraction order. Wire-neutral except for the intended behavior changes; no invented surface.

For each fix the reference behavior was confirmed against the TS (and Python) source, the Ruby bug was reproduced, then fixed to match.

| Issue | Reference matched | Ruby change |
|---|---|---|
| **#191** `set_function_includes` | TS `setFunctionIncludes` per-entry filter (`url && Array.isArray(functions)`) | Drop per-entry invalid includes (non-Hash / missing `url` / non-array `functions`) **and warn once per drop**. Previously only the top-level array was type-checked, so invalid entries passed through. |
| **#185** default prompt fallback | TS `text: prompt \|\| `You are ${name}, a helpful AI assistant.`` | When the prompt is empty/nil, emit the fallback `"You are {name}, a helpful AI assistant."` instead of omitting the prompt entirely. Exact TS string. |
| **#182** `prompt_add_subsection` | TS `PomBuilder.addSubsection` auto-creates the parent if absent | Auto-create the parent section (via existing `find_or_create_section`) instead of silently no-oping when the parent is missing. (`prompt_add_to_section` was already correct — untouched.) |
| **#183** `on_summary` extraction order | Python `_find_summary_in_post_data` / TS `findSummary`: `summary` → `parsed[0]` → `raw` | Reordered to top-level `summary` key, then `post_prompt_data["parsed"][0]` (when a non-empty array), then `raw` (JSON-parsed when possible, else the raw string). Previously returned the whole `parsed` value `\|\| raw` and skipped the top-level `summary` key. |

Per the bundle instructions, **#190 (`set_global_data` merge)** and **#182 `prompt_add_to_section`** were already clean and left untouched. The ts#95 `RestClient.validateRequest` delegator is **not** part of this bundle and was not added.

## Tests (TDD — failing-before / passing-after proven)

New `tests/behavior_bundle_test.rb` with a regression test per fix:
- `FunctionIncludesDropFilterTest` — drop-filter + per-drop warn + valid-entry retention (#191)
- `DefaultPromptFallbackTest` — empty→fallback, explicit prompt not overridden (#185)
- `SubsectionAutoCreateTest` — auto-create missing parent, existing parent reused (#182)
- `SummaryExtractionOrderTest` — full `summary` / `parsed[0]` / raw-JSON / raw-string / empty-parsed / nil ordering (#183)

Two pre-existing tests that **ratified the old buggy behavior** were updated to assert the corrected, reference-aligned behavior:
- `tests/agent_test.rb` `test_post_prompt_endpoint` — now uses the canonical array `parsed` shape and asserts `parsed[0]`.
- `tests/pom_builder_test.rb` `test_subsection_to_nonexistent_parent` — now asserts the parent is auto-created.

New private helpers are appended to the explicit `private :…` list so the public surface is unchanged (DRIFT / SURFACE-FRESH / SURFACE-DIFF green).

## CI

`bash scripts/run-ci.sh` — **all 13 gates PASS** (TEST, SIGNATURES, DRIFT, SURFACE-FRESH, NO-CHEAT, REST-COVERAGE, SPEC-PARITY, EMISSION, FMT, LINT, DOC-AUDIT, SURFACE-DIFF, SKILL-CONTRACT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau
