### PR TITLE
fix: resolve ruby issues #32/#34/#35/#36/#43/#44/#45

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,64 @@
+# SignalWire AI Agents SDK — example environment configuration.
+#
+# Copy to `.env` and fill in the values you need. Every variable the SDK reads
+# is listed here; most are optional (defaults shown in comments). Nothing in
+# this file is loaded automatically — export the vars, or use your own dotenv
+# loader — the SDK only reads process ENV.
+
+# ── Credentials (RELAY + REST) ────────────────────────────────────────────
+# Your SignalWire project id, API token, and space hostname.
+SIGNALWIRE_PROJECT_ID=
+SIGNALWIRE_API_TOKEN=
+SIGNALWIRE_SPACE=example.signalwire.com
+
+# ── Agent HTTP server ─────────────────────────────────────────────────────
+# Basic-auth credentials for the agent's SWML/SWAIG endpoints. If unset, the
+# SDK generates a random username/password at startup (printed in the log).
+SWML_BASIC_AUTH_USER=
+SWML_BASIC_AUTH_PASSWORD=
+# HMAC key for inbound webhook signature validation. Validation stays OFF until
+# this (or the agent's signing_key:) is set.
+SIGNALWIRE_SIGNING_KEY=
+# Base URL to advertise when the agent runs behind a reverse proxy, and the
+# external domain used to build absolute webhook/SSL URLs.
+SWML_PROXY_URL_BASE=
+SWML_DOMAIN=
+# TLS termination in-process (alternative to a proxy).
+SWML_SSL_ENABLED=false
+SWML_SSL_CERT_PATH=
+SWML_SSL_KEY_PATH=
+
+# ── Safety / validation toggles ───────────────────────────────────────────
+# Allow webhook/tool URLs that resolve to private or loopback addresses. Off by
+# default as an SSRF guard; set to 1/true/yes only for local development.
+SWML_ALLOW_PRIVATE_URLS=false
+# Skip SWML schema validation (1/true/yes). Leave unset in production.
+SWML_SKIP_SCHEMA_VALIDATION=false
+
+# ── Skills ────────────────────────────────────────────────────────────────
+# Extra directories to search for custom skills (colon-separated).
+SIGNALWIRE_SKILL_PATHS=
+
+# ── RELAY WebSocket overrides (testing / self-hosted) ─────────────────────
+# Redirect the RELAY client at a different host/scheme, and supply a custom CA
+# bundle for the TLS connection. Leave unset to use the SignalWire cloud.
+SIGNALWIRE_RELAY_HOST=
+SIGNALWIRE_RELAY_SCHEME=wss
+SIGNALWIRE_RELAY_SSL_CA_FILE=
+# Cap on simultaneously-tracked inbound calls in the RELAY client.
+RELAY_MAX_ACTIVE_CALLS=
+
+# ── Logging ───────────────────────────────────────────────────────────────
+SIGNALWIRE_LOG_LEVEL=info
+# Set to `off` to suppress all SDK logging.
+SIGNALWIRE_LOG_MODE=
+
+# ── Built-in skill endpoint overrides (testing / audit fixtures) ──────────
+# Each skill defaults to its production endpoint; these override the host so
+# tests and audits can point at a mock. Not needed for normal use.
+DATASPHERE_BASE_URL=
+WEATHER_API_BASE_URL=
+WEB_SEARCH_BASE_URL=
+WIKIPEDIA_BASE_URL=
+API_NINJAS_BASE_URL=
+SPIDER_BASE_URL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,9 @@ gem build signalwire-sdk.gemspec && gem install signalwire-sdk-*.gem
 ```bash
 # Test SWAIG functions locally (from bin/)
 ruby bin/swaig-test examples/simple_agent.rb --list-tools
-ruby bin/swaig-test examples/simple_agent.rb --exec tool_name --param value
+# --exec runs a tool; pass each argument as a separate --param KEY=VALUE
+# (values are parsed as JSON: numbers/true/false/null typed, else string):
+ruby bin/swaig-test examples/simple_agent.rb --exec get_weather --param location="San Francisco"
 
 # Build search indexes
 ruby bin/sw-search ./docs --output knowledge.swsearch

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ swaig-test my_agent.rb --simulate-serverless lambda \
 
 ### Agent Examples
 
-The [`examples/`](examples/) directory contains 54 working examples:
+The [`examples/`](examples/) directory contains 56 working examples:
 
 | Example | What it demonstrates |
 |---------|---------------------|

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ Each agent is a self-contained microservice that generates [SWML](docs/swml_serv
 ```ruby
 require 'signalwire'
 
-agent = SignalWire::AgentBase.new(name: 'my-agent', route: '/')
+AGENT = SignalWire::AgentBase.new(name: 'my-agent', route: '/')
 
-agent.add_language('English', 'en-US', 'elevenlabs.rachel')
-agent.prompt_add_section('Role', 'You are a helpful assistant.')
+AGENT.add_language('English', 'en-US', 'elevenlabs.rachel')
+AGENT.prompt_add_section('Role', 'You are a helpful assistant.')
 
-agent.define_tool(
+AGENT.define_tool(
   name:        'get_time',
   description: 'Get the current time',
   parameters:  {}
@@ -62,15 +62,18 @@ agent.define_tool(
   SignalWire::Swaig::FunctionResult.new("The time is #{Time.now.strftime('%H:%M:%S')}")
 end
 
-agent.run
+AGENT.run if __FILE__ == $PROGRAM_NAME
 ```
+
+Exposing the agent as the `AGENT` constant lets `swaig-test` discover it, and
+guarding `AGENT.run` keeps loading the file for a test from starting a server.
 
 Test locally without running a server:
 
 ```bash
-swaig-test my_agent.rb --simulate-serverless lambda --list-tools
-swaig-test my_agent.rb --simulate-serverless lambda --dump-swml
-swaig-test my_agent.rb --simulate-serverless lambda --exec get_time
+swaig-test quickstart_agent.rb --simulate-serverless lambda --list-tools
+swaig-test quickstart_agent.rb --simulate-serverless lambda --dump-swml
+swaig-test quickstart_agent.rb --simulate-serverless lambda --exec get_time
 ```
 
 ### Agent Features

--- a/README.md
+++ b/README.md
@@ -246,14 +246,26 @@ Guides are also available in the [`docs/`](docs/) directory:
 | `SIGNALWIRE_PROJECT_ID` | RELAY, REST | Project identifier |
 | `SIGNALWIRE_API_TOKEN` | RELAY, REST | API token |
 | `SIGNALWIRE_SPACE` | RELAY, REST | Space hostname (e.g. `example.signalwire.com`) |
+| `SIGNALWIRE_SIGNING_KEY` | Agents | HMAC key for inbound webhook signature validation (validation is off until set) |
 | `SWML_BASIC_AUTH_USER` | Agents | Basic auth username (default: auto-generated) |
 | `SWML_BASIC_AUTH_PASSWORD` | Agents | Basic auth password (default: auto-generated) |
 | `SWML_PROXY_URL_BASE` | Agents | Base URL when behind a reverse proxy |
+| `SWML_DOMAIN` | Agents | External domain used to build absolute webhook/SSL URLs |
 | `SWML_SSL_ENABLED` | Agents | Enable HTTPS (`true`, `1`, `yes`) |
 | `SWML_SSL_CERT_PATH` | Agents | Path to SSL certificate |
 | `SWML_SSL_KEY_PATH` | Agents | Path to SSL private key |
+| `SWML_ALLOW_PRIVATE_URLS` | Agents | Allow webhook/tool URLs pointing at private/loopback IPs (`1`/`true`/`yes`); off by default (SSRF guard) |
+| `SWML_SKIP_SCHEMA_VALIDATION` | Agents | Skip SWML schema validation (`1`/`true`/`yes`) |
+| `SIGNALWIRE_SKILL_PATHS` | Skills | Extra skill search directories (colon-separated) |
+| `SIGNALWIRE_RELAY_HOST` | RELAY | Override the RELAY WebSocket host (testing / self-hosted) |
+| `SIGNALWIRE_RELAY_SCHEME` | RELAY | Override the RELAY WebSocket scheme (`ws`/`wss`) |
+| `SIGNALWIRE_RELAY_SSL_CA_FILE` | RELAY | Custom CA bundle for the RELAY TLS connection |
 | `SIGNALWIRE_LOG_LEVEL` | All | Logging level (`debug`, `info`, `warn`, `error`) |
 | `SIGNALWIRE_LOG_MODE` | All | Set to `off` to suppress all logging |
+
+A ready-to-copy [`.env.example`](.env.example) at the repo root lists every
+environment variable the SDK reads, including the skill `*_BASE_URL` overrides
+used for testing.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ swaig-test quickstart_agent.rb --simulate-serverless lambda --dump-swml
 swaig-test quickstart_agent.rb --simulate-serverless lambda --exec get_time
 ```
 
+`--exec NAME` runs a tool. Pass each argument as its own `--param KEY=VALUE`
+(values are parsed as JSON — numbers, `true`/`false`, and `null` are typed;
+anything else is a string). For a tool `get_weather(location)`:
+
+```bash
+swaig-test my_agent.rb --simulate-serverless lambda \
+  --exec get_weather --param location="San Francisco" --param units=metric
+```
+
 ### Agent Features
 
 - **Prompt Object Model (POM)** -- structured prompt composition via `prompt_add_section`

--- a/ROOT_HYGIENE_ALLOW.md
+++ b/ROOT_HYGIENE_ALLOW.md
@@ -38,3 +38,7 @@ pipeline (which this port cannot edit).
 ## Gem build/publish manifest
 
 - signalwire-sdk.gemspec — gem build/publish manifest; the built-in allowlist covers Gemfile/Rakefile but not the per-port .gemspec (name varies), analogous to how .csproj/.sln are regex-allowed for dotnet (orchestrator, 2026-07-06)
+
+## Standard developer-config templates
+
+- .env.example — dotenv template documenting every env var the SDK reads (issue #36); a copy-to-`.env` file that must live at the repo root by the dotenv convention to serve its purpose, alongside the built-in .gitignore/.editorconfig config files (fix-ruby, 2026-07-14)

--- a/bin/swaig-test
+++ b/bin/swaig-test
@@ -157,7 +157,16 @@ module SwaigTest
       Object.constants.each do |c|
         next if c == :AGENT
 
-        value = Object.const_get(c)
+        # Some constants are autoload stubs that RAISE on resolution — most
+        # notably SortedSet on Ruby 3.2+ ("has been extracted from the `set`
+        # library"). A raising const_get must skip that constant, not abort the
+        # whole scan; otherwise discovery crashes for any agent not bound to an
+        # AGENT constant (the README quickstart style).
+        begin
+          value = Object.const_get(c)
+        rescue StandardError
+          next
+        end
         return value if value.is_a?(SignalWire::AgentBase)
       end
       nil

--- a/examples/quickstart_agent.rb
+++ b/examples/quickstart_agent.rb
@@ -4,17 +4,21 @@
 #
 # A self-contained microservice that generates SWML and handles SWAIG tool
 # calls. Run it with `ruby quickstart_agent.rb`, or test it without a server
-# via `swaig-test quickstart_agent.rb --list-tools`.
+# via `swaig-test quickstart_agent.rb --simulate-serverless lambda --list-tools`.
+#
+# The agent is exposed as the `AGENT` constant so swaig-test can discover it,
+# and the blocking `AGENT.run` is guarded so loading the file for a test does
+# not start a server.
 
 # region: agent
 require 'signalwire'
 
-agent = SignalWire::AgentBase.new(name: 'my-agent', route: '/')
+AGENT = SignalWire::AgentBase.new(name: 'my-agent', route: '/')
 
-agent.add_language('English', 'en-US', 'elevenlabs.rachel')
-agent.prompt_add_section('Role', 'You are a helpful assistant.')
+AGENT.add_language('English', 'en-US', 'elevenlabs.rachel')
+AGENT.prompt_add_section('Role', 'You are a helpful assistant.')
 
-agent.define_tool(
+AGENT.define_tool(
   name:        'get_time',
   description: 'Get the current time',
   parameters:  {}
@@ -22,5 +26,5 @@ agent.define_tool(
   SignalWire::Swaig::FunctionResult.new("The time is #{Time.now.strftime('%H:%M:%S')}")
 end
 
-agent.run
+AGENT.run if __FILE__ == $PROGRAM_NAME
 # endregion: agent

--- a/lib/signalwire/agent/agent_base.rb
+++ b/lib/signalwire/agent/agent_base.rb
@@ -889,13 +889,23 @@ module SignalWire
     #     specific tuning, voice settings, etc.). Emitted as the language
     #     object's ``params`` key in SWML; the key is only emitted when
     #     non-empty so existing entries stay byte-identical.
-    def add_language(name_or_config, code = nil, voice = nil,
+    #   @param opts [Hash] a braceless hash passed as the whole config —
+    #     ``add_language('name' => 'English', 'code' => 'en-US',
+    #     'voice' => '…')``. Ruby routes a trailing braceless hash toward
+    #     keywords, so this shape arrives here (not as +name_or_config+); it is
+    #     unfolded back into the hash config form.
+    def add_language(name_or_config = nil, code = nil, voice = nil,
                      speech_fillers: nil, function_fillers: nil,
-                     engine: nil, model: nil, params: nil)
+                     engine: nil, model: nil, params: nil, **opts)
+      # Braceless hash form: `add_language('name' => …, 'code' => …)` — Ruby
+      # collects the trailing pairs into **opts, leaving no positional. Re-route
+      # to the hash config form so the documented one-liner call just works.
+      name_or_config = braceless_config(name_or_config, opts)
+
       # Hash form (legacy / direct config)
       return (@languages << name_or_config) && self if hash_language_form?(name_or_config, code, voice)
 
-      raise ArgumentError, 'add_language: name, code, voice are required (or pass a Hash)' if code.nil? || voice.nil?
+      require_language_args!(name_or_config, code, voice)
 
       lang = { 'name' => name_or_config, 'code' => code }
       apply_language_voice(lang, voice, engine, model)
@@ -904,6 +914,21 @@ module SignalWire
       lang['params'] = params if params.is_a?(Hash) && !params.empty?
       @languages << lang
       self
+    end
+
+    # When no positional name was given but keyword-style pairs arrived (a
+    # braceless hash routed to **opts), fold them back into a string-keyed
+    # config hash; otherwise pass the positional name through unchanged.
+    def braceless_config(name_or_config, opts)
+      return name_or_config unless name_or_config.nil? && !opts.empty?
+
+      opts.transform_keys(&:to_s)
+    end
+
+    def require_language_args!(name, code, voice)
+      return unless name.nil? || code.nil? || voice.nil?
+
+      raise ArgumentError, 'add_language: name, code, voice are required (or pass a Hash)'
     end
 
     def hash_language_form?(name_or_config, code, voice)

--- a/lib/signalwire/agent/agent_base.rb
+++ b/lib/signalwire/agent/agent_base.rb
@@ -2645,6 +2645,7 @@ module SignalWire
     # methods span multiple public/private regions above.
     private :add_context_step, :add_pom_section, :append_section_bullets, :apply_compound_voice
     private :apply_dynamic_config, :apply_language_fillers, :apply_language_voice, :attach_context_builder
+    private :braceless_config, :require_language_args!
     private :basic_auth_source, :build_context_builder_from_hash, :build_pattern_hint, :build_section
     private :build_subsection, :build_subsections, :build_tool_definition, :build_tool_param_schema
     private :coerce_function_result, :compound_voice?, :define_skill_tool, :find_or_create_section

--- a/lib/signalwire/skills/builtin/datasphere.rb
+++ b/lib/signalwire/skills/builtin/datasphere.rb
@@ -47,10 +47,7 @@ module SignalWire
         # the host (the `/api/datasphere/...` path is preserved so the audit
         # can match on `datasphere` in req.path).
         def datasphere_host_url
-          override = ENV.fetch('DATASPHERE_BASE_URL', nil)
-          return override.sub(%r{/$}, '') unless override.nil? || override.empty?
-
-          "https://#{@space_name}.signalwire.com"
+          resolved_base_url('DATASPHERE_BASE_URL', "https://#{@space_name}.signalwire.com")
         end
 
         def handle_search(args, _raw_data)

--- a/lib/signalwire/skills/builtin/datetime.rb
+++ b/lib/signalwire/skills/builtin/datetime.rb
@@ -23,12 +23,14 @@ module SignalWire
         def name = 'datetime'
         def description = 'Get current date, time, and timezone information'
 
-        # Timezones are resolved through the stdlib ``time``/``date``
-        # libraries (no third-party dependency), so setup verifies those
-        # are loadable and returns whether the skill is ready.
+        # Timezones are resolved through the ``tzinfo`` gem — a thread-safe,
+        # OS-tzdata-independent lookup that needs no process-global ENV['TZ']
+        # mutation. Setup verifies the libraries are loadable and returns
+        # whether the skill is ready.
         def setup
           require 'time'
           require 'date'
+          require 'tzinfo'
           true
         rescue LoadError => e
           logger.error("datetime skill setup failed: #{e.message}")
@@ -103,17 +105,18 @@ module SignalWire
           return Time.now.utc if tz_name.upcase == 'UTC'
 
           time_in_zone(tz_name)
-        rescue StandardError
-          nil
         end
 
-        # ENV-based TZ resolution (works on most systems). If TZ is invalid,
-        # Ruby silently falls back to UTC on some platforms.
+        # Thread-safe timezone resolution via tzinfo — no process-global
+        # ENV['TZ'] mutation, so concurrent calls with different timezones
+        # never clobber each other, and the result is independent of the host
+        # OS tzdata layout. An unknown timezone returns nil so the caller
+        # emits the "unknown timezone" error result.
         def time_in_zone(tz_name)
-          ENV['TZ'] = tz_name
-          Time.now
-        ensure
-          ENV.delete('TZ')
+          require 'tzinfo'
+          TZInfo::Timezone.get(tz_name).now
+        rescue TZInfo::InvalidTimezoneIdentifier
+          nil
         end
       end
     end

--- a/lib/signalwire/skills/builtin/weather_api.rb
+++ b/lib/signalwire/skills/builtin/weather_api.rb
@@ -100,9 +100,7 @@ module SignalWire
         # overrides for tests and the audit fixture. The `/v1/current.json`
         # path is preserved so the audit can match on `current.json`.
         def base_url
-          base = ENV.fetch('WEATHER_API_BASE_URL', nil)
-          base = 'https://api.weatherapi.com' if base.nil? || base.empty?
-          base.sub(%r{/$}, '')
+          resolved_base_url('WEATHER_API_BASE_URL', 'https://api.weatherapi.com')
         end
 
         def fallback_message

--- a/lib/signalwire/skills/builtin/web_search.rb
+++ b/lib/signalwire/skills/builtin/web_search.rb
@@ -240,9 +240,8 @@ module SignalWire
         # is the *host*, the `/customsearch/v1` path is appended so the audit
         # can match on `customsearch` in req.path).
         def google_search_uri(query, num)
-          base = ENV.fetch('WEB_SEARCH_BASE_URL', nil)
-          base = 'https://www.googleapis.com' if base.nil? || base.empty?
-          uri = URI("#{base.sub(%r{/$}, '')}/customsearch/v1")
+          base = resolved_base_url('WEB_SEARCH_BASE_URL', 'https://www.googleapis.com')
+          uri = URI("#{base}/customsearch/v1")
           uri.query = URI.encode_www_form(
             key: @api_key, cx: @search_engine_id, q: query, num: [num, 10].min
           )

--- a/lib/signalwire/skills/builtin/wikipedia_search.rb
+++ b/lib/signalwire/skills/builtin/wikipedia_search.rb
@@ -83,9 +83,7 @@ module SignalWire
         # `/w/api.php` path is appended so audit_skills_dispatch can match
         # on `api.php` in req.path.
         def api_endpoint
-          base = ENV.fetch('WIKIPEDIA_BASE_URL', nil)
-          base = 'https://en.wikipedia.org' if base.nil? || base.empty?
-          "#{base.sub(%r{/$}, '')}/w/api.php"
+          "#{resolved_base_url('WIKIPEDIA_BASE_URL', 'https://en.wikipedia.org')}/w/api.php"
         end
 
         # Step 1: Search. Returns the list of result hashes, or nil if the

--- a/lib/signalwire/skills/skill_base.rb
+++ b/lib/signalwire/skills/skill_base.rb
@@ -156,6 +156,22 @@ module SignalWire
 
       private
 
+      # Resolve a skill's base URL: the +env_var+ override when set and
+      # non-empty, otherwise +default+, with any trailing slash stripped so
+      # callers can append a path segment cleanly. Centralizes the
+      # `ENV.fetch(...) → default → sub(%r{/$}, '')` pattern the HTTP skills
+      # each hand-rolled. Private: an internal helper for subclasses, not part
+      # of the enumerated public skill surface.
+      #
+      # @param env_var [String] the override env var name (e.g. "WEATHER_API_BASE_URL")
+      # @param default [String] the production host used when the override is absent
+      # @return [String] the resolved base URL, without a trailing slash
+      def resolved_base_url(env_var, default)
+        base = ENV.fetch(env_var, nil)
+        base = default if base.nil? || base.empty?
+        base.sub(%r{/$}, '')
+      end
+
       # Logger namespace segment: the skill +name+, or the class name when
       # +name+ is still the abstract NotImplementedError raiser.
       def logger_name_segment

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -5025,7 +5025,8 @@
                 {
                   "name": "name_or_config",
                   "type": "any",
-                  "required": true
+                  "required": false,
+                  "default": null
                 },
                 {
                   "name": "code",
@@ -5071,6 +5072,13 @@
                   "name": "params",
                   "type": "optional<dict<string,any>>",
                   "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "opts",
+                  "type": "any",
+                  "kind": "var_keyword",
                   "required": false,
                   "default": null
                 }

--- a/signalwire-sdk.gemspec
+++ b/signalwire-sdk.gemspec
@@ -30,6 +30,9 @@ Gem::Specification.new do |s|
   # Runtime dependencies — keep minimal
   s.add_dependency 'rack', '>= 2.0'
   s.add_dependency 'rackup', '>= 1.0'
+  # tzinfo powers thread-safe, OS-tzdata-independent timezone resolution in the
+  # datetime skill (no process-global ENV['TZ'] mutation).
+  s.add_dependency 'tzinfo', '>= 2.0'
   s.add_dependency 'webrick', '>= 1.7'
   s.add_dependency 'websocket-client-simple', '>= 0.8'
 

--- a/tests/aiconfig_test.rb
+++ b/tests/aiconfig_test.rb
@@ -72,6 +72,39 @@ class AIConfigLanguagesTest < Minitest::Test
 
     assert_equal 2, ai['languages'].length
   end
+
+  # #34 regression (RED on the pre-fix code, which raised ArgumentError
+  # "wrong number of arguments (given 0)"). A braceless string-keyed hash —
+  # `add_language('name' => …, 'code' => …, 'voice' => …)` — is routed by Ruby
+  # toward keywords; it must be accepted as the hash config form.
+  def test_add_language_braceless_string_keyed_hash
+    @agent.add_language('name' => 'English', 'code' => 'en-US', 'voice' => 'rachel')
+    langs = @agent.instance_variable_get(:@languages)
+
+    assert_equal 1, langs.length
+    assert_equal 'English', langs[0]['name']
+    assert_equal 'en-US', langs[0]['code']
+    assert_equal 'rachel', langs[0]['voice']
+  end
+
+  # The braceless symbol-keyed shape must also work, with keys stringified to
+  # match SWML's string-keyed language config.
+  def test_add_language_braceless_symbol_keyed_hash
+    @agent.add_language(name: 'French', code: 'fr-FR', voice: 'amelie')
+    langs = @agent.instance_variable_get(:@languages)
+
+    assert_equal 'French', langs[0]['name']
+    assert_equal 'fr-FR', langs[0]['code']
+  end
+
+  # The positional form remains supported (no regression).
+  def test_add_language_positional_form
+    @agent.add_language('Spanish', 'es-ES', 'es-ES-Neural2-A')
+    langs = @agent.instance_variable_get(:@languages)
+
+    assert_equal 'Spanish', langs[0]['name']
+    assert_equal 'es-ES-Neural2-A', langs[0]['voice']
+  end
 end
 
 # Ports Python 029ca6f: per-language params via add_language(params:),

--- a/tests/cli_test.rb
+++ b/tests/cli_test.rb
@@ -396,3 +396,61 @@ class SwaigTestCLIFileModeTest < Minitest::Test
     end
   end
 end
+
+# #45 regression: the agent-discovery scan (AgentFileLoader.discovered_agent)
+# iterates Object.constants + Object.const_get. On Ruby 3.2+, resolving the
+# SortedSet autoload stub RAISES (RuntimeError "has been extracted from the
+# `set` library"). Before the fix a raising const_get aborted the whole scan,
+# so `swaig-test my_agent.rb` crashed for any agent NOT bound to an AGENT
+# constant (the README quickstart style). These tests define a raising
+# autoload stub and assert the scan survives it and still finds the agent.
+class SwaigTestDiscoveryScanTest < Minitest::Test
+  def teardown
+    %i[BrokenAutoloadFixture QuickstartAgentFixture].each do |c|
+      Object.send(:remove_const, c) if Object.const_defined?(c, false)
+    end
+  end
+
+  # A top-level constant whose const_get raises StandardError — the same shape
+  # as the SortedSet autoload stub that crashed the scan.
+  def install_raising_constant
+    Object.autoload(:BrokenAutoloadFixture, '/nonexistent/raises_on_resolve_xyz')
+    # Redefine const_get so resolving the fixture raises RuntimeError (matching
+    # SortedSet), not the LoadError a bare autoload-miss would give — proving the
+    # `rescue StandardError` guard, which is what the real bug needs.
+    def Object.const_get(name, *args)
+      raise 'BrokenAutoloadFixture raises on resolve' if name == :BrokenAutoloadFixture
+
+      super
+    end
+  end
+
+  def uninstall_raising_constant
+    class << Object
+      remove_method(:const_get)
+    end
+  end
+
+  def test_scan_survives_a_raising_autoload_and_finds_the_agent
+    agent = SignalWire::AgentBase.new(name: 'quickstart')
+    Object.const_set(:QuickstartAgentFixture, agent)
+    install_raising_constant
+
+    found = SwaigTest::AgentFileLoader.discovered_agent
+
+    assert_same agent, found,
+                'scan must skip the raising constant and still find the agent'
+  ensure
+    uninstall_raising_constant
+  end
+
+  def test_scan_does_not_raise_when_a_constant_resolution_raises
+    install_raising_constant
+
+    # No agent defined: the scan should return nil (not crash) when it walks
+    # past the raising constant.
+    assert_nil SwaigTest::AgentFileLoader.discovered_agent
+  ensure
+    uninstall_raising_constant
+  end
+end

--- a/tests/skills/datetime_skill_test.rb
+++ b/tests/skills/datetime_skill_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'minitest/autorun'
+require 'tzinfo'
 require_relative '../../lib/signalwire/swaig/function_result'
 require_relative '../../lib/signalwire/skills/skill_base'
 require_relative '../../lib/signalwire/skills/skill_registry'
@@ -70,5 +71,77 @@ class DateTimeSkillDetailedTest < Minitest::Test
     skill = factory.call({})
 
     assert skill.setup
+  end
+
+  # --- #32 regression: thread-safe, ENV-clean timezone resolution ---------
+  # (Correct wall-clock per zone is asserted under load by the concurrent test.)
+
+  # An unknown timezone must return the "unknown timezone" error result, not
+  # silently fall back to UTC (the old ENV['TZ'] path did on some platforms).
+  def test_unknown_timezone_returns_error_result
+    assert_match(/unknown timezone/i, call_time('Not/AZone'))
+  end
+
+  # Would have caught the bug: resolving a zone must NEVER mutate the
+  # process-global ENV['TZ'] (the old code set ENV['TZ'] = tz_name to compute it).
+  def test_env_tz_is_never_mutated
+    ENV.delete('TZ')
+    call_time('Asia/Tokyo')
+
+    assert_nil ENV.fetch('TZ', nil), "resolving a timezone must not set ENV['TZ']"
+
+    ENV['TZ'] = 'America/Chicago'
+    call_time('Europe/Paris')
+
+    assert_equal 'America/Chicago', ENV.fetch('TZ', nil),
+                 "resolving a timezone must not clobber a pre-existing ENV['TZ']"
+  ensure
+    ENV.delete('TZ')
+  end
+
+  # Would have caught the bug: concurrent calls with different zones must not
+  # corrupt each other (the old ENV['TZ'] mutation let one thread leak into
+  # another's Time.now). Each thread checks its own zone vs tzinfo under load.
+  def test_concurrent_different_timezones_do_not_corrupt_each_other
+    zones = %w[America/New_York Asia/Tokyo Europe/London Australia/Sydney Pacific/Honolulu]
+    mismatches = []
+    threads = zones.map { |zone| Thread.new { 50.times { verify_zone(zone, mismatches) } } }
+    threads.each(&:join)
+
+    assert_empty mismatches,
+                 "concurrent zone resolution corrupted results: #{mismatches.first(3).inspect}"
+  end
+
+  private
+
+  # Call get_current_time for a zone and return its FunctionResult response text.
+  def call_time(zone)
+    tool = @skill.register_tools.find { |t| t[:name] == 'get_current_time' }
+    tool[:handler].call({ 'timezone' => zone }, {}).response
+  end
+
+  # Record a mismatch if the skill's wall-clock for +zone+ disagrees with tzinfo.
+  def verify_zone(zone, mismatches)
+    expected = TZInfo::Timezone.get(zone).now.strftime('%I:%M %p')
+    got = call_time(zone)[/\d{1,2}:\d{2}:\d{2} [AP]M/]&.sub(/:\d{2} /, ' ')
+    mismatches << [zone, expected, got] unless got && near_minute?(expected, got)
+  end
+
+  # True when two "HH:MM AM/PM" strings are within one minute of each other
+  # (tolerates the clock ticking over between the handler call and the assert).
+  def near_minute?(expected, got)
+    e = minutes_of(expected)
+    g = minutes_of(got)
+    return false unless e && g
+
+    diff = (e - g).abs
+    diff <= 1 || diff >= ((12 * 60) - 1)
+  end
+
+  def minutes_of(str)
+    m = str.match(/(\d{1,2}):(\d{2}) ([AP])M/)
+    return nil unless m
+
+    (((m[1].to_i % 12) + (m[3] == 'P' ? 12 : 0)) * 60) + m[2].to_i
   end
 end

--- a/tests/skills_test.rb
+++ b/tests/skills_test.rb
@@ -745,6 +745,36 @@ class SkillBaseTest < Minitest::Test
     ENV.delete('TEST_SKILL_KEY')
   end
 
+  # resolved_base_url is a private internal helper (kept off the enumerated
+  # public surface), so exercise it via send.
+  def test_resolved_base_url_uses_default_when_env_unset
+    ENV.delete('TEST_BASE_URL')
+    skill = SignalWire::Skills::SkillBase.new({})
+
+    assert_equal 'https://api.example.com',
+                 skill.send(:resolved_base_url, 'TEST_BASE_URL', 'https://api.example.com/')
+  end
+
+  def test_resolved_base_url_uses_default_when_env_blank
+    ENV['TEST_BASE_URL'] = ''
+    skill = SignalWire::Skills::SkillBase.new({})
+
+    assert_equal 'https://api.example.com',
+                 skill.send(:resolved_base_url, 'TEST_BASE_URL', 'https://api.example.com')
+  ensure
+    ENV.delete('TEST_BASE_URL')
+  end
+
+  def test_resolved_base_url_override_wins_and_strips_trailing_slash
+    ENV['TEST_BASE_URL'] = 'http://localhost:9000/'
+    skill = SignalWire::Skills::SkillBase.new({})
+
+    assert_equal 'http://localhost:9000',
+                 skill.send(:resolved_base_url, 'TEST_BASE_URL', 'https://api.example.com')
+  ensure
+    ENV.delete('TEST_BASE_URL')
+  end
+
   def test_abstract_methods_raise
     skill = SignalWire::Skills::SkillBase.new({})
     assert_raises(NotImplementedError) { skill.name }


### PR DESCRIPTION
Fixes a batch of concrete, verified open Ruby issues. One commit per issue; each behavior fix ships a regression test that FAILS on the pre-fix code (RED) and PASSES after.

## Commit → issue map

| Commit | Issue | What |
|---|---|---|
| `fix(skills): thread-safe timezone resolution` | **#32** | datetime skill mutated process-global `ENV['TZ']` to compute a zone — thread-unsafe + OS-tzdata-dependent. Now uses the `tzinfo` gem (`TZInfo::Timezone.get(tz).now`); unknown zone → error result; UTC fast-path kept. `tzinfo` added as a runtime dep. |
| `fix(agent): accept braceless hash form of add_language` | **#34** | `add_language('name'=>…, 'code'=>…, 'voice'=>…)` raised `ArgumentError: wrong number of arguments (given 0)` — Ruby routes a trailing braceless hash toward keywords. Now accepts braceless string- **and** symbol-keyed hashes, the explicit brace hash, and the positional form. |
| `fix(cli): survive raising autoload stubs in agent discovery` | **#45** | `swaig-test <file>` scanned `Object.constants`/`const_get`; on Ruby 3.2+ the SortedSet autoload stub RAISES and aborted the scan, crashing discovery for any agent not bound to a constant. Now `rescue StandardError; next`. Also aligns the README quickstart to the working `AGENT =` + guarded-`run` pattern (verified end-to-end). |
| `docs: correct swaig-test --param syntax` | **#44** | CLAUDE.md showed the wrong `--param value`; corrected to the real `--param KEY=VALUE` and added a worked README example. |
| `docs: correct examples count 54 -> 56` | **#35** | README said 54; `ls examples/*.rb` is 56. |
| `docs: add .env.example and complete the README env-var table` + `chore: allowlist .env.example` | **#36** | No `.env.example` existed and the README env table omitted many real vars. Enumerated every `ENV[...]` key in `lib/`, added a grouped root `.env.example`, and completed the README table (SIGNING_KEY, SWML_DOMAIN, SWML_ALLOW_PRIVATE_URLS, SWML_SKIP_SCHEMA_VALIDATION, SIGNALWIRE_SKILL_PATHS, RELAY host/scheme/CA overrides). |
| `refactor(skills): extract resolved_base_url helper` | **#43** | The 4 HTTP skills (datasphere/weather_api/web_search/wikipedia_search) hand-rolled the same `ENV.fetch → default → strip-slash` logic; extracted a private `SkillBase#resolved_base_url` helper (kept off the enumerated surface) and routed all four through it. |

**Out of scope (deferred, per triage):** #41 (idiomatic-Ruby alignment pass) and #42 (test-suite overhaul) — too broad/subjective for this PR.

## Regression tests (RED-proven)
- **#32**: unknown-zone → error result; `ENV['TZ']` never mutated/clobbered; concurrent multi-zone resolution stays correct under contention. (3 failures on pre-fix code.)
- **#34**: braceless string-keyed and symbol-keyed forms (exact `ArgumentError` on pre-fix code) + positional no-regression.
- **#45**: discovery scan survives a constant whose `const_get` raises and still finds the agent (and returns nil, not a crash, when none is defined). (2 errors on pre-fix code.)

## Verification
Full `bash scripts/run-ci.sh` → **CI PASS** (all ~40 gates green: TEST 2460 runs/0 failures, LINT, FMT, DRIFT, SURFACE-DIFF, DOC-ENV, DOC-CLI, COUNT-CLAIM, README-INCLUDE, ROOT-HYGIENE, SEMVER-DIFF, PACKAGE-SMOKE, REST-COVERAGE, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
