### PR TITLE
docs: correct false 'offline document search' claim — remote-only (W1.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ swaig-test my_agent.rb --exec get_time
 - **Call flow control** -- pre-answer, post-answer, and post-AI verb insertion
 - **Prefab agents** -- ready-to-use archetypes (InfoGatherer, Survey, FAQ, Receptionist, Concierge)
 - **Multi-agent hosting** -- serve multiple agents on a single server with `AgentServer`
-- **Local search** -- offline document search via the `native_vector_search` skill
+- **Document search** -- vector/keyword search over a remote index via the `native_vector_search` skill (remote HTTP mode; the Ruby port does not ship the offline/embedded backend)
 - **SIP routing** -- route SIP calls to agents based on usernames
 - **Session state** -- persistent conversation state with global data and post-prompt summaries
 - **Security** -- auto-generated basic auth, function-specific HMAC tokens, SSL support


### PR DESCRIPTION
**Wave-1 STATUS-CLAIM §C2 burn.** README claimed 'Local search -- offline document search', but `native_vector_search.rb` is remote-only: 'Network/remote mode only' (:13), requires `@remote_url` (:29), POSTs via `Net::HTTP` (:87). The Ruby port doesn't ship the offline backend. Corrected to remote-HTTP document search.

**Verified:** STATUS-CLAIM gate clean · README-INCLUDE PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DbkphxGZfj9bx9uyYDMFp