### PR TITLE
docs+test: wire-truth W1 burn — from_→from + areacode (ruby)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ client = SignalWire::REST::RestClient.new(
 
 client.fabric.ai_agents.create(name: 'Support Bot', prompt: { 'text' => 'You are helpful.' })
 client.calling.play(call_id, play: [{ 'type' => 'tts', 'text' => 'Hello!' }])
-client.phone_numbers.search(area_code: '512')
+client.phone_numbers.search(areacode: '512')
 client.datasphere.documents.search(query_string: 'billing policy')
 ```
 

--- a/examples/quickstart_rest.rb
+++ b/examples/quickstart_rest.rb
@@ -20,6 +20,6 @@ client = SignalWire::REST::RestClient.new(
 
 client.fabric.ai_agents.create(name: 'Support Bot', prompt: { 'text' => 'You are helpful.' })
 client.calling.play(call_id, play: [{ 'type' => 'tts', 'text' => 'Hello!' }])
-client.phone_numbers.search(area_code: '512')
+client.phone_numbers.search(areacode: '512')
 client.datasphere.documents.search(query_string: 'billing policy')
 # endregion: rest

--- a/rest/README.md
+++ b/rest/README.md
@@ -20,11 +20,11 @@ agent = client.fabric.ai_agents.create(
 )
 
 # Search for a phone number
-results = client.phone_numbers.search(area_code: '512')
+results = client.phone_numbers.search(areacode: '512')
 
 # Place a call via REST
 client.calling.dial(
-  from_: '+15559876543',
+  from: '+15559876543',
   to:    '+15551234567',
   url:   'https://example.com/call-handler'
 )
@@ -54,7 +54,7 @@ client.fabric.ai_agents.delete(agent['id'])
 ### Calling -- Play and Record
 
 ```ruby
-call = client.calling.dial(from_: '+15559876543', to: '+15551234567', url: 'https://example.com/handler')
+call = client.calling.dial(from: '+15559876543', to: '+15551234567', url: 'https://example.com/handler')
 call_id = call['id']
 
 client.calling.play(call_id, play: [{ 'type' => 'tts', 'text' => 'Hello!' }])
@@ -65,7 +65,7 @@ client.calling.end_call(call_id, reason: 'hangup')
 ### Phone Numbers
 
 ```ruby
-available = client.phone_numbers.search(area_code: '512', max_results: 3)
+available = client.phone_numbers.search(areacode: '512', max_results: 3)
 number = client.phone_numbers.create(number: '+15125551234')
 client.phone_numbers.update(number['id'], name: 'Main Line')
 client.phone_numbers.delete(number['id'])
@@ -90,7 +90,7 @@ client.video.rooms.delete(room['id'])
 ### MFA
 
 ```ruby
-result = client.mfa.sms(to: '+15551234567', from_: '+15559876543', message: 'Code: {{code}}', token_length: 6)
+result = client.mfa.sms(to: '+15551234567', from: '+15559876543', message: 'Code: {{code}}', token_length: 6)
 client.mfa.verify(result['id'], token: '123456')
 ```
 

--- a/rest/examples/rest_calling_play_and_record.rb
+++ b/rest/examples/rest_calling_play_and_record.rb
@@ -19,7 +19,7 @@ client = SignalWire::REST::RestClient.new
 puts 'Dialing outbound call...'
 begin
   call = client.calling.dial(
-    from_: '+15559876543',
+    from: '+15559876543',
     to:    '+15551234567',
     url:   'https://example.com/call-handler'
   )

--- a/rest/examples/rest_manage_resources.rb
+++ b/rest/examples/rest_manage_resources.rb
@@ -38,7 +38,7 @@ end
 puts "\nPlacing a test call..."
 begin
   result = client.calling.dial(
-    from_: '+15559876543',
+    from: '+15559876543',
     to:    '+15551234567',
     url:   'https://example.com/call-handler'
   )

--- a/rest/examples/rest_queues_mfa_and_recordings.rb
+++ b/rest/examples/rest_queues_mfa_and_recordings.rb
@@ -84,7 +84,7 @@ request_id = nil
 begin
   sms_result = client.mfa.sms(
     to:           '+15551234567',
-    from_:        '+15559876543',
+    from:        '+15559876543',
     message:      'Your code is {{code}}',
     token_length: 6
   )
@@ -99,7 +99,7 @@ puts "\nSending MFA voice code..."
 begin
   voice_result = client.mfa.call(
     to:           '+15551234567',
-    from_:        '+15559876543',
+    from:        '+15559876543',
     message:      'Your verification code is {{code}}',
     token_length: 6
   )

--- a/tests/rest/small_namespaces_mock_test.rb
+++ b/tests/rest/small_namespaces_mock_test.rb
@@ -211,7 +211,7 @@ class SmallNamespacesMockTestPartTwo < Minitest::Test
   def test_mfa_call
     body = @client.mfa.call(
       to: '+15551234567',
-      from_: '+15559876543',
+      from: '+15559876543',
       message: 'Your code is {code}'
     )
 
@@ -219,7 +219,7 @@ class SmallNamespacesMockTestPartTwo < Minitest::Test
     # The mfa response has 'id', 'success', 'channel', 'to'.
     assert body.key?('id')
     last = assert_request('POST', "#{RELAY_BASE}/mfa/call")
-    assert_sent_body(last, 'to' => '+15551234567', 'from_' => '+15559876543',
+    assert_sent_body(last, 'to' => '+15551234567', 'from' => '+15559876543',
                            'message' => 'Your code is {code}')
   end
 


### PR DESCRIPTION
**Wave-1 wire-truth burn** (§A1/§A2 red list, ruby). `from_:` was never a declared kwarg — it fell into `**kwargs` and shipped as a bogus body key (and `dial(from_:)` doesn't run at all: `from:` is required → missing-keyword). Includes the plan's headline **test enshrinement**: `small_namespaces_mock_test.rb` asserted the bogus `'from_'` body key; it now pins the spec's `'from'`. Plus 3 `area_code`→`areacode` sites incl. the README-INCLUDE fixture.

**Verified:** fixed test file 19 runs / 106 assertions green · README-INCLUDE PASS · NO-LAUNDER clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DbkphxGZfj9bx9uyYDMFp