### PR TITLE
test(ruby): suite quality improvements (#42)

### DIFF
--- a/tests/cli_test.rb
+++ b/tests/cli_test.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require_relative 'test_helper'
 require 'json'
 require 'net/http'
 require 'uri'
-require 'socket'
 require 'stringio'
 
 # Suppress logging during tests
@@ -189,6 +188,8 @@ end
 
 # Integration tests that start a real WEBrick server and test the CLI against it
 class SwaigTestCLIIntegrationTest < Minitest::Test
+  include TestHelper::Helpers
+
   def setup
     @port = find_available_port
     @agent = build_test_agent(@port)
@@ -270,25 +271,6 @@ class SwaigTestCLIIntegrationTest < Minitest::Test
   end
 
   private
-
-  def find_available_port
-    server = TCPServer.new('127.0.0.1', 0)
-    port = server.addr[1]
-    server.close
-    port
-  end
-
-  def wait_for_server(host, port, timeout: 5)
-    deadline = Time.now + timeout
-    loop do
-      TCPSocket.new(host, port).close
-      return
-    rescue Errno::ECONNREFUSED, Errno::ECONNRESET
-      raise "Server did not start within #{timeout}s" if Time.now > deadline
-
-      sleep 0.05
-    end
-  end
 
   def capture_stdout
     old_stdout = $stdout

--- a/tests/per_skill_parity_test.rb
+++ b/tests/per_skill_parity_test.rb
@@ -18,85 +18,16 @@
 # reached via the skills' own SPIDER_BASE_URL / WIKIPEDIA_BASE_URL overrides —
 # so the actual fetch/parse code path runs, not a stand-in.
 
-require 'minitest/autorun'
-require 'webrick'
+require_relative 'test_helper'
 require 'json'
-require 'socket'
 
-require_relative '../lib/signalwire/swaig/function_result'
-require_relative '../lib/signalwire/skills/skill_base'
-require_relative '../lib/signalwire/skills/skill_registry'
 require_relative '../lib/signalwire/skills/builtin/datetime'
 require_relative '../lib/signalwire/skills/builtin/math'
 require_relative '../lib/signalwire/skills/builtin/spider'
 require_relative '../lib/signalwire/skills/builtin/wikipedia_search'
 
-# ---------------------------------------------------------------------------
-# Tiny local HTTP fixture. A block decides each response based on the request;
-# returns [content_type, body] (or nil for 404). Bound to an ephemeral port on
-# loopback so tests never touch the network or the shared mock server.
-# ---------------------------------------------------------------------------
-class LocalHTTPFixture
-  attr_reader :port
-
-  def initialize(&handler)
-    @handler = handler
-    @port = pick_free_port
-    @server = build_server(@port)
-    @server.mount_proc('/') { |req, res| render_response(req, res) }
-    @thread = Thread.new { @server.start }
-    wait_until_ready
-  end
-
-  def base_url
-    "http://127.0.0.1:#{@port}"
-  end
-
-  def shutdown
-    @server&.shutdown
-    @thread&.join(5)
-  end
-
-  private
-
-  def build_server(port)
-    WEBrick::HTTPServer.new(
-      BindAddress: '127.0.0.1',
-      Port: port,
-      Logger: WEBrick::Log.new(File.open(File::NULL, 'w'), WEBrick::Log::FATAL),
-      AccessLog: []
-    )
-  end
-
-  def render_response(req, res)
-    result = @handler.call(req)
-    if result.nil?
-      res.status = 404
-      res.body = 'not found'
-    else
-      content_type, body = result
-      res.status = 200
-      res['Content-Type'] = content_type
-      res.body = body
-    end
-  end
-
-  def pick_free_port
-    s = TCPServer.new('127.0.0.1', 0)
-    port = s.addr[1]
-    s.close
-    port
-  end
-
-  def wait_until_ready
-    20.times do
-      TCPSocket.new('127.0.0.1', @port).close
-      return
-    rescue Errno::ECONNREFUSED
-      sleep 0.05
-    end
-  end
-end
+# The ephemeral-port WEBrick fixture now lives in the shared helper.
+LocalHTTPFixture = TestHelper::LocalHTTPFixture
 
 # ---------------------------------------------------------------------------
 # DateTimeSkill / MathSkill: setup + get_parameter_schema overrides

--- a/tests/relay/call_test.rb
+++ b/tests/relay/call_test.rb
@@ -23,7 +23,8 @@ class RelayCallDetailedTest < Minitest::Test
     @call = SignalWire::Relay::Call.new(
       @stub_client,
       call_id: 'call-1', node_id: 'node-1', project_id: 'proj-1',
-      context: 'default', tag: 'tag-1', direction: 'inbound', state: 'answered'
+      context: 'default', tag: 'tag-1', direction: 'inbound',
+      state: SignalWire::Relay::CallState::ANSWERED
     )
   end
 
@@ -34,14 +35,14 @@ class RelayCallDetailedTest < Minitest::Test
     assert_equal 'default', @call.context
     assert_equal 'tag-1', @call.tag
     assert_equal 'inbound', @call.direction
-    assert_equal 'answered', @call.state
+    assert_equal SignalWire::Relay::CallState::ANSWERED, @call.state
   end
 
   def test_call_to_s
     str = @call.to_s
 
     assert_match(/call-1/, str)
-    assert_match(/answered/, str)
+    assert_match(/#{SignalWire::Relay::CallState::ANSWERED}/o, str)
   end
 
   def test_call_answer
@@ -118,11 +119,12 @@ class RelayCallDetailedTest < Minitest::Test
   def test_state_update_on_event
     payload = {
       'event_type' => 'calling.call.state',
-      'params' => { 'call_id' => 'call-1', 'call_state' => 'ended', 'end_reason' => 'hangup' }
+      'params' => { 'call_id' => 'call-1', 'call_state' => SignalWire::Relay::CallState::ENDED,
+                    'end_reason' => 'hangup' }
     }
     @call._dispatch_event(payload)
 
-    assert_equal 'ended', @call.state
+    assert_equal SignalWire::Relay::CallState::ENDED, @call.state
     assert_predicate @call, :ended?
   end
 
@@ -132,7 +134,7 @@ class RelayCallDetailedTest < Minitest::Test
     refute_predicate action, :done?
     payload = {
       'event_type' => 'calling.call.state',
-      'params' => { 'call_id' => 'call-1', 'call_state' => 'ended' }
+      'params' => { 'call_id' => 'call-1', 'call_state' => SignalWire::Relay::CallState::ENDED }
     }
     @call._dispatch_event(payload)
 

--- a/tests/relay/message_test.rb
+++ b/tests/relay/message_test.rb
@@ -11,13 +11,13 @@ class RelayMessageDetailedTest < Minitest::Test
     msg = SignalWire::Relay::Message.new(
       message_id: 'msg-1', context: 'default', direction: 'outbound',
       from_number: '+15551111111', to_number: '+15552222222',
-      body: 'Hello', state: 'queued'
+      body: 'Hello', state: SignalWire::Relay::MessageState::QUEUED
     )
 
     assert_equal 'msg-1', msg.message_id
     assert_equal 'outbound', msg.direction
     assert_equal 'Hello', msg.body
-    assert_equal 'queued', msg.state
+    assert_equal SignalWire::Relay::MessageState::QUEUED, msg.state
     refute_predicate msg, :done?
   end
 
@@ -27,25 +27,28 @@ class RelayMessageDetailedTest < Minitest::Test
   end
 
   def test_message_state_dispatch
-    msg = SignalWire::Relay::Message.new(message_id: 'msg-2', state: 'queued')
+    msg = SignalWire::Relay::Message.new(message_id: 'msg-2',
+                                         state: SignalWire::Relay::MessageState::QUEUED)
 
-    msg._dispatch_event(state_event('msg-2', 'sent'))
+    msg._dispatch_event(state_event('msg-2', SignalWire::Relay::MessageState::SENT))
 
-    assert_equal 'sent', msg.state
+    assert_equal SignalWire::Relay::MessageState::SENT, msg.state
     refute_predicate msg, :done?
 
-    msg._dispatch_event(state_event('msg-2', 'delivered'))
+    msg._dispatch_event(state_event('msg-2', SignalWire::Relay::MessageState::DELIVERED))
 
-    assert_equal 'delivered', msg.state
+    assert_equal SignalWire::Relay::MessageState::DELIVERED, msg.state
     assert_predicate msg, :done?
   end
 
   def test_message_on_completed
-    msg = SignalWire::Relay::Message.new(message_id: 'msg-4', state: 'queued')
+    msg = SignalWire::Relay::Message.new(message_id: 'msg-4',
+                                         state: SignalWire::Relay::MessageState::QUEUED)
     callback_fired = false
     msg.on_completed { callback_fired = true }
 
-    msg._dispatch_event(state_event('msg-4', 'failed', 'reason' => 'carrier error'))
+    msg._dispatch_event(state_event('msg-4', SignalWire::Relay::MessageState::FAILED,
+                                    'reason' => 'carrier error'))
 
     assert callback_fired
     assert_equal 'carrier error', msg.reason
@@ -53,7 +56,7 @@ class RelayMessageDetailedTest < Minitest::Test
 
   def test_message_to_s
     msg = SignalWire::Relay::Message.new(
-      message_id: 'msg-6', direction: 'outbound', state: 'queued',
+      message_id: 'msg-6', direction: 'outbound', state: SignalWire::Relay::MessageState::QUEUED,
       from_number: '+15551111111', to_number: '+15552222222'
     )
     str = msg.to_s
@@ -63,10 +66,11 @@ class RelayMessageDetailedTest < Minitest::Test
   end
 
   def test_message_wait_with_timeout
-    msg = SignalWire::Relay::Message.new(message_id: 'msg-3', state: 'queued')
+    msg = SignalWire::Relay::Message.new(message_id: 'msg-3',
+                                         state: SignalWire::Relay::MessageState::QUEUED)
     Thread.new do
       sleep 0.05
-      msg._dispatch_event(state_event('msg-3', 'delivered'))
+      msg._dispatch_event(state_event('msg-3', SignalWire::Relay::MessageState::DELIVERED))
     end
     result = msg.wait(timeout: 2)
 
@@ -77,7 +81,7 @@ end
 
 # Tier-2 idiom layer: pattern matching / to_h / value equality.
 class RelayMessageIdiomTest < Minitest::Test
-  def sample_message(message_id: 'msg-9', state: 'queued')
+  def sample_message(message_id: 'msg-9', state: SignalWire::Relay::MessageState::QUEUED)
     SignalWire::Relay::Message.new(
       message_id: message_id, context: 'default', direction: 'outbound',
       from_number: '+15551111111', to_number: '+15552222222',
@@ -103,18 +107,18 @@ class RelayMessageIdiomTest < Minitest::Test
   def test_message_deconstruct_keys_subset
     subset = sample_message.deconstruct_keys(%i[message_id state])
 
-    assert_equal({ message_id: 'msg-9', state: 'queued' }, subset)
+    assert_equal({ message_id: 'msg-9', state: SignalWire::Relay::MessageState::QUEUED }, subset)
     refute subset.key?(:body), 'subset must not include unrequested keys'
   end
 
   def test_message_array_pattern_match
     destructured =
-      case sample_message(message_id: 'msg-arr', state: 'sent')
+      case sample_message(message_id: 'msg-arr', state: SignalWire::Relay::MessageState::SENT)
       in [id, direction, state]
         [id, direction, state]
       end
 
-    assert_equal %w[msg-arr outbound sent], destructured
+    assert_equal ['msg-arr', 'outbound', SignalWire::Relay::MessageState::SENT], destructured
   end
 
   def test_message_to_h_excludes_completion_machinery

--- a/tests/rest/small_namespaces_mock_test.rb
+++ b/tests/rest/small_namespaces_mock_test.rb
@@ -47,6 +47,28 @@ module SmallNamespacesHelpers
 
     expected.each { |k, v| assert_equal(v, sent[k], "body[#{k.inspect}]") }
   end
+
+  # The mock's queue-member example uses one id for both queue_id and call_id.
+  QUEUE_MEMBER_ID = '596e2dea-a269-4765-a0b4-01b82d11c120'
+
+  # Assert the SIP-profile resource shape returned by the mock.
+  def assert_sip_profile_shape(body)
+    assert_equal 'your-space-example.sip.signalwire.com', body['domain']
+    assert_equal 'example', body['domain_identifier']
+    assert_equal 'optional', body['default_encryption']
+    %w[default_codecs default_ciphers].each do |field|
+      assert_kind_of Array, body[field], "sip_profile.#{field} must be an array"
+    end
+  end
+
+  # Assert the queue-member resource shape returned by the mock.
+  def assert_queue_member_shape(body)
+    assert_equal QUEUE_MEMBER_ID, body['queue_id']
+    assert_equal QUEUE_MEMBER_ID, body['call_id']
+    assert_equal 'd421473b-d696-449a-a1a1-4ddd83d2d0e5', body['project_id']
+    assert_equal 2, body['position']
+    assert_equal "#{RELAY_BASE}/queues/#{QUEUE_MEMBER_ID}/members/#{QUEUE_MEMBER_ID}", body['uri']
+  end
 end
 
 class SmallNamespacesMockTest < Minitest::Test
@@ -232,8 +254,9 @@ class SmallNamespacesMockTestPartTwo < Minitest::Test
     )
 
     assert_kind_of Hash, body
-    # The SIP profile resource has a 'domain' field.
-    assert(body.key?('domain') || body.key?('default_codecs'))
+    # Exact SIP-profile resource shape returned by the mock (was: presence-only
+    # disjunctive key check).
+    assert_sip_profile_shape(body)
     last = assert_request('PUT', "#{RELAY_BASE}/sip_profile")
     assert_sent_body(last, 'domain' => 'myco.sip.signalwire.com', 'default_codecs' => %w[PCMU PCMA])
   end
@@ -313,8 +336,9 @@ class SmallNamespacesMockTestPartTwo < Minitest::Test
     body = @client.queues.get_member('q-1', 'mem-7')
 
     assert_kind_of Hash, body
-    # A queue member has 'queue_id' and 'call_id' per the spec example.
-    assert(body.key?('queue_id') || body.key?('call_id'))
+    # Exact queue-member shape returned by the mock (was: presence-only
+    # disjunctive key check).
+    assert_queue_member_shape(body)
     last = @mock.last
 
     assert_equal 'GET', last.method

--- a/tests/skills/datasphere_skill_test.rb
+++ b/tests/skills/datasphere_skill_test.rb
@@ -1,26 +1,38 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
-require_relative '../../lib/signalwire/swaig/function_result'
-require_relative '../../lib/signalwire/skills/skill_base'
-require_relative '../../lib/signalwire/skills/skill_registry'
+require_relative '../test_helper'
 require_relative '../../lib/signalwire/skills/builtin/datasphere'
 
 class DatasphereSkillDetailedTest < Minitest::Test
-  def test_setup_requires_all_params
-    saved = %w[SIGNALWIRE_PROJECT_ID SIGNALWIRE_TOKEN].to_h { |k| [k, ENV.delete(k)] }
-    factory = SignalWire::Skills::SkillRegistry.get_factory('datasphere')
+  include TestHelper::Helpers
 
-    refute factory.call({}).setup
-    refute factory.call({ 'space_name' => 'test', 'project_id' => 'p' }).setup
-    assert build_full_skill(factory).setup
-  ensure
-    saved.each { |k, v| ENV[k] = v if v }
+  DATASPHERE_ENV = %w[SIGNALWIRE_PROJECT_ID SIGNALWIRE_TOKEN].freeze
+
+  # Each input path of the old test_setup_requires_all_params is now its own
+  # method so a failure pinpoints which path broke.
+  def test_setup_fails_with_no_params
+    without_env_vars(DATASPHERE_ENV) do
+      refute build_skill('datasphere').setup,
+             'datasphere must fail setup with no params'
+    end
+  end
+
+  def test_setup_fails_with_partial_params
+    without_env_vars(DATASPHERE_ENV) do
+      refute build_skill('datasphere', 'space_name' => 'test', 'project_id' => 'p').setup,
+             'datasphere must fail setup missing token/document_id'
+    end
+  end
+
+  def test_setup_succeeds_with_full_params
+    without_env_vars(DATASPHERE_ENV) do
+      assert build_full_skill.setup,
+             'datasphere must set up with the full required-params set'
+    end
   end
 
   def test_register_tools
-    factory = SignalWire::Skills::SkillRegistry.get_factory('datasphere')
-    skill = build_full_skill(factory)
+    skill = build_full_skill
     skill.setup
     tools = skill.register_tools
 
@@ -29,15 +41,13 @@ class DatasphereSkillDetailedTest < Minitest::Test
   end
 
   def test_supports_multiple_instances
-    factory = SignalWire::Skills::SkillRegistry.get_factory('datasphere')
-    skill = factory.call({})
+    skill = build_skill('datasphere')
 
     assert_predicate skill, :supports_multiple_instances?
   end
 
   def test_global_data
-    factory = SignalWire::Skills::SkillRegistry.get_factory('datasphere')
-    skill = build_full_skill(factory, document_id: 'doc1')
+    skill = build_full_skill(document_id: 'doc1')
     skill.setup
     data = skill.get_global_data
 
@@ -47,11 +57,10 @@ class DatasphereSkillDetailedTest < Minitest::Test
 
   private
 
-  # Build a skill instance with the full required-params set.
-  def build_full_skill(factory, document_id: 'd')
-    factory.call({
-                   'space_name' => 'test', 'project_id' => 'p',
-                   'token' => 't', 'document_id' => document_id
-                 })
+  # Build a datasphere skill with the full required-params set.
+  def build_full_skill(document_id: 'd')
+    build_skill('datasphere',
+                'space_name' => 'test', 'project_id' => 'p',
+                'token' => 't', 'document_id' => document_id)
   end
 end

--- a/tests/skills/registry_test.rb
+++ b/tests/skills/registry_test.rb
@@ -1,20 +1,9 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
-require_relative '../../lib/signalwire/swaig/function_result'
-require_relative '../../lib/signalwire/datamap/data_map'
-require_relative '../../lib/signalwire/skills/skill_base'
-require_relative '../../lib/signalwire/skills/skill_manager'
-require_relative '../../lib/signalwire/skills/skill_registry'
-
-SignalWire::Skills::SkillRegistry.register_builtins!
+require_relative '../test_helper'
 
 class RegistryDetailedTest < Minitest::Test
-  EXPECTED_SKILLS = %w[
-    api_ninjas_trivia claude_skills custom_skills datasphere datasphere_serverless
-    datetime google_maps info_gatherer joke math native_vector_search
-    play_background_file spider swml_transfer weather_api web_search wikipedia_search
-  ].freeze
+  EXPECTED_SKILLS = TestHelper::BUILTIN_SKILL_NAMES
 
   def test_has_all_builtin_skills
     registered = SignalWire::Skills::SkillRegistry.list_skills.sort

--- a/tests/skills/weather_api_skill_test.rb
+++ b/tests/skills/weather_api_skill_test.rb
@@ -1,38 +1,65 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
-require_relative '../../lib/signalwire/swaig/function_result'
-require_relative '../../lib/signalwire/datamap/data_map'
-require_relative '../../lib/signalwire/skills/skill_base'
-require_relative '../../lib/signalwire/skills/skill_registry'
+require_relative '../test_helper'
 require_relative '../../lib/signalwire/skills/builtin/weather_api'
 
 class WeatherApiSkillDetailedTest < Minitest::Test
-  def test_setup_requires_api_key
-    saved = ENV.delete('WEATHER_API_KEY')
-    begin
-      factory = SignalWire::Skills::SkillRegistry.get_factory('weather_api')
-      skill = factory.call({})
+  include TestHelper::Helpers
 
-      refute skill.setup
+  # Each input path of the old test_setup_requires_api_key is now its own
+  # method so a failure pinpoints which path broke.
+  def test_setup_fails_without_api_key
+    without_env_vars('WEATHER_API_KEY') do
+      skill = build_skill('weather_api')
 
-      skill_with_key = factory.call({ 'api_key' => 'test_key' })
-
-      assert skill_with_key.setup
-    ensure
-      ENV['WEATHER_API_KEY'] = saved if saved
+      refute skill.setup, 'weather_api must fail setup without an API key'
     end
   end
 
+  def test_setup_succeeds_with_api_key
+    without_env_vars('WEATHER_API_KEY') do
+      skill = build_skill('weather_api', 'api_key' => 'test_key')
+
+      assert skill.setup, 'weather_api must set up once an API key is provided'
+    end
+  end
+
+  # The exact parameters schema the weather_api datamap advertises.
+  EXPECTED_PARAMETERS = {
+    'type' => 'object',
+    'properties' => {
+      'location' => { 'type' => 'string',
+                      'description' => 'The city, state, country, or location to get weather for' }
+    },
+    'required' => ['location']
+  }.freeze
+
   def test_register_tools_returns_datamap
-    factory = SignalWire::Skills::SkillRegistry.get_factory('weather_api')
-    skill = factory.call({ 'api_key' => 'test_key' })
+    skill = build_skill('weather_api', 'api_key' => 'test_key')
     skill.setup
     tools = skill.register_tools
 
     assert_equal 1, tools.size
-    assert tools[0].key?(:datamap)
-    assert_equal 'get_weather', tools[0][:datamap]['function']
+    # Exact shape of the returned datamap tool (was: presence-only key check).
+    assert_weather_datamap(tools[0][:datamap])
+  end
+
+  # Assert the full shape of the weather datamap tool.
+  def assert_weather_datamap(datamap)
+    assert_kind_of Hash, datamap
+    assert_equal 'get_weather', datamap['function']
+    assert_equal 'Get current weather information for any location', datamap['description']
+    assert_equal EXPECTED_PARAMETERS, datamap['parameters']
+    assert_equal ['error'], datamap['data_map']['error_keys']
+    assert_weather_webhook(datamap['data_map']['webhooks'][0])
+  end
+
+  # Assert the shape of the weather datamap's single webhook.
+  def assert_weather_webhook(webhook)
+    assert_equal 'GET', webhook['method']
+    assert_includes webhook['url'], 'api.weatherapi.com/v1/current.json'
+    assert_includes webhook['url'], 'key=test_key'
+    assert_includes webhook['output']['response'], 'Fahrenheit'
   end
 
   def test_custom_tool_name

--- a/tests/skills/web_search_skill_test.rb
+++ b/tests/skills/web_search_skill_test.rb
@@ -1,30 +1,34 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require_relative '../test_helper'
 require 'net/http'
-require_relative '../../lib/signalwire/swaig/function_result'
-require_relative '../../lib/signalwire/skills/skill_base'
-require_relative '../../lib/signalwire/skills/skill_registry'
 require_relative '../../lib/signalwire/skills/builtin/web_search'
 
 class WebSearchSkillDetailedTest < Minitest::Test
+  include TestHelper::Helpers
+
   SEARCH_ENV_VARS = %w[GOOGLE_SEARCH_API_KEY GOOGLE_SEARCH_ENGINE_ID].freeze
 
-  # Clear the Google-search env vars for the block, restoring them afterward.
-  def without_search_env
-    saved = SEARCH_ENV_VARS.to_h { |k| [k, ENV.delete(k)] }
-    yield
-  ensure
-    saved.each { |k, v| ENV[k] = v if v }
+  # Each input path of the old test_setup_requires_api_key_and_engine_id is
+  # now its own method so a failure pinpoints which path broke.
+  def test_setup_fails_without_any_params
+    without_env_vars(SEARCH_ENV_VARS) do
+      refute build_skill('web_search').setup,
+             'web_search must fail setup with neither api_key nor engine id'
+    end
   end
 
-  def test_setup_requires_api_key_and_engine_id
-    without_search_env do
-      factory = SignalWire::Skills::SkillRegistry.get_factory('web_search')
+  def test_setup_fails_with_api_key_but_no_engine_id
+    without_env_vars(SEARCH_ENV_VARS) do
+      refute build_skill('web_search', 'api_key' => 'key').setup,
+             'web_search must fail setup without a search_engine_id'
+    end
+  end
 
-      refute factory.call({}).setup
-      refute factory.call({ 'api_key' => 'key' }).setup
-      assert factory.call({ 'api_key' => 'key', 'search_engine_id' => 'cx' }).setup
+  def test_setup_succeeds_with_api_key_and_engine_id
+    without_env_vars(SEARCH_ENV_VARS) do
+      assert build_skill('web_search', 'api_key' => 'key', 'search_engine_id' => 'cx').setup,
+             'web_search must set up with both api_key and search_engine_id'
     end
   end
 

--- a/tests/skills_test.rb
+++ b/tests/skills_test.rb
@@ -1,52 +1,13 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
+require_relative 'test_helper'
 require 'tempfile'
 require 'tmpdir'
 
-# Load core dependencies
-require_relative '../lib/signalwire/swaig/function_result'
-require_relative '../lib/signalwire/datamap/data_map'
-require_relative '../lib/signalwire/skills/skill_base'
-require_relative '../lib/signalwire/skills/skill_manager'
-require_relative '../lib/signalwire/skills/skill_registry'
-
-# Load all built-in skills
-SignalWire::Skills::SkillRegistry.register_builtins!
-
-# Shared env-var save/restore helper for the skills tests.
-module SkillsTestHelpers
-  # Clear +names+ for the duration of the block, restoring prior values after.
-  def without_env_vars(*names)
-    saved = names.flatten.to_h { |k| [k, ENV.delete(k)] }
-    yield
-  ensure
-    saved.each { |k, v| ENV[k] = v if v }
-  end
-end
-
 class SkillRegistryTest < Minitest::Test
-  include SkillsTestHelpers
+  include TestHelper::Helpers
 
-  EXPECTED_SKILLS = %w[
-    api_ninjas_trivia
-    claude_skills
-    custom_skills
-    datasphere
-    datasphere_serverless
-    datetime
-    google_maps
-    info_gatherer
-    joke
-    math
-    native_vector_search
-    play_background_file
-    spider
-    swml_transfer
-    weather_api
-    web_search
-    wikipedia_search
-  ].freeze
+  EXPECTED_SKILLS = TestHelper::BUILTIN_SKILL_NAMES
 
   def test_registry_has_all_builtin_skills
     registered = SignalWire::Skills::SkillRegistry.list_skills.sort
@@ -107,7 +68,7 @@ end
 # Registry directory-scanning + instance-API coverage (split from
 # SkillRegistryTest to keep each class under the size limit).
 class SkillRegistryDirectoryTest < Minitest::Test
-  include SkillsTestHelpers
+  include TestHelper::Helpers
 
   # ── add_skill_directory parity ────────────────────────────────────────
   # Mirrors Python's signalwire.skills.registry.SkillRegistry.add_skill_directory
@@ -179,8 +140,7 @@ class SkillRegistryDirectoryTest < Minitest::Test
 
     # Clean up only the entry we added so other tests still see the
     # built-ins.
-    factories_var = SignalWire::Skills::SkillRegistry.instance_variable_get(:@factories)
-    factories_var.delete('test_register_skill_class_form')
+    deregister_skill('test_register_skill_class_form')
   end
 
   def test_add_skill_directory_dedup

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+# Shared test helper for the signalwire-ruby suite.
+#
+# Centralizes the setup that was previously duplicated across the skill,
+# CLI, and parity tests:
+#
+#   - the built-in skill registry is registered exactly once (idempotent),
+#   - the canonical built-in skill-name list (BUILTIN_SKILL_NAMES),
+#   - global-state reset helpers (ENV save/restore, skill-registry reset)
+#     so tests are order-independent and don't leak env vars / registry
+#     entries into each other,
+#   - the ephemeral-port picker + WEBrick fixture (LocalHTTPFixture) and the
+#     server-readiness wait used by the CLI and network-backed skill tests.
+#
+# This helper only relocates setup; it does NOT change what any test asserts.
+# Test files pull it in with `require_relative 'test_helper'` (or
+# `'../test_helper'` from a subdir).
+
+require 'minitest/autorun'
+require 'socket'
+require 'webrick'
+
+require_relative '../lib/signalwire/swaig/function_result'
+require_relative '../lib/signalwire/datamap/data_map'
+require_relative '../lib/signalwire/skills/skill_base'
+require_relative '../lib/signalwire/skills/skill_manager'
+require_relative '../lib/signalwire/skills/skill_registry'
+
+module TestHelper
+  # The canonical list of built-in skills the Ruby port registers.
+  #
+  # 17 built-ins: mcp_gateway is NOT ported (approved Python-only per §I.1).
+  # This is the single source consumed by both skills_test.rb and
+  # skills/registry_test.rb. tests/skill_name_test.rb keeps its OWN copy on
+  # purpose — it is a deliberate independent cross-check of this set.
+  BUILTIN_SKILL_NAMES = %w[
+    api_ninjas_trivia
+    claude_skills
+    custom_skills
+    datasphere
+    datasphere_serverless
+    datetime
+    google_maps
+    info_gatherer
+    joke
+    math
+    native_vector_search
+    play_background_file
+    spider
+    swml_transfer
+    weather_api
+    web_search
+    wikipedia_search
+  ].freeze
+
+  # Register the built-in skills exactly once for the whole test process.
+  # SkillRegistry.register_builtins! is idempotent, but calling it from a
+  # single place keeps the ordering deterministic regardless of which test
+  # file loads first.
+  def self.register_builtins!
+    SignalWire::Skills::SkillRegistry.register_builtins!
+  end
+
+  register_builtins!
+
+  # Mixin of global-state reset + fixture helpers. `include TestHelper::Helpers`
+  # in a Minitest::Test to get them.
+  module Helpers
+    # ── ENV save/restore ────────────────────────────────────────────────
+    # Clear +names+ for the duration of the block, restoring prior values
+    # afterward (whether the block raises or not). A nil prior value means the
+    # var was unset and stays unset.
+    def without_env_vars(*names)
+      saved = names.flatten.to_h { |k| [k, ENV.delete(k)] }
+      yield
+    ensure
+      saved.each { |k, v| ENV[k] = v if v }
+    end
+
+    # Set +name+ to +value+ for the block, restoring the prior value after.
+    def with_env_var(name, value)
+      saved = ENV.delete(name)
+      ENV[name] = value
+      yield
+    ensure
+      ENV.delete(name)
+      ENV[name] = saved if saved
+    end
+
+    # ── skill registry ──────────────────────────────────────────────────
+    # Build a built-in skill instance by name with the given params.
+    def build_skill(name, params = {})
+      SignalWire::Skills::SkillRegistry.get_factory(name).call(params)
+    end
+
+    # Remove a dynamically-registered skill factory so a test that registers
+    # its own class does not leak into later tests (the built-ins are left
+    # intact).
+    def deregister_skill(name)
+      factories = SignalWire::Skills::SkillRegistry.instance_variable_get(:@factories)
+      factories&.delete(name)
+    end
+
+    # ── ephemeral port + server readiness ───────────────────────────────
+    # Bind an OS-assigned free loopback port and release it, returning the
+    # port number. Callers immediately bind their own server to it.
+    def find_available_port
+      server = TCPServer.new('127.0.0.1', 0)
+      port = server.addr[1]
+      server.close
+      port
+    end
+
+    # Poll until a TCP server accepts a connection on host:port, or raise once
+    # +timeout+ seconds elapse.
+    def wait_for_server(host, port, timeout: 5)
+      deadline = Time.now + timeout
+      loop do
+        TCPSocket.new(host, port).close
+        return
+      rescue Errno::ECONNREFUSED, Errno::ECONNRESET
+        raise "Server did not start within #{timeout}s" if Time.now > deadline
+
+        sleep 0.05
+      end
+    end
+  end
+
+  # A tiny local WEBrick HTTP fixture bound to an ephemeral loopback port.
+  # A block decides each response from the request, returning
+  # [content_type, body] (or nil for a 404). Used by the network-backed skill
+  # tests so they never touch the real network or the shared mock server.
+  class LocalHTTPFixture
+    attr_reader :port
+
+    def initialize(&handler)
+      @handler = handler
+      @port = pick_free_port
+      @server = build_server(@port)
+      @server.mount_proc('/') { |req, res| render_response(req, res) }
+      @thread = Thread.new { @server.start }
+      wait_until_ready
+    end
+
+    def base_url
+      "http://127.0.0.1:#{@port}"
+    end
+
+    def shutdown
+      @server&.shutdown
+      @thread&.join(5)
+    end
+
+    private
+
+    def build_server(port)
+      WEBrick::HTTPServer.new(
+        BindAddress: '127.0.0.1',
+        Port: port,
+        Logger: WEBrick::Log.new(File.open(File::NULL, 'w'), WEBrick::Log::FATAL),
+        AccessLog: []
+      )
+    end
+
+    def render_response(req, res)
+      result = @handler.call(req)
+      if result.nil?
+        res.status = 404
+        res.body = 'not found'
+      else
+        content_type, body = result
+        res.status = 200
+        res['Content-Type'] = content_type
+        res.body = body
+      end
+    end
+
+    def pick_free_port
+      s = TCPServer.new('127.0.0.1', 0)
+      port = s.addr[1]
+      s.close
+      port
+    end
+
+    def wait_until_ready
+      20.times do
+        TCPSocket.new('127.0.0.1', @port).close
+        return
+      rescue Errno::ECONNREFUSED
+        sleep 0.05
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #42.

Five independent test-quality improvements. All are tests-only; no `lib/` changes.

### 1. Magic wire strings -> constants
`tests/relay/call_test.rb` and `tests/relay/message_test.rb` now assert against the already-required `CallState`/`MessageState` constants (`ANSWERED`, `QUEUED`, `SENT`, `DELIVERED`, `ENDED`, `FAILED`) instead of raw strings.

**Note:** the `'calling.answer'`/`'calling.end'` RPC-method strings the issue mentions have **no constant** in `lib/` (the library itself builds them via `"calling.#{method}"` string interpolation), so there is nothing to reference them by; those are left unchanged. Only the state strings had constants.

### 2. De-dup skill lists
`tests/skills_test.rb` and `tests/skills/registry_test.rb` now consume the single `TestHelper::BUILTIN_SKILL_NAMES` constant. The independent copy in `tests/skills/skill_name_test.rb` is left untouched as a deliberate cross-check.

### 3. Strengthen weak assertions
- `weather_api_skill_test.rb`: the presence-only `assert tools[0].key?(:datamap)` is replaced by exact assertions on the datamap's function/description/parameters/webhook shape.
- `rest/small_namespaces_mock_test.rb`: the disjunctive `assert(body.key?(x) || body.key?(y))` checks for `sip_profile.update` and `queues.get_member` now assert the exact returned values.

**Note:** the issue named `tests/rest/compat_calls_streams_mock_test.rb` (`assert(result.key?('sid') || result.key?('name'))`), but that file no longer exists — the compatibility/LaML namespace was excised. The live analogs of the same presence-only-disjunctive pattern were strengthened instead.

### 4. Split inline multi-path tests
In `web_search_skill_test.rb`, `weather_api_skill_test.rb`, and `datasphere_skill_test.rb`, a single method that exercised several input paths inline is split into one method per path so a failure pinpoints the path.

### 5. Shared `tests/test_helper.rb`
Centralizes the previously-duplicated global-state reset (ENV save/restore, skill-registry register/deregister) and the ephemeral-port + WEBrick `LocalHTTPFixture` setup that was copied across `cli_test.rb`, `per_skill_parity_test.rb`, and the skill tests. `cli_test.rb`, `per_skill_parity_test.rb`, `skills_test.rb`, `skills/registry_test.rb`, and the three skill tests now require it. This is setup relocation only — no test's assertions change — and it closes the ENV/registry leakage window.

### Verification
- Full suite green: **2477 runs, 0 failures, 0 errors**.
- Order-independent: green under default seed and shuffled seeds `12345` and `99991`.
- Rubocop clean on all changed files; full-tree format check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
