### PR TITLE
test+ci: dynamic free ports + fail-loud for mock servers

### DIFF
--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -119,8 +119,15 @@ run_gate "NO-CHEAT" "audit_no_cheat_tests" \
 # against it (one shared journal), then runs porting-sdk's rest_coverage checker
 # with the shared baseline + this port's REST_COVERAGE_GAPS.md. A stale allowlist
 # entry (route now covered) fails the gate. Same shape as python/java/ts/go.
+# Pick a free TCP port on 127.0.0.1 (bind :0, read the OS-assigned port,
+# release). Never reuse a hardcoded port — a leftover or concurrent mock
+# squatting a fixed port otherwise makes the gate hang on its health poll.
+pick_free_port() {
+    python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
+}
 rest_coverage_gate() {
-    local port=8769
+    local port
+    port="$(pick_free_port)" || { echo "could not allocate a free port" >&2; return 1; }
     local mock_pkg_parent="$PORTING_SDK_DIR/test_harness/mock_signalwire"
     export PYTHONPATH="$mock_pkg_parent${PYTHONPATH:+:$PYTHONPATH}"
     python3 -m mock_signalwire --host 127.0.0.1 --port "$port" --log-level error \
@@ -128,13 +135,24 @@ rest_coverage_gate() {
     local mock_pid=$!
     # shellcheck disable=SC2064
     trap "kill $mock_pid 2>/dev/null" RETURN
-    local i
+    # Fail LOUD if the mock dies mid-startup or never becomes healthy — never hang.
+    local i ready=0
     for i in $(seq 1 60); do
+        if ! kill -0 "$mock_pid" 2>/dev/null; then
+            echo "mock_signalwire died on port $port — log:" >&2
+            cat "/tmp/rest_cov_mock_ruby.$$.log" >&2
+            return 1
+        fi
         if python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:$port/__mock__/health',timeout=1)" 2>/dev/null; then
+            ready=1
             break
         fi
         sleep 0.5
     done
+    if [ "$ready" -ne 1 ]; then
+        echo "mock_signalwire on port $port not healthy within 30s" >&2
+        return 1
+    fi
     python3 -c "import urllib.request; urllib.request.urlopen(urllib.request.Request('http://127.0.0.1:$port/__mock__/journal/reset',method='POST'),timeout=5).read()"
     MOCK_SIGNALWIRE_PORT="$port" bundle exec rake test || return 1
     python3 -m mock_signalwire.rest_coverage \

--- a/tests/relay/mock_test.rb
+++ b/tests/relay/mock_test.rb
@@ -23,9 +23,6 @@ require_relative '../../lib/signalwire/relay/client'
 require_relative '../../lib/signalwire/relay/constants'
 
 module RelayMockTest
-  DEFAULT_WS_PORT   = 8779
-  DEFAULT_HTTP_PORT = 9779
-
   # `python -m mock_relay` cold-start can take a few seconds (module import
   # plus schema loading). Keep the budget slack but bounded.
   STARTUP_TIMEOUT_S = 30
@@ -341,8 +338,8 @@ module RelayMockTest
 
     # Resolve ports, build the Harness, and probe-or-spawn the server.
     def start_harness
-      @ws_port   = resolve_port('MOCK_RELAY_PORT', DEFAULT_WS_PORT)
-      @http_port = resolve_port('MOCK_RELAY_HTTP_PORT', DEFAULT_HTTP_PORT)
+      @ws_port   = resolve_port('MOCK_RELAY_PORT')
+      @http_port = resolve_port('MOCK_RELAY_HTTP_PORT')
       @host      = '127.0.0.1'
       @harness   = Harness.new(host: @host, ws_port: @ws_port, http_port: @http_port)
 
@@ -360,9 +357,7 @@ module RelayMockTest
       @mu.synchronize do
         return false if @harness && probe_health(@harness)
 
-        spawn_server(@host || '127.0.0.1',
-                     @ws_port   || DEFAULT_WS_PORT,
-                     @http_port || DEFAULT_HTTP_PORT)
+        spawn_server(@host || '127.0.0.1', @ws_port, @http_port)
         wait_for_health(@harness)
         true
       end
@@ -370,7 +365,7 @@ module RelayMockTest
 
     private
 
-    def resolve_port(env_var, default_port)
+    def resolve_port(env_var)
       raw = ENV.fetch(env_var, nil)
       if raw && !raw.empty?
         n = begin
@@ -380,7 +375,17 @@ module RelayMockTest
         end
         return n if n&.positive?
       end
-      default_port
+      # No env override: pick a FREE port (bind :0) rather than a hardcoded
+      # default. WS and HTTP control plane are picked independently.
+      pick_free_port
+    end
+
+    def pick_free_port
+      require 'socket'
+      s = TCPServer.new('127.0.0.1', 0)
+      port = s.addr[1]
+      s.close
+      port
     end
 
     def probe_health(harness)

--- a/tests/rest/mock_test.rb
+++ b/tests/rest/mock_test.rb
@@ -27,7 +27,6 @@ require_relative '../../lib/signalwire/rest/rest_client'
 module MockTest
   # Default port for the Ruby slot in the parallel SDK rollouts.
   # TS=8766, Java=8767, PHP=8768, Ruby=8769, Perl=8770, Rust=8771, C++=8772.
-  DEFAULT_PORT = 8769
 
   # Cap how long we wait for an externally-launched server to answer
   # /__mock__/health. The Python in-process harness boots in ~1s, but
@@ -252,7 +251,17 @@ module MockTest
         end
         return n if n&.positive?
       end
-      DEFAULT_PORT
+      # No env override: pick a FREE port (bind :0) rather than a hardcoded
+      # default that collides with a stale/concurrent mock and hangs the suite.
+      pick_free_port
+    end
+
+    def pick_free_port
+      require 'socket'
+      s = TCPServer.new('127.0.0.1', 0)
+      port = s.addr[1]
+      s.close
+      port
     end
 
     def probe_health(url)

--- a/tests/tls/tls_mock_helper.rb
+++ b/tests/tls/tls_mock_helper.rb
@@ -39,11 +39,14 @@ module TlsHarness
   # TLS listener, which can stretch to ~15s cold. Keep the budget bounded.
   STARTUP_TIMEOUT_S = 40
 
-  # Dedicated ports for the TLS capability tests — distinct from every other
-  # mock test's default slot so the two never collide in one `rake test` run.
-  TLS_RELAY_WS_PORT   = 18_775
-  TLS_RELAY_HTTP_PORT = 19_775
-  TLS_SIGNALWIRE_PORT = 18_766
+  # Test-local TLS mocks pick FREE ports (bind :0) per role rather than
+  # hardcoded slots; memoized. Env override (positive int) wins when set.
+  @tls_ports = {}
+  TLS_PORT_ENV = { ws: 'MOCK_RELAY_TLS_WS_PORT', http: 'MOCK_RELAY_TLS_HTTP_PORT',
+                   sw: 'MOCK_SIGNALWIRE_TLS_PORT' }.freeze
+  def tls_port(role)
+    @tls_ports[role] ||= ((raw = ENV.fetch(TLS_PORT_ENV.fetch(role), '').to_i).positive? ? raw : TlsTransport.free_port)
+  end
 
   # Walk up from this file to an adjacent porting-sdk/test_harness/tls, run the
   # idempotent gen_certs.sh, and return the certs dir. Returns nil when
@@ -120,7 +123,7 @@ module TlsHarness
     pkg = discover_pkg('mock_signalwire')
     return nil unless pkg
 
-    base = "https://127.0.0.1:#{TLS_SIGNALWIRE_PORT}"
+    base = "https://127.0.0.1:#{tls_port(:sw)}"
     store = trusting_store
     health = "#{base}/__mock__/health"
     return base if TlsTransport.probe_https(health, store)
@@ -133,7 +136,7 @@ module TlsHarness
 
   def signalwire_cmd
     ['python3', '-m', 'mock_signalwire', '--host', '127.0.0.1',
-     '--port', TLS_SIGNALWIRE_PORT.to_s, '--tls', '--log-level', 'error']
+     '--port', tls_port(:sw).to_s, '--tls', '--log-level', 'error']
   end
 
   # Spawn `python -m mock_relay --tls` on the dedicated WS+HTTP port pair and
@@ -143,8 +146,8 @@ module TlsHarness
     pkg = discover_pkg('mock_relay')
     return nil unless pkg
 
-    http_url = "http://127.0.0.1:#{TLS_RELAY_HTTP_PORT}"
-    info = { ws_port: TLS_RELAY_WS_PORT, http_url: http_url }
+    http_url = "http://127.0.0.1:#{tls_port(:http)}"
+    info = { ws_port: tls_port(:ws), http_url: http_url }
     health = "#{http_url}/__mock__/health"
     return info if TlsTransport.probe_http(health)
 
@@ -156,7 +159,7 @@ module TlsHarness
 
   def relay_cmd
     ['python3', '-m', 'mock_relay', '--host', '127.0.0.1',
-     '--ws-port', TLS_RELAY_WS_PORT.to_s, '--http-port', TLS_RELAY_HTTP_PORT.to_s,
+     '--ws-port', tls_port(:ws).to_s, '--http-port', tls_port(:http).to_s,
      '--tls', '--log-level', 'error']
   end
 


### PR DESCRIPTION
Replace hardcoded mock ports in the REST-COVERAGE gate and the REST/RELAY/TLS test harnesses with OS-assigned free ports (`TCPServer(0)`; python socket :0 in the gate), and add a fail-loud guard so a dead/never-healthy mock fails the gate instead of hanging. Fixes the ts↔ruby 8769 collision and the per-test ECONNREFUSED churn. Env-var overrides preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzeysbfURBuHL5Sn7Sjau