### PR TITLE
chore(ruby): idiomatic alignment pass (#41)

### DIFF
--- a/lib/signalwire.rb
+++ b/lib/signalwire.rb
@@ -149,7 +149,9 @@ module SignalWire
   # Singleton SkillRegistry instance used by the top-level helpers.
   # Internal — exposed only so the helpers can share state across calls.
   def _signalwire_singleton_registry
-    @_signalwire_singleton_registry ||= Skills::SkillRegistry.new
+    return @_signalwire_singleton_registry if defined?(@_signalwire_singleton_registry)
+
+    @_signalwire_singleton_registry = Skills::SkillRegistry.new
   end
   private_class_method :_signalwire_singleton_registry
 end

--- a/lib/signalwire/agent/agent_base.rb
+++ b/lib/signalwire/agent/agent_base.rb
@@ -53,14 +53,14 @@ module SignalWire
     # Maximum request body size (1 MB)
     MAX_BODY_SIZE = 1_048_576
 
-    # _create_ephemeral_copy: ivars whose value is an array of dup-able
+    # create_ephemeral_copy: ivars whose value is an array of dup-able
     # elements (deep-copied via map(&:dup)).
     EPHEMERAL_ARRAY_OF_DUPS = %i[
       @pom_sections @languages @pronounce @function_includes
       @pre_answer_verbs @post_answer_verbs @post_ai_verbs @mcp_servers
     ].freeze
 
-    # _create_ephemeral_copy: ivars deep-copied with a shallow #dup.
+    # create_ephemeral_copy: ivars deep-copied with a shallow #dup.
     EPHEMERAL_SHALLOW_DUPS = %i[
       @hints @params @global_data @native_functions @prompt_llm_params
       @post_prompt_llm_params @answer_config @swaig_query_params @loaded_skills
@@ -102,6 +102,13 @@ module SignalWire
     end
 
     private
+
+    # Read-only agent configuration, set during construction / one-time config
+    # calls (enable_sip_routing, enable_debug_events, etc.) and only read after.
+    attr_reader :auto_answer, :record_call, :record_format, :record_stereo,
+                :suppress_logs, :trust_proxy_for_signature, :proxy_url_base,
+                :sip_routing_enabled, :sip_path, :sip_auto_map, :debug_events_level,
+                :debug_events_enabled, :debug_routes_enabled, :mcp_server_enabled
 
     # Resolve basic auth. Returns [auth_pair, password_auto_generated?].
     # Resolution: explicit arg → SWML_BASIC_AUTH_* env → random UUIDs.
@@ -146,7 +153,7 @@ module SignalWire
       @session_manager = Security::SessionManager.new(token_expiry_secs: opts[:token_expiry_secs])
       init_signing_key(opts[:signing_key], opts[:trust_proxy_for_signature])
       init_default_state
-      @logger.info "Agent '#{@name}' initialised (route=#{@route}, port=#{@port})"
+      @logger.info "Agent '#{name}' initialised (route=#{route}, port=#{port})"
     end
 
     def init_call_settings(auto_answer:, record_call:, record_format:, record_stereo:)
@@ -171,13 +178,13 @@ module SignalWire
 
     # Webhook signature validation (per the SignalWire webhook signing spec).
     # Resolution:
-    # explicit arg → SIGNALWIRE_SIGNING_KEY env. When set, _build_rack_app
+    # explicit arg → SIGNALWIRE_SIGNING_KEY env. When set, build_rack_app
     # mounts WebhookMiddleware on the signed routes; when unset, warn so
     # production users notice unsigned traffic is being accepted.
     def init_signing_key(signing_key, trust_proxy_for_signature)
       @signing_key = signing_key || ENV.fetch('SIGNALWIRE_SIGNING_KEY', nil)
       @trust_proxy_for_signature = trust_proxy_for_signature
-      log_signing_key_status unless @suppress_logs
+      log_signing_key_status unless suppress_logs
     end
 
     def log_signing_key_status
@@ -274,7 +281,7 @@ module SignalWire
     #
     # @return [String] the agent name
     def get_name
-      @name
+      name
     end
 
     # Build the full URL for this agent.
@@ -684,7 +691,7 @@ module SignalWire
     # Normalise parameters into JSON-Schema form and inject the caller's
     # `required:` list onto an object schema.
     def build_tool_param_schema(parameters, required)
-      param_schema = _normalise_parameters(parameters)
+      param_schema = normalise_parameters(parameters)
       if required.is_a?(Array) && !required.empty? && param_schema.is_a?(Hash) && param_schema['type'] == 'object'
         existing = param_schema['required'] || []
         param_schema['required'] = (existing + required).uniq
@@ -1484,7 +1491,7 @@ module SignalWire
       # SIP username from the request body and returns nil (matched → this agent
       # handles the call so dispatch renders SWML; unmatched → routing
       # continues) — exactly Python's sip_routing_callback.
-      register_routing_callback(path) { |body, _headers| _sip_routing_callback(body) }
+      register_routing_callback(path) { |body, _headers| sip_routing_callback(body) }
 
       auto_map_sip_usernames if auto_map
       self
@@ -1495,7 +1502,7 @@ module SignalWire
     # whether it matched a registered username. Always returns nil: a matched
     # username is handled by this agent (dispatch renders SWML), an unmatched
     # one lets routing continue.
-    def _sip_routing_callback(body)
+    def sip_routing_callback(body)
       username = self.class.extract_sip_username_from_request(body)
       return nil if username.nil?
 
@@ -1527,10 +1534,10 @@ module SignalWire
         register_sip_username(candidate) unless candidate.empty? || @sip_usernames.include?(candidate)
       end
 
-      clean_name = sanitize_sip_username(@name)
+      clean_name = sanitize_sip_username(name)
       register.call(clean_name) unless clean_name.empty?
 
-      clean_route = sanitize_sip_username(@route)
+      clean_route = sanitize_sip_username(route)
       register.call(clean_route) if !clean_route.empty? && clean_route != clean_name
 
       register_no_vowels_variation(clean_name, register)
@@ -1646,59 +1653,59 @@ module SignalWire
       req_id  = body['id']
       params  = body['params'] || {}
 
-      return _mcp_error(req_id, -32_600, 'Invalid JSON-RPC version') unless body['jsonrpc'] == '2.0'
+      return mcp_error(req_id, -32_600, 'Invalid JSON-RPC version') unless body['jsonrpc'] == '2.0'
 
       # Each branch is a distinct JSON-RPC method; the no-op ack arms
       # (notifications/initialized, ping) share an empty-result body but stay
-      # documented by name in _mcp_empty_result_method?.
+      # documented by name in mcp_empty_result_method?.
       case method
-      when 'initialize'   then _mcp_initialize_response(req_id)
-      when 'tools/list'   then _mcp_result(req_id, { 'tools' => _build_mcp_tool_list })
-      when 'tools/call'   then _mcp_tools_call(req_id, params)
-      else _mcp_default_response(method, req_id)
+      when 'initialize'   then mcp_initialize_response(req_id)
+      when 'tools/list'   then mcp_result(req_id, { 'tools' => _build_mcp_tool_list })
+      when 'tools/call'   then mcp_tools_call(req_id, params)
+      else mcp_default_response(method, req_id)
       end
     end
 
-    def _mcp_default_response(method, req_id)
-      return _mcp_result(req_id, {}) if _mcp_empty_result_method?(method)
+    def mcp_default_response(method, req_id)
+      return mcp_result(req_id, {}) if mcp_empty_result_method?(method)
 
-      _mcp_error(req_id, -32_601, "Method not found: #{method}")
+      mcp_error(req_id, -32_601, "Method not found: #{method}")
     end
 
-    def _mcp_empty_result_method?(method)
+    def mcp_empty_result_method?(method)
       %w[notifications/initialized ping].include?(method)
     end
 
-    def _mcp_result(req_id, result)
+    def mcp_result(req_id, result)
       { 'jsonrpc' => '2.0', 'id' => req_id, 'result' => result }
     end
 
-    def _mcp_initialize_response(req_id)
+    def mcp_initialize_response(req_id)
       {
         'jsonrpc' => '2.0', 'id' => req_id,
         'result' => {
           'protocolVersion' => '2025-06-18',
           'capabilities' => { 'tools' => {} },
-          'serverInfo' => { 'name' => @name, 'version' => '1.0.0' }
+          'serverInfo' => { 'name' => name, 'version' => '1.0.0' }
         }
       }
     end
 
-    def _mcp_tools_call(req_id, params)
+    def mcp_tools_call(req_id, params)
       tool_name = params['name'] || ''
       arguments = params['arguments'] || {}
       tool = @tools[tool_name]
-      return _mcp_error(req_id, -32_602, "Unknown tool: #{tool_name}") unless tool
+      return mcp_error(req_id, -32_602, "Unknown tool: #{tool_name}") unless tool
 
       raw_data = { 'function' => tool_name, 'argument' => { 'parsed' => [arguments] } }
       result = tool[:handler].call(arguments, raw_data)
-      _mcp_tool_result(req_id, _mcp_response_text(result), is_error: false)
+      mcp_tool_result(req_id, mcp_response_text(result), is_error: false)
     rescue StandardError => e
       @logger.error "MCP tool call error: #{tool_name}: #{e.message}"
-      _mcp_tool_result(req_id, "Error: #{e.message}", is_error: true)
+      mcp_tool_result(req_id, "Error: #{e.message}", is_error: true)
     end
 
-    def _mcp_response_text(result)
+    def mcp_response_text(result)
       return result.to_h['response'] || '' if result.respond_to?(:to_h)
       return result['response'] || result.to_s if result.is_a?(Hash)
       return result if result.is_a?(String)
@@ -1706,7 +1713,7 @@ module SignalWire
       ''
     end
 
-    def _mcp_tool_result(req_id, text, is_error:)
+    def mcp_tool_result(req_id, text, is_error:)
       {
         'jsonrpc' => '2.0', 'id' => req_id,
         'result' => {
@@ -1717,7 +1724,7 @@ module SignalWire
     end
 
     # @api private
-    def _mcp_error(req_id, code, message)
+    def mcp_error(req_id, code, message)
       {
         'jsonrpc' => '2.0',
         'id' => req_id,
@@ -1816,7 +1823,7 @@ module SignalWire
     # idiom) or a Rack-request-like object, translate it into a Rack env,
     # and return a +{ 'status', 'headers', 'body' }+ response.
     def _run_gcf(request)
-      _run_http_serverless(request)
+      run_http_serverless(request)
     end
 
     # @api private
@@ -1824,18 +1831,18 @@ module SignalWire
     # object/dict (method / url / headers / body); translate to a Rack env and
     # return a +{ 'status', 'headers', 'body' }+ response.
     def _run_azure(request)
-      _run_http_serverless(request)
+      run_http_serverless(request)
     end
 
     # @api private
     # Shared GCF/Azure request pump: normalise the HTTP-request-shaped input
     # into a Rack env, invoke the app, and return a +{status,headers,body}+
     # response hash.
-    def _run_http_serverless(request)
+    def run_http_serverless(request)
       require 'stringio'
-      method, path, query, body, headers = _extract_http_request(request)
+      method, path, query, body, headers = extract_http_request(request)
       env = rack_env(path: path, method: method, query: query, body: body)
-      _apply_env_headers(env, headers)
+      apply_env_headers(env, headers)
       status, resp_headers, resp_body = rack_app.call(env)
       { 'status' => Integer(status), 'headers' => resp_headers, 'body' => join_rack_body(resp_body) }
     end
@@ -1844,25 +1851,25 @@ module SignalWire
     # Normalise a serverless HTTP request (Hash with string/symbol keys, or a
     # Rack-request-like object) into +[method, path, query, body, headers]+.
     # For Azure, a full +url+ is split into path + query string.
-    def _extract_http_request(request)
+    def extract_http_request(request)
       req = request || {}
-      method = (_req_field(req, :method, :request_method, :httpMethod) || 'GET').to_s.upcase
-      path, query = _extract_path_and_query(req)
-      [method, path, query, (_req_field(req, :body) || '').to_s, _req_field(req, :headers) || {}]
+      method = (req_field(req, :method, :request_method, :httpMethod) || 'GET').to_s.upcase
+      path, query = extract_path_and_query(req)
+      [method, path, query, (req_field(req, :body) || '').to_s, req_field(req, :headers) || {}]
     end
 
     # Resolve [path, query] from a request: the target may be a bare path or a
     # full URL (Azure); the query may come from a dedicated field or the URL.
-    def _extract_path_and_query(req)
-      path, url_query = _split_url_path((_req_field(req, :path, :url, :rawPath, :request_uri) || '/').to_s)
-      query = (_req_field(req, :query, :query_string, :rawQueryString) || url_query || '').to_s
+    def extract_path_and_query(req)
+      path, url_query = split_url_path((req_field(req, :path, :url, :rawPath, :request_uri) || '/').to_s)
+      query = (req_field(req, :query, :query_string, :rawQueryString) || url_query || '').to_s
       [path, query]
     end
 
     # Split a request target into [path, query]. Accepts a bare path
     # ("/health?x=1") or a full URL ("https://host/health?x=1", as Azure sends)
     # and returns just the path component + query string.
-    def _split_url_path(raw)
+    def split_url_path(raw)
       if raw.include?('://')
         require 'uri'
         parsed = URI.parse(raw)
@@ -1876,7 +1883,7 @@ module SignalWire
 
     # Look up the first present key (string or symbol) from a Hash, or call the
     # first matching reader on a request-like object.
-    def _req_field(req, *names)
+    def req_field(req, *names)
       if req.is_a?(Hash)
         names.each do |n|
           return req[n.to_s] if req.key?(n.to_s)
@@ -1895,7 +1902,7 @@ module SignalWire
 
     # Merge request headers (a Hash) into a Rack env as HTTP_* keys, pulling out
     # CONTENT_TYPE / CONTENT_LENGTH which Rack expects unprefixed.
-    def _apply_env_headers(env, headers)
+    def apply_env_headers(env, headers)
       return unless headers.is_a?(Hash)
 
       headers.each do |name, value|
@@ -1988,7 +1995,7 @@ module SignalWire
 
     # Return a Rack-compatible application for mounting.
     def rack_app
-      @rack_app ||= _build_rack_app
+      @rack_app ||= build_rack_app
     end
 
     alias as_rack_app rack_app
@@ -2010,7 +2017,7 @@ module SignalWire
 
     # Framework-free request-dispatch core for AgentBase — overrides
     # {SWMLService#handle_request} so the primitive dispatch surface renders SWML
-    # via the agent's {#render_swml} (mirroring the Rack +_handle_main_request+
+    # via the agent's {#render_swml} (mirroring the Rack +handle_main_request+
     # path) instead of the base +render_document+. Performs proxy detection,
     # basic-auth, the routing-callback check, and the +on_swml_request+
     # modification hook over plain primitives, returning a
@@ -2038,13 +2045,13 @@ module SignalWire
       redirect = routing_redirect(method, body, headers, callback_path)
       return redirect if redirect
 
-      _agent_render_triple(body, callback_path, request:)
+      agent_render_triple(body, callback_path, request:)
     end
 
     # 200 triple rendering agent SWML with any on_swml_request modifications
     # shallow-merged in. Split out of {#handle_request} for clarity.
-    def _agent_render_triple(body, callback_path, request: nil)
-      modifications = _agent_on_swml_request(body, callback_path, request)
+    def agent_render_triple(body, callback_path, request: nil)
+      modifications = agent_on_swml_request(body, callback_path, request)
       swml = render_swml(body, request:)
       swml = swml.merge(modifications) if modifications.is_a?(Hash)
       [200, {}, JSON.generate(swml)]
@@ -2053,7 +2060,7 @@ module SignalWire
     # Call +on_swml_request+ (a raising modifier does not 500 the
     # request), returning its modifications or nil. +request+ is the live Rack
     # request on the served path, or nil for the framework-free primitive path.
-    def _agent_on_swml_request(body, callback_path, request = nil)
+    def agent_on_swml_request(body, callback_path, request = nil)
       on_swml_request(body, callback_path, request:)
     rescue StandardError => e
       @log&.error("error_in_request_modifier: #{e.message}")
@@ -2061,10 +2068,10 @@ module SignalWire
     end
 
     def apply_dynamic_config(request_data, request)
-      agent = _create_ephemeral_copy
-      query_params = request ? _parse_query_string(request) : {}
+      agent = create_ephemeral_copy
+      query_params = request ? parse_query_string(request) : {}
       body_params  = request_data || {}
-      headers      = request ? _extract_headers(request) : {}
+      headers      = request ? extract_headers(request) : {}
       @dynamic_config_callback.call(query_params, body_params, headers, agent)
       agent
     rescue StandardError => e
@@ -2075,12 +2082,12 @@ module SignalWire
     # @api private
     def _render_swml_internal
       sections_main = []
-      sections_main.concat(verb_entries(@pre_answer_verbs))   # PHASE 1: pre-answer verbs
-      sections_main << answer_entry if @auto_answer           # PHASE 2: answer verb
-      sections_main << record_call_entry if @record_call      # PHASE 3a: record_call
-      sections_main.concat(verb_entries(@post_answer_verbs))  # PHASE 3b: post-answer verbs
-      sections_main << { 'ai' => _build_ai_config }           # PHASE 4: AI verb
-      sections_main.concat(verb_entries(@post_ai_verbs))      # PHASE 5: post-AI verbs
+      sections_main.concat(verb_entries(@pre_answer_verbs)) # PHASE 1: pre-answer verbs
+      sections_main << answer_entry if auto_answer           # PHASE 2: answer verb
+      sections_main << record_call_entry if record_call      # PHASE 3a: record_call
+      sections_main.concat(verb_entries(@post_answer_verbs)) # PHASE 3b: post-answer verbs
+      sections_main << { 'ai' => build_ai_config } # PHASE 4: AI verb
+      sections_main.concat(verb_entries(@post_ai_verbs)) # PHASE 5: post-AI verbs
 
       { 'version' => '1.0.0', 'sections' => { 'main' => sections_main } }
     end
@@ -2095,7 +2102,7 @@ module SignalWire
     end
 
     def record_call_entry
-      { 'record_call' => { 'format' => @record_format, 'stereo' => @record_stereo } }
+      { 'record_call' => { 'format' => record_format, 'stereo' => record_stereo } }
     end
 
     # Get the configured basic-auth credentials.
@@ -2131,7 +2138,7 @@ module SignalWire
     private
 
     # Build the AI verb configuration hash.
-    def _build_ai_config
+    def build_ai_config
       ai = {}
       add_ai_prompt(ai)
       add_ai_post_prompt(ai)
@@ -2148,7 +2155,7 @@ module SignalWire
       prompt = get_prompt
       if prompt.nil? || (prompt.respond_to?(:empty?) && prompt.empty?)
         # Match TS: emit the default fallback prompt rather than omitting it.
-        prompt = "You are #{@name}, a helpful AI assistant."
+        prompt = "You are #{name}, a helpful AI assistant."
       end
       key = prompt.is_a?(Array) ? 'pom' : 'text'
 
@@ -2163,11 +2170,11 @@ module SignalWire
       pp_obj = { 'text' => @post_prompt_text }
       pp_obj.merge!(@post_prompt_llm_params) unless @post_prompt_llm_params.empty?
       config['post_prompt'] = pp_obj
-      config['post_prompt_url'] = (@post_prompt_url_override || _build_webhook_url('post_prompt'))
+      config['post_prompt_url'] = (@post_prompt_url_override || build_webhook_url('post_prompt'))
     end
 
     def add_ai_swaig(config)
-      functions = _build_functions_array
+      functions = build_functions_array
       swaig = { 'defaults' => { 'web_hook_url' => swaig_default_url } }
       swaig['functions']        = functions          unless functions.empty?
       swaig['native_functions'] = @native_functions  unless @native_functions.empty?
@@ -2178,7 +2185,7 @@ module SignalWire
 
     def swaig_default_url
       @web_hook_url_override ||
-        _build_webhook_url('swaig', @swaig_query_params.empty? ? nil : @swaig_query_params)
+        build_webhook_url('swaig', @swaig_query_params.empty? ? nil : @swaig_query_params)
     end
 
     def add_ai_collections(config)
@@ -2193,9 +2200,9 @@ module SignalWire
 
     def add_ai_params(config)
       merged_params = @params.dup
-      if @debug_events_enabled
-        merged_params['debug_webhook_url']   = _build_webhook_url('debug_events')
-        merged_params['debug_webhook_level'] = @debug_events_level
+      if debug_events_enabled
+        merged_params['debug_webhook_url']   = build_webhook_url('debug_events')
+        merged_params['debug_webhook_level'] = debug_events_level
       end
       config['params'] = merged_params unless merged_params.empty?
     end
@@ -2209,7 +2216,7 @@ module SignalWire
     end
 
     # Build the functions array for the SWAIG section.
-    def _build_functions_array
+    def build_functions_array
       functions = @tools.values.map { |tool| tool_function_entry(tool) }
       @swaig_functions.each_value { |func_def| functions << func_def.dup }
       functions
@@ -2222,15 +2229,15 @@ module SignalWire
       # render — so the default webhook URL handles their dispatch here.)
       if tool[:secure] || !@swaig_query_params.empty?
         qp = @swaig_query_params.dup
-        func_entry['web_hook_url'] = _build_webhook_url('swaig', qp) unless qp.empty?
+        func_entry['web_hook_url'] = build_webhook_url('swaig', qp) unless qp.empty?
       end
       func_entry
     end
 
     # Build a webhook URL with optional query params.
-    def _build_webhook_url(endpoint, query_params = nil)
-      base = _base_url
-      path = @route == '/' ? "/#{endpoint}" : "#{@route}/#{endpoint}"
+    def build_webhook_url(endpoint, query_params = nil)
+      base = base_url
+      path = route == '/' ? "/#{endpoint}" : "#{route}/#{endpoint}"
 
       url = "#{base}#{path}"
 
@@ -2253,29 +2260,29 @@ module SignalWire
     #   3. +http://user:pass@host:port+ for local server mode
     #
     # This method intentionally returns only the *base* — the agent's
-    # +@route+ is appended by {#_build_webhook_url}. Never bake the
+    # +@route+ is appended by {#build_webhook_url}. Never bake the
     # route into the base here, or a non-root agent deployed behind a
     # proxy will have its mount point silently dropped from webhook
     # URLs.
-    def _base_url
-      return @proxy_url_base.chomp('/') if @proxy_url_base && !@proxy_url_base.empty?
+    def base_url
+      return proxy_url_base.chomp('/') if proxy_url_base && !proxy_url_base.empty?
 
       if Runtime.lambda?
         lambda_base = Runtime.lambda_base_url
         if lambda_base
           user, pass = @basic_auth
-          return _embed_auth(lambda_base, user, pass)
+          return embed_auth(lambda_base, user, pass)
         end
       end
 
       user, pass = @basic_auth
-      "http://#{user}:#{pass}@#{@host}:#{@port}"
+      "http://#{user}:#{pass}@#{host}:#{port}"
     end
 
     # Embed basic-auth credentials into +base+ immediately after the
     # scheme. Returns +base+ untouched when either credential is blank
     # or the URL already contains an @-delimited userinfo component.
-    def _embed_auth(base, user, pass)
+    def embed_auth(base, user, pass)
       return base if blank?(user) || blank?(pass)
 
       uri = URI.parse(base)
@@ -2292,7 +2299,7 @@ module SignalWire
     end
 
     # Normalise tool parameters into JSON-Schema form.
-    def _normalise_parameters(params)
+    def normalise_parameters(params)
       return params if object_schema?(params)
       return { 'type' => 'object', 'properties' => {} } if params.nil? || params.empty?
 
@@ -2307,13 +2314,13 @@ module SignalWire
     end
 
     # Create an ephemeral deep copy for dynamic config.
-    def _create_ephemeral_copy
+    def create_ephemeral_copy
       copy = dup
       ephemeral_copy_values.each { |ivar, value| copy.instance_variable_set(ivar, value) }
       copy
     end
 
-    # The deep-copied ivar => value pairs for {#_create_ephemeral_copy}. The
+    # The deep-copied ivar => value pairs for {#create_ephemeral_copy}. The
     # dynamic-config callback is intentionally nil'd to prevent infinite
     # recursion; @mcp_server_enabled is a scalar so it's copied as-is.
     def ephemeral_copy_values
@@ -2328,21 +2335,21 @@ module SignalWire
       {
         :@tools => @tools.transform_values(&:dup),
         :@swaig_functions => @swaig_functions.transform_values(&:dup),
-        :@internal_fillers => _deep_dup_hash(@internal_fillers),
+        :@internal_fillers => deep_dup_hash(@internal_fillers),
         :@mcp_server_enabled => @mcp_server_enabled,
         :@dynamic_config_callback => nil
       }
     end
 
     # Deep-dup a hash of hashes
-    def _deep_dup_hash(hash)
+    def deep_dup_hash(hash)
       hash.each_with_object({}) do |(k, v), result|
         result[k] = v.is_a?(Hash) ? v.dup : v
       end
     end
 
     # Parse query string from Rack request
-    def _parse_query_string(request)
+    def parse_query_string(request)
       return {} unless request.respond_to?(:env)
 
       qs = request.env['QUERY_STRING'] || ''
@@ -2352,7 +2359,7 @@ module SignalWire
     end
 
     # Extract headers from Rack request
-    def _extract_headers(request)
+    def extract_headers(request)
       return {} unless request.respond_to?(:env)
 
       request.env.select { |k, _| k.start_with?('HTTP_') }
@@ -2365,22 +2372,22 @@ module SignalWire
     # Rack app
     # ==================================================================
 
-    def _build_rack_app
+    def build_rack_app
       agent = self
-      main_route = @route
-      authenticated = _build_authenticated_app
+      main_route = route
+      authenticated = build_authenticated_app
       Rack::Builder.new do
         # --- public endpoints (no auth) --------------------------------
-        map('/health') { run ->(_env) { agent.send(:_static_status_response, 'healthy') } }
-        map('/ready')  { run ->(_env) { agent.send(:_static_status_response, 'ready') } }
+        map('/health') { run ->(_env) { agent.send(:static_status_response, 'healthy') } }
+        map('/ready')  { run ->(_env) { agent.send(:static_status_response, 'ready') } }
         # --- authenticated endpoints -----------------------------------
         map(main_route) { run authenticated }
       end
     end
 
     # The middleware stack + handler for the authenticated main route, as its
-    # own Rack app so _build_rack_app stays a thin router.
-    def _build_authenticated_app
+    # own Rack app so build_rack_app stays a thin router.
+    def build_authenticated_app
       agent = self
       # Webhook signature validation runs BEFORE basic auth so a spoofed but
       # unsigned request is rejected with 403 (the spec) rather than 401 (which
@@ -2393,7 +2400,7 @@ module SignalWire
         use AgentBodyLimitMiddleware, AgentBase::MAX_BODY_SIZE
         use(SignalWire::Security::WebhookMiddleware, **webhook_args) if webhook_args
         use AgentTimingSafeBasicAuth, agent
-        run ->(env) { agent.send(:_handle_main_request, env) }
+        run ->(env) { agent.send(:handle_main_request, env) }
       end
     end
 
@@ -2401,17 +2408,17 @@ module SignalWire
     def webhook_middleware_args
       return nil if @signing_key.nil? || @signing_key.empty?
 
-      { signing_key: @signing_key, trust_proxy: @trust_proxy_for_signature,
+      { signing_key: @signing_key, trust_proxy: trust_proxy_for_signature,
         paths: ['/', '/swaig', '/post_prompt'], methods: ['POST'] }
     end
 
-    def _static_status_response(status)
+    def static_status_response(status)
       [200, { 'content-type' => 'application/json' }, [JSON.generate({ status: status })]]
     end
 
     # The authenticated main-route Rack handler: parse the body, then dispatch
     # to /swaig, the extra routes (/post_prompt, /debug_events, /mcp), or SWML.
-    def _handle_main_request(env)
+    def handle_main_request(env)
       request  = Rack::Request.new(env)
       sub_path = env['PATH_INFO'] || '/'
       sub_path = '/' if sub_path.empty?
@@ -2429,16 +2436,16 @@ module SignalWire
       # unconditionally rendering SWML. Basic auth already ran in the Rack
       # middleware, so skip the redundant re-check; the request is threaded
       # through for dynamic config's query/header access.
-      _dispatch_via_handle_request(request, env, sub_path, request_data)
+      dispatch_via_handle_request(request, env, sub_path, request_data)
     end
 
     # Marshal the served Rack request into the (method, url, headers, body)
     # primitives, call {#handle_request}, and turn its
     # +[status, headers, body_string]+ triple back into a Rack response array.
-    def _dispatch_via_handle_request(request, env, sub_path, request_data)
+    def dispatch_via_handle_request(request, env, sub_path, request_data)
       method  = env['REQUEST_METHOD'] || 'GET'
-      url     = _served_request_url(env, sub_path)
-      headers = _extract_headers(request)
+      url     = served_request_url(env, sub_path)
+      headers = extract_headers(request)
       status, headers_out, body = handle_request(
         method, url, headers, request_data, request:, skip_auth: true
       )
@@ -2448,7 +2455,7 @@ module SignalWire
 
     # Build the request URL (path + query string) that handle_request's
     # callback-path matcher and proxy detection consume.
-    def _served_request_url(env, sub_path)
+    def served_request_url(env, sub_path)
       qs = env['QUERY_STRING']
       qs && !qs.empty? ? "#{sub_path}?#{qs}" : sub_path
     end
@@ -2482,9 +2489,9 @@ module SignalWire
 
     def handle_additional_route(sub_path, request_data, env)
       case sub_path
-      when '/post_prompt'  then _handle_post_prompt(request_data, env)
-      when '/debug_events' then _handle_debug_events(request_data, env)
-      when '/mcp'          then _handle_mcp_endpoint(request_data, env)
+      when '/post_prompt'  then handle_post_prompt(request_data, env)
+      when '/debug_events' then handle_debug_events(request_data, env)
+      when '/mcp'          then handle_mcp_endpoint(request_data, env)
       end
     end
 
@@ -2497,7 +2504,7 @@ module SignalWire
 
     # Handle post_prompt callback.
     # @api private
-    def _handle_post_prompt(request_data, _env)
+    def handle_post_prompt(request_data, _env)
       invoke_summary_callback(request_data) if @summary_callback && request_data
       json_response(200, { 'status' => 'ok' })
     end
@@ -2540,7 +2547,7 @@ module SignalWire
 
     # Handle debug events.
     # @api private
-    def _handle_debug_events(request_data, _env)
+    def handle_debug_events(request_data, _env)
       invoke_debug_event_callback(request_data) if @debug_event_callback && request_data
       json_response(200, { 'status' => 'ok' })
     end
@@ -2554,9 +2561,9 @@ module SignalWire
 
     # Handle MCP JSON-RPC 2.0 endpoint.
     # @api private
-    def _handle_mcp_endpoint(request_data, _env)
-      return json_response(404, { 'error' => 'MCP server not enabled' }) unless @mcp_server_enabled
-      return json_response(400, _mcp_error(nil, -32_700, 'Parse error')) unless request_data
+    def handle_mcp_endpoint(request_data, _env)
+      return json_response(404, { 'error' => 'MCP server not enabled' }) unless mcp_server_enabled
+      return json_response(400, mcp_error(nil, -32_700, 'Parse error')) unless request_data
 
       json_response(200, _handle_mcp_request(request_data))
     end
@@ -2577,10 +2584,14 @@ module SignalWire
       end
 
       def call(env)
-        status, headers, body = @app.call(env)
+        status, headers, body = app.call(env)
         HEADERS.each { |k, v| headers[k] = v }
         [status, headers, body]
       end
+
+      private
+
+      attr_reader :app
     end
 
     class AgentBodyLimitMiddleware
@@ -2590,12 +2601,16 @@ module SignalWire
       end
 
       def call(env)
-        if env['CONTENT_LENGTH'] && env['CONTENT_LENGTH'].to_i > @max_size
+        if env['CONTENT_LENGTH'] && env['CONTENT_LENGTH'].to_i > max_size
           body = JSON.generate({ 'error' => 'Request body too large' })
           return [413, { 'content-type' => 'application/json' }, [body]]
         end
-        @app.call(env)
+        app.call(env)
       end
+
+      private
+
+      attr_reader :app, :max_size
     end
 
     class AgentTimingSafeBasicAuth
@@ -2606,9 +2621,9 @@ module SignalWire
 
       def call(env)
         auth = Rack::Auth::Basic::Request.new(env)
-        return _unauthorized unless auth.provided? && auth.basic?
+        return unauthorized unless auth.provided? && auth.basic?
 
-        credentials_valid?(auth.credentials) ? @app.call(env) : _unauthorized
+        credentials_valid?(auth.credentials) ? @app.call(env) : unauthorized
       end
 
       private
@@ -2622,7 +2637,7 @@ module SignalWire
         user_ok && pass_ok
       end
 
-      def _unauthorized
+      def unauthorized
         # Python parity (AuthMixin._send_lambda_auth_challenge / the CGI + server
         # challenges): a JSON {"error":"Unauthorized"} body with a JSON
         # content-type, not a plain-text "Unauthorized".
@@ -2659,5 +2674,14 @@ module SignalWire
     private :answer_entry, :record_call_entry, :webrick_handler
     private :valid_function_include?, :warn_dropped_function_include, :find_summary_in_post_data
     private :summary_from_post_prompt_data
+    # Formerly leading-underscore-by-convention internals; underscore dropped in
+    # the idiom pass. Declared private so the cross-port surface enumerator keeps
+    # excluding them (unchanged public surface).
+    private :agent_on_swml_request, :agent_render_triple, :apply_env_headers,
+            :extract_http_request, :extract_path_and_query, :handle_debug_events,
+            :handle_mcp_endpoint, :handle_post_prompt, :mcp_default_response,
+            :mcp_empty_result_method?, :mcp_error, :mcp_initialize_response,
+            :mcp_response_text, :mcp_result, :mcp_tool_result, :mcp_tools_call,
+            :req_field, :run_http_serverless, :sip_routing_callback, :split_url_path
   end
 end

--- a/lib/signalwire/agent/agent_base.rb
+++ b/lib/signalwire/agent/agent_base.rb
@@ -1995,7 +1995,9 @@ module SignalWire
 
     # Return a Rack-compatible application for mounting.
     def rack_app
-      @rack_app ||= build_rack_app
+      return @rack_app if defined?(@rack_app)
+
+      @rack_app = build_rack_app
     end
 
     alias as_rack_app rack_app

--- a/lib/signalwire/agent/agent_base.rb
+++ b/lib/signalwire/agent/agent_base.rb
@@ -2030,12 +2030,12 @@ module SignalWire
     # @return [Array(Integer, Hash{String=>String}, String)]
     def handle_request(method, url, headers, body = nil, request: nil, skip_auth: false)
       body ||= {}
-      callback_path = _callback_path_for_url(url)
+      callback_path = callback_path_for_url(url)
 
-      _detect_proxy_from_primitives(url, headers)
-      return _unauthorized_triple unless skip_auth || _check_basic_auth_headers(headers)
+      detect_proxy_from_primitives(url, headers)
+      return unauthorized_triple unless skip_auth || check_basic_auth_headers(headers)
 
-      redirect = _routing_redirect(method, body, headers, callback_path)
+      redirect = routing_redirect(method, body, headers, callback_path)
       return redirect if redirect
 
       _agent_render_triple(body, callback_path, request:)
@@ -2419,7 +2419,7 @@ module SignalWire
 
       # /swaig — handled by Service; dispatch uses on_function_call (which
       # AgentBase overrides for token validation).
-      return _handle_swaig_endpoint(request, request_data, env) if sub_path == '/swaig'
+      return handle_swaig_endpoint(request, request_data, env) if sub_path == '/swaig'
 
       extra = handle_additional_route(sub_path, request_data, env)
       return extra if extra
@@ -2490,7 +2490,7 @@ module SignalWire
 
     # These methods must be accessible from the Rack lambda
 
-    # _handle_swaig is now provided by Service (lifted as _handle_swaig_endpoint).
+    # _handle_swaig is now provided by Service (lifted as handle_swaig_endpoint).
     # AgentBase still hooks the dispatch path via the on_function_call override
     # below, which adds session-token validation on top of Service's plain
     # registry lookup.

--- a/lib/signalwire/contexts/context_builder.rb
+++ b/lib/signalwire/contexts/context_builder.rb
@@ -645,7 +645,7 @@ module SignalWire
 
       def add_enter_filler(lang_code, fillers)
         if lang_code && fillers.is_a?(Array) && fillers.any?
-          @enter_fillers ||= {}
+          @enter_fillers = {} unless defined?(@enter_fillers) && @enter_fillers
           @enter_fillers[lang_code] = fillers
         end
         self
@@ -653,7 +653,7 @@ module SignalWire
 
       def add_exit_filler(lang_code, fillers)
         if lang_code && fillers.is_a?(Array) && fillers.any?
-          @exit_fillers ||= {}
+          @exit_fillers = {} unless defined?(@exit_fillers) && @exit_fillers
           @exit_fillers[lang_code] = fillers
         end
         self

--- a/lib/signalwire/contexts/context_builder.rb
+++ b/lib/signalwire/contexts/context_builder.rb
@@ -347,7 +347,7 @@ module SignalWire
 
       def to_h
         step_h = { 'name' => @name, 'text' => render_text }
-        _add_step_fields(step_h)
+        add_step_fields(step_h)
 
         reset = reset_hash
         step_h['reset'] = reset if reset.any?
@@ -355,22 +355,22 @@ module SignalWire
         step_h
       end
 
-      def _add_step_fields(step_h)
+      def add_step_fields(step_h)
         step_h['step_criteria']  = @step_criteria if @step_criteria
         step_h['functions']      = @functions     unless @functions.nil?
         step_h['valid_steps']    = @valid_steps    if @valid_steps
         step_h['valid_contexts'] = @valid_contexts if @valid_contexts
         step_h['history']        = @history        if @history
-        _add_step_flags(step_h)
+        add_step_flags(step_h)
       end
-      private :_add_step_fields
+      private :add_step_fields
 
-      def _add_step_flags(step_h)
+      def add_step_flags(step_h)
         step_h['end']               = true if @end
         step_h['skip_user_turn']    = true if @skip_user_turn
         step_h['skip_to_next_step'] = true if @skip_to_next_step
       end
-      private :_add_step_flags
+      private :add_step_flags
 
       def reset_hash
         reset = {}
@@ -465,19 +465,19 @@ module SignalWire
         step = Step.new(name)
         @steps[name] = step
         @step_order << name
-        _apply_step_shortcuts(step, task, bullets, criteria, functions, valid_steps)
+        apply_step_shortcuts(step, task, bullets, criteria, functions, valid_steps)
         step
       end
 
       # @api private — apply add_step's optional one-call configuration.
-      def _apply_step_shortcuts(step, task, bullets, criteria, functions, valid_steps)
+      def apply_step_shortcuts(step, task, bullets, criteria, functions, valid_steps)
         step.add_section('Task', task)        unless task.nil?
         step.add_bullets('Process', bullets)  unless bullets.nil?
         step.set_step_criteria(criteria)      unless criteria.nil?
         step.set_functions(functions)         unless functions.nil?
         step.set_valid_steps(valid_steps)     unless valid_steps.nil?
       end
-      private :_apply_step_shortcuts
+      private :apply_step_shortcuts
 
       # Get an existing step by name. Returns Step or nil.
       def get_step(name)
@@ -663,9 +663,9 @@ module SignalWire
         raise ArgumentError, "Context '#{@name}' has no steps defined" if @steps.empty?
 
         ctx = { 'steps' => @step_order.map { |n| @steps[n].to_h } }
-        _add_navigation(ctx)
-        _add_reset_flags(ctx)
-        _add_prompt(ctx)
+        add_navigation(ctx)
+        add_reset_flags(ctx)
+        add_prompt(ctx)
         ctx['enter_fillers'] = @enter_fillers if @enter_fillers
         ctx['exit_fillers']  = @exit_fillers  if @exit_fillers
         ctx['history']       = @history       if @history
@@ -703,7 +703,7 @@ module SignalWire
         Contexts._render_pom_sections(@system_prompt_sections)
       end
 
-      def _add_navigation(ctx)
+      def add_navigation(ctx)
         ctx['valid_contexts'] = @valid_contexts if @valid_contexts
         ctx['valid_steps']    = @valid_steps    if @valid_steps
         ctx['initial_step']   = @initial_step   if @initial_step
@@ -712,14 +712,14 @@ module SignalWire
         ctx['system_prompt'] = sys if sys
       end
 
-      def _add_reset_flags(ctx)
+      def add_reset_flags(ctx)
         ctx['consolidate']  = @consolidate  if @consolidate
         ctx['full_reset']   = @full_reset   if @full_reset
         ctx['user_prompt']  = @user_prompt  if @user_prompt
         ctx['isolated']     = @isolated     if @isolated
       end
 
-      def _add_prompt(ctx)
+      def add_prompt(ctx)
         if @prompt_sections.any?
           ctx['pom'] = @prompt_sections
         elsif @prompt_text
@@ -813,14 +813,14 @@ module SignalWire
       def validate!
         raise ArgumentError, 'At least one context must be defined' if @contexts.empty?
 
-        _validate_single_context_name
-        _validate_steps_present
-        _validate_initial_steps
-        _validate_valid_steps_refs
-        _validate_context_level_refs
-        _validate_step_level_context_refs
-        _validate_gather_infos
-        _validate_reserved_tool_names
+        validate_single_context_name
+        validate_steps_present
+        validate_initial_steps
+        validate_valid_steps_refs
+        validate_context_level_refs
+        validate_step_level_context_refs
+        validate_gather_infos
+        validate_reserved_tool_names
         true
       end
 
@@ -841,7 +841,7 @@ module SignalWire
       private
 
       # Single context must be named "default".
-      def _validate_single_context_name
+      def validate_single_context_name
         return unless @contexts.size == 1
 
         ctx_name = @contexts.keys.first
@@ -850,14 +850,14 @@ module SignalWire
         raise ArgumentError, "When using a single context, it must be named 'default'"
       end
 
-      def _validate_steps_present
+      def validate_steps_present
         @contexts.each do |ctx_name, ctx|
           raise ArgumentError, "Context '#{ctx_name}' must have at least one step" if ctx._steps.empty?
         end
       end
 
       # initial_step (when set) must reference a real step in the context.
-      def _validate_initial_steps
+      def validate_initial_steps
         @contexts.each do |ctx_name, ctx|
           is = ctx._initial_step
           next unless is && !ctx._steps.key?(is)
@@ -869,25 +869,25 @@ module SignalWire
         end
       end
 
-      def _validate_valid_steps_refs
+      def validate_valid_steps_refs
         @contexts.each do |ctx_name, ctx|
           ctx._steps.each do |step_name, step|
             valid = step.to_h['valid_steps']
             next unless valid
 
-            valid.each { |ref| _check_step_ref(ctx, ctx_name, step_name, ref) }
+            valid.each { |ref| check_step_ref(ctx, ctx_name, step_name, ref) }
           end
         end
       end
 
-      def _check_step_ref(ctx, ctx_name, step_name, ref)
+      def check_step_ref(ctx, ctx_name, step_name, ref)
         return if ref == 'next' || ctx._steps.key?(ref)
 
         raise ArgumentError,
               "Step '#{step_name}' in context '#{ctx_name}' references unknown step '#{ref}'"
       end
 
-      def _validate_context_level_refs
+      def validate_context_level_refs
         @contexts.each do |ctx_name, ctx|
           valid = ctx.to_h['valid_contexts']
           next unless valid
@@ -900,18 +900,18 @@ module SignalWire
         end
       end
 
-      def _validate_step_level_context_refs
+      def validate_step_level_context_refs
         @contexts.each do |ctx_name, ctx|
           ctx._steps.each do |step_name, step|
             valid = step.to_h['valid_contexts']
             next unless valid
 
-            valid.each { |ref| _check_context_ref(ctx_name, step_name, ref) }
+            valid.each { |ref| check_context_ref(ctx_name, step_name, ref) }
           end
         end
       end
 
-      def _check_context_ref(ctx_name, step_name, ref)
+      def check_context_ref(ctx_name, step_name, ref)
         return if @contexts.key?(ref)
 
         raise ArgumentError,
@@ -924,29 +924,29 @@ module SignalWire
     module GatherInfoValidation
       private
 
-      def _validate_gather_infos
+      def validate_gather_infos
         @contexts.each do |ctx_name, ctx|
           ctx._steps.each do |step_name, step|
             gather = step.to_h['gather_info']
             next unless gather
 
-            _validate_gather_questions(gather, ctx_name, step_name)
-            _validate_gather_completion(gather, ctx, ctx_name, step_name)
+            validate_gather_questions(gather, ctx_name, step_name)
+            validate_gather_completion(gather, ctx, ctx_name, step_name)
           end
         end
       end
 
-      def _validate_gather_questions(gather, ctx_name, step_name)
+      def validate_gather_questions(gather, ctx_name, step_name)
         questions = gather['questions'] || []
         if questions.empty?
           raise ArgumentError,
                 "Step '#{step_name}' in context '#{ctx_name}' has gather_info with no questions"
         end
 
-        _check_duplicate_keys(questions, ctx_name, step_name)
+        check_duplicate_keys(questions, ctx_name, step_name)
       end
 
-      def _check_duplicate_keys(questions, ctx_name, step_name)
+      def check_duplicate_keys(questions, ctx_name, step_name)
         keys_seen = Set.new
         questions.each do |q|
           if keys_seen.include?(q['key'])
@@ -958,18 +958,18 @@ module SignalWire
         end
       end
 
-      def _validate_gather_completion(gather, ctx, ctx_name, step_name)
+      def validate_gather_completion(gather, ctx, ctx_name, step_name)
         action = gather['completion_action']
         return unless action
 
         if action == 'next_step'
-          _validate_next_step_action(ctx, ctx_name, step_name)
+          validate_next_step_action(ctx, ctx_name, step_name)
         elsif !ctx._steps.key?(action)
-          _raise_unknown_completion_action(ctx, ctx_name, step_name, action)
+          raise_unknown_completion_action(ctx, ctx_name, step_name, action)
         end
       end
 
-      def _validate_next_step_action(ctx, ctx_name, step_name)
+      def validate_next_step_action(ctx, ctx_name, step_name)
         idx = ctx._step_order.index(step_name)
         return if idx < ctx._step_order.size - 1
 
@@ -982,7 +982,7 @@ module SignalWire
               "(default) to stay in '#{step_name}' after gathering completes."
       end
 
-      def _raise_unknown_completion_action(ctx, ctx_name, step_name, action)
+      def raise_unknown_completion_action(ctx, ctx_name, step_name, action)
         available = ctx._steps.keys.sort
         raise ArgumentError,
               "Step '#{step_name}' in context '#{ctx_name}' has gather_info " \
@@ -995,7 +995,7 @@ module SignalWire
       # User-defined tools must not collide with reserved native tool names
       # (next_step / change_context / gather_submit auto-injected by the
       # runtime when contexts/steps are present).
-      def _validate_reserved_tool_names
+      def validate_reserved_tool_names
         return unless @agent.respond_to?(:list_tool_names)
 
         registered = @agent.list_tool_names.to_a

--- a/lib/signalwire/core/auth_handler.rb
+++ b/lib/signalwire/core/auth_handler.rb
@@ -193,7 +193,9 @@ module SignalWire
       end
 
       def logger
-        @logger ||= SignalWire::Logging.logger('auth_handler')
+        return @logger if defined?(@logger)
+
+        @logger = SignalWire::Logging.logger('auth_handler')
       end
 
       def basic_auth_info

--- a/lib/signalwire/core/security_config.rb
+++ b/lib/signalwire/core/security_config.rb
@@ -160,7 +160,9 @@ module SignalWire
       private
 
       def logger
-        @logger ||= SignalWire::Logging.logger('security_config')
+        return @logger if defined?(@logger)
+
+        @logger = SignalWire::Logging.logger('security_config')
       end
 
       def config_summary

--- a/lib/signalwire/pom/prompt_object_model.rb
+++ b/lib/signalwire/pom/prompt_object_model.rb
@@ -160,7 +160,7 @@ module SignalWire
       # Mirrors Python's
       # ``PromptObjectModel.add_pom_as_subsection(target, pom_to_add)``.
       def add_pom_as_subsection(target, pom_to_add)
-        target_section = _resolve_target_section(target)
+        target_section = resolve_target_section(target)
         pom_to_add.sections.each do |section|
           target_section.subsections << section
         end
@@ -168,7 +168,7 @@ module SignalWire
 
       private
 
-      def _resolve_target_section(target)
+      def resolve_target_section(target)
         case target
         when String
           section = find_section(target)

--- a/lib/signalwire/prefabs/receptionist.rb
+++ b/lib/signalwire/prefabs/receptionist.rb
@@ -54,7 +54,7 @@ module SignalWire
       def handle_transfer(args, _raw_data)
         dept_name = args['department']
         dept = @departments.find { |d| d['name'] == dept_name }
-        return _department_not_found_result unless dept
+        return department_not_found_result unless dept
 
         result = Swaig::FunctionResult.new("Transferring you to #{dept_name} now.")
         result.connect(dept['number'])
@@ -90,7 +90,7 @@ module SignalWire
         end
       end
 
-      def _department_not_found_result
+      def department_not_found_result
         names = @departments.map { |d| d['name'] }.join(', ')
         Swaig::FunctionResult.new(
           "I couldn't find that department. Available departments: #{names}"

--- a/lib/signalwire/relay/action.rb
+++ b/lib/signalwire/relay/action.rb
@@ -55,7 +55,7 @@ module SignalWire
           @completed = true
           @condition.broadcast
         end
-        _fire_on_completed(event)
+        fire_on_completed(event)
       end
 
       # Wait for the action to complete. Returns the terminal event.
@@ -65,7 +65,7 @@ module SignalWire
           return @result if @completed
 
           if timeout
-            _wait_with_timeout(timeout)
+            wait_with_timeout(timeout)
           else
             @condition.wait(@mutex) until @completed
           end
@@ -82,7 +82,7 @@ module SignalWire
       private
 
       # Fire the on_completed callback outside the mutex, swallowing errors.
-      def _fire_on_completed(event)
+      def fire_on_completed(event)
         return unless @on_completed
 
         begin
@@ -93,7 +93,7 @@ module SignalWire
       end
 
       # Block on the condition variable until completed or the deadline passes.
-      def _wait_with_timeout(timeout)
+      def wait_with_timeout(timeout)
         deadline = Time.now + timeout
         until @completed
           remaining = deadline - Time.now

--- a/lib/signalwire/relay/call.rb
+++ b/lib/signalwire/relay/call.rb
@@ -20,12 +20,12 @@ module SignalWire
       def initialize(client, call_id:, node_id:, project_id: '', context: '',
                      tag: '', direction: '', device: {}, state: '', segment_id: '')
         @client = client
-        _init_identity(call_id, node_id, project_id, context, tag, direction, device, state, segment_id)
-        _init_event_state
+        init_identity(call_id, node_id, project_id, context, tag, direction, device, state, segment_id)
+        init_event_state
       end
 
       # Assign the descriptive call attributes (the public attr_readers).
-      def _init_identity(call_id, node_id, project_id, context, tag, direction, device, state, segment_id)
+      def init_identity(call_id, node_id, project_id, context, tag, direction, device, state, segment_id)
         @call_id    = call_id
         @node_id    = node_id
         @project_id = project_id
@@ -39,7 +39,7 @@ module SignalWire
 
       # Initialize the per-call event/action bookkeeping and synchronization
       # primitives (listeners, active actions, ended-state condition).
-      def _init_event_state
+      def init_event_state
         # Event listeners: event_type -> list of handlers
         @listeners = {}
         # Active actions indexed by control_id
@@ -58,22 +58,22 @@ module SignalWire
       # Send a calling.<method> JSON-RPC request for this call.
       def _execute(method, extra_params = nil)
         params = {
-          'node_id' => @node_id,
-          'call_id' => @call_id
+          'node_id' => node_id,
+          'call_id' => call_id
         }
         params.merge!(extra_params) if extra_params
-        @client.execute("calling.#{method}", params)
+        client.execute("calling.#{method}", params)
       rescue RelayError => e
         # A gone (404/410) call returns {} instead of raising; everything else
         # propagates.
-        raise unless _call_gone_error?(e)
+        raise unless call_gone_error?(e)
 
-        warn "[RELAY] Call #{@call_id} gone during #{method} (code=#{e.code})"
+        warn "[RELAY] Call #{call_id} gone during #{method} (code=#{e.code})"
         {}
       end
 
       # True when a RelayError carries a 404/410 "call gone" code.
-      def _call_gone_error?(error)
+      def call_gone_error?(error)
         code = error.code
         code && [404, 410, '404', '410'].include?(code)
       end
@@ -92,14 +92,14 @@ module SignalWire
       # Called by RelayClient when an event arrives for this call.
       def _dispatch_event(payload)
         event = Relay.parse_event(payload)
-        _apply_state_event(event) if event.event_type == EVENT_CALL_STATE
-        _route_to_action(event)
-        _notify_listeners(event)
+        apply_state_event(event) if event.event_type == EVENT_CALL_STATE
+        route_to_action(event)
+        notify_listeners(event)
       end
 
       # Update @state from a call.state event and, on ENDED, mark the call
       # ended and resolve any still-pending actions.
-      def _apply_state_event(event)
+      def apply_state_event(event)
         @state = event.params['call_state'] || @state
         return unless @state == CALL_STATE_ENDED
 
@@ -114,7 +114,7 @@ module SignalWire
 
       # Route an event to the active action matching its control_id, dropping
       # the action once completed.
-      def _route_to_action(event)
+      def route_to_action(event)
         control_id = event.params['control_id'] || ''
         return if control_id.empty? || !@actions.key?(control_id)
 
@@ -125,7 +125,7 @@ module SignalWire
 
       # Fire registered listeners for the event's type, swallowing handler
       # errors so one bad handler can't break dispatch.
-      def _notify_listeners(event)
+      def notify_listeners(event)
         event_type = event.event_type
         handlers = @mutex.synchronize { (@listeners[event_type] || []).dup }
         handlers.each do |handler|
@@ -140,14 +140,14 @@ module SignalWire
         @mutex.synchronize do
           return @end_event if @ended
 
-          _block_until(@ended_cv, @mutex, timeout) { @ended }
+          block_until(@ended_cv, @mutex, timeout) { @ended }
           @end_event
         end
       end
 
       # Block on +condition+ (holding +mutex+) until the block returns truthy,
       # or +timeout+ seconds elapse. Caller must already hold +mutex+.
-      def _block_until(condition, mutex, timeout)
+      def block_until(condition, mutex, timeout)
         if timeout
           deadline = Time.now + timeout
           until yield
@@ -172,7 +172,7 @@ module SignalWire
       # already at/past the target resolves with a synthetic state event
       # (matching the legacy SDK's short-circuit).
       def _wait_for_state(target, timeout)
-        return _synthetic_state_event if _state_rank(@state) >= _state_rank(target)
+        return synthetic_state_event if state_rank(@state) >= state_rank(target)
 
         wait_for(
           EVENT_CALL_STATE,
@@ -183,13 +183,13 @@ module SignalWire
 
       # Short-circuit event carrying the current @state, used when the call is
       # already at or past the requested wait target.
-      def _synthetic_state_event
+      def synthetic_state_event
         RelayEvent.new(event_type: EVENT_CALL_STATE, params: { 'call_state' => @state })
       end
 
       # Ordinal of a call state in CALL_STATES (created < ringing < answered <
       # ending < ended); unknown states rank -1.
-      def _state_rank(state)
+      def state_rank(state)
         idx = CALL_STATES.index(state)
         idx.nil? ? -1 : idx
       end
@@ -231,25 +231,25 @@ module SignalWire
         mutex   = Mutex.new
         cv      = ConditionVariable.new
         state   = { result: nil, satisfied: false }
-        handler = _one_shot_handler(mutex, cv, state, predicate)
+        handler = one_shot_handler(mutex, cv, state, predicate)
 
         on(event_type, &handler)
-        _with_one_shot_listener(event_type, handler) do
-          mutex.synchronize { _block_until(cv, mutex, timeout) { state[:satisfied] } }
+        with_one_shot_listener(event_type, handler) do
+          mutex.synchronize { block_until(cv, mutex, timeout) { state[:satisfied] } }
           state[:result]
         end
       end
 
       # Run the block, guaranteeing the one-shot listener is removed afterward.
-      def _with_one_shot_listener(event_type, handler)
+      def with_one_shot_listener(event_type, handler)
         yield
       ensure
-        _remove_listener(event_type, handler)
+        remove_listener(event_type, handler)
       end
 
       # Build a one-shot event handler that, under +mutex+, records the first
       # event satisfying +predicate+ into +state+ and signals +cv+.
-      def _one_shot_handler(mutex, condition, state, predicate)
+      def one_shot_handler(mutex, condition, state, predicate)
         lambda do |event|
           mutex.synchronize do
             next if state[:satisfied]
@@ -263,7 +263,7 @@ module SignalWire
       end
 
       # Remove a one-shot listener so it doesn't fire for later events.
-      def _remove_listener(event_type, handler)
+      def remove_listener(event_type, handler)
         @mutex.synchronize do
           listeners = @listeners[event_type]
           listeners&.delete(handler)
@@ -274,37 +274,37 @@ module SignalWire
       # Action helper
       # ------------------------------------------------------------------
 
-      def _start_action(action, method, params, on_completed: nil)
+      def start_action(action, method, params, on_completed: nil)
         if @state == CALL_STATE_ENDED
-          warn "[RELAY] Call #{@call_id} already ended, skipping #{method}"
-          action._resolve(_gone_event)
+          warn "[RELAY] Call #{call_id} already ended, skipping #{method}"
+          action._resolve(gone_event)
           return action
         end
         action._set_on_completed(on_completed) if on_completed
         @actions[action.control_id] = action
-        result = _execute_action(action, method, params)
+        result = execute_action(action, method, params)
         # _execute returns {} when the call is gone (404/410)
-        _resolve_gone(action) if result.nil? || result.empty?
+        resolve_gone(action) if result.nil? || result.empty?
         action
       end
 
       # Run the action's RPC; on error drop it, resolve it gone, and re-raise.
-      def _execute_action(action, method, params)
+      def execute_action(action, method, params)
         _execute(method, params)
       rescue StandardError
         @actions.delete(action.control_id)
-        action._resolve(_gone_event)
+        action._resolve(gone_event)
         raise
       end
 
       # Drop a pending action and resolve it with a synthetic gone event.
-      def _resolve_gone(action)
+      def resolve_gone(action)
         @actions.delete(action.control_id)
-        action._resolve(_gone_event) unless action.done?
+        action._resolve(gone_event) unless action.done?
       end
 
       # Synthetic "call gone" terminal event.
-      def _gone_event
+      def gone_event
         RelayEvent.new(event_type: '', params: {})
       end
 
@@ -521,7 +521,7 @@ module SignalWire
         params['loop']      = loop_count if loop_count
         kwargs.each { |k, v| params[k.to_s] = v }
         action = PlayAction.new(self, cid)
-        _start_action(action, 'play', params, on_completed: on_completed)
+        start_action(action, 'play', params, on_completed: on_completed)
       end
 
       # Play text-to-speech. Typed convenience over #play.
@@ -585,7 +585,7 @@ module SignalWire
         params = { 'control_id' => cid, 'record' => record_obj }
         kwargs.each { |k, v| params[k.to_s] = v }
         action = RecordAction.new(self, cid)
-        _start_action(action, 'record', params, on_completed: on_completed)
+        start_action(action, 'record', params, on_completed: on_completed)
       end
 
       # ------------------------------------------------------------------
@@ -599,7 +599,7 @@ module SignalWire
         params['volume'] = volume if volume
         kwargs.each { |k, v| params[k.to_s] = v }
         action = CollectAction.new(self, cid)
-        _start_action(action, 'play_and_collect', params, on_completed: on_completed)
+        start_action(action, 'play_and_collect', params, on_completed: on_completed)
       end
 
       def collect(collect_opts, control_id: nil, on_completed: nil, **kwargs)
@@ -608,7 +608,7 @@ module SignalWire
         params.merge!(collect_opts.transform_keys(&:to_s)) if collect_opts.is_a?(Hash)
         kwargs.each { |k, v| params[k.to_s] = v }
         action = StandaloneCollectAction.new(self, cid)
-        _start_action(action, 'collect', params, on_completed: on_completed)
+        start_action(action, 'collect', params, on_completed: on_completed)
       end
 
       # Play TTS then collect input. Typed media over #play_and_collect.
@@ -651,7 +651,7 @@ module SignalWire
         params['timeout'] = timeout if timeout
         kwargs.each { |k, v| params[k.to_s] = v }
         action = DetectAction.new(self, cid)
-        _start_action(action, 'detect', params, on_completed: on_completed)
+        start_action(action, 'detect', params, on_completed: on_completed)
       end
 
       # Detect DTMF digits. Typed convenience over #detect.
@@ -713,7 +713,7 @@ module SignalWire
         params = { 'control_id' => cid, 'document' => document }
         kwargs.each { |k, v| params[k.to_s] = v }
         action = FaxAction.new(self, cid, 'send_fax')
-        _start_action(action, 'send_fax', params, on_completed: on_completed)
+        start_action(action, 'send_fax', params, on_completed: on_completed)
       end
 
       def receive_fax(control_id: nil, on_completed: nil, **kwargs)
@@ -721,7 +721,7 @@ module SignalWire
         params = { 'control_id' => cid }
         kwargs.each { |k, v| params[k.to_s] = v }
         action = FaxAction.new(self, cid, 'receive_fax')
-        _start_action(action, 'receive_fax', params, on_completed: on_completed)
+        start_action(action, 'receive_fax', params, on_completed: on_completed)
       end
 
       # ------------------------------------------------------------------
@@ -733,7 +733,7 @@ module SignalWire
         params = { 'control_id' => cid, 'tap' => tap_opts, 'device' => device }
         kwargs.each { |k, v| params[k.to_s] = v }
         action = TapAction.new(self, cid)
-        _start_action(action, 'tap', params, on_completed: on_completed)
+        start_action(action, 'tap', params, on_completed: on_completed)
       end
 
       # ------------------------------------------------------------------
@@ -745,7 +745,7 @@ module SignalWire
         params = { 'control_id' => cid, 'url' => url }
         kwargs.each { |k, v| params[k.to_s] = v }
         action = StreamAction.new(self, cid)
-        _start_action(action, 'stream', params, on_completed: on_completed)
+        start_action(action, 'stream', params, on_completed: on_completed)
       end
 
       # ------------------------------------------------------------------
@@ -757,7 +757,7 @@ module SignalWire
         params = { 'control_id' => cid }
         kwargs.each { |k, v| params[k.to_s] = v }
         action = TranscribeAction.new(self, cid)
-        _start_action(action, 'transcribe', params, on_completed: on_completed)
+        start_action(action, 'transcribe', params, on_completed: on_completed)
       end
 
       # ------------------------------------------------------------------
@@ -769,7 +769,7 @@ module SignalWire
         params = { 'control_id' => cid, 'payment_connector_url' => payment_connector_url }
         kwargs.each { |k, v| params[k.to_s] = v }
         action = PayAction.new(self, cid)
-        _start_action(action, 'pay', params, on_completed: on_completed)
+        start_action(action, 'pay', params, on_completed: on_completed)
       end
 
       # ------------------------------------------------------------------
@@ -781,16 +781,31 @@ module SignalWire
         params = { 'control_id' => cid }
         kwargs.each { |k, v| params[k.to_s] = v }
         action = AIAction.new(self, cid)
-        _start_action(action, 'ai', params, on_completed: on_completed)
+        start_action(action, 'ai', params, on_completed: on_completed)
       end
 
       def to_s
-        "Call(id=#{@call_id}, state=#{@state}, direction=#{@direction})"
+        "Call(id=#{call_id}, state=#{@state}, direction=#{direction})"
       end
 
       def inspect
         to_s
       end
+
+      # Owning RelayClient — set once at construction, read-only thereafter.
+      attr_reader :client
+
+      # Internal helpers (formerly leading-underscore by convention). Not part of
+      # the public/Python surface — declared private so the cross-port surface
+      # enumerator continues to exclude them. _execute / _dispatch_event /
+      # _wait_for_state stay public+underscored: they are invoked cross-instance
+      # (Action, RelayClient, and the test suite call them with an explicit
+      # receiver), which private/protected would break.
+      private :client, :init_identity, :init_event_state, :call_gone_error?,
+              :apply_state_event, :route_to_action, :notify_listeners, :block_until,
+              :synthetic_state_event, :state_rank, :with_one_shot_listener,
+              :one_shot_handler, :remove_listener, :start_action, :execute_action,
+              :resolve_gone, :gone_event
     end
   end
 end

--- a/lib/signalwire/relay/client.rb
+++ b/lib/signalwire/relay/client.rb
@@ -51,10 +51,10 @@ module SignalWire
       }.freeze
       # Event types whose handler takes the outer params hash.
       OUTER_PARAM_EVENT_HANDLERS = {
-        EVENT_CALL_RECEIVE => :_handle_inbound_call,
-        EVENT_CALL_DIAL => :_handle_dial_event,
-        EVENT_MESSAGING_RECEIVE => :_handle_inbound_message,
-        EVENT_MESSAGING_STATE => :_handle_message_state
+        EVENT_CALL_RECEIVE => :handle_inbound_call,
+        EVENT_CALL_DIAL => :handle_dial_event,
+        EVENT_MESSAGING_RECEIVE => :handle_inbound_message,
+        EVENT_MESSAGING_STATE => :handle_message_state
       }.freeze
 
       # Construct a RelayClient. An earlier release accepted ``space:``
@@ -78,32 +78,35 @@ module SignalWire
                      space: nil)
         @jwt_token  = jwt_token
         @contexts   = contexts
-        @max_active_calls = _resolve_max_active_calls(max_active_calls)
-        _resolve_credentials(project, token, host, space)
+        @max_active_calls = resolve_max_active_calls(max_active_calls)
+        resolve_credentials(project, token, host, space)
 
-        _validate_credentials
+        validate_credentials
         @host = @space.include?('.') ? @space : "#{@space}.signalwire.com"
 
-        _init_correlation_state
-        _init_session_state
+        init_correlation_state
+        init_session_state
       end
 
       private
 
-      def _resolve_credentials(project, token, host, space)
-        @project_id = _value_or_env(project, 'SIGNALWIRE_PROJECT_ID')
-        @token      = _value_or_env(token, 'SIGNALWIRE_API_TOKEN')
+      # Read-only connection config, set once during initialize.
+      attr_reader :space, :token, :jwt_token, :contexts
+
+      def resolve_credentials(project, token, host, space)
+        @project_id = value_or_env(project, 'SIGNALWIRE_PROJECT_ID')
+        @token      = value_or_env(token, 'SIGNALWIRE_API_TOKEN')
         # Accept either `host:` (Python parity) or legacy `space:`.
-        @space      = _value_or_env(host || space, 'SIGNALWIRE_SPACE')
+        @space      = value_or_env(host || space, 'SIGNALWIRE_SPACE')
       end
 
-      def _value_or_env(explicit, env_key)
+      def value_or_env(explicit, env_key)
         explicit || ENV[env_key] || ''
       end
 
       # Resolve max_active_calls: the explicit arg, else the
       # RELAY_MAX_ACTIVE_CALLS env var.
-      def _resolve_max_active_calls(max_active_calls)
+      def resolve_max_active_calls(max_active_calls)
         if max_active_calls.nil?
           env_val = ENV.fetch('RELAY_MAX_ACTIVE_CALLS', nil)
           env_val && !env_val.empty? ? Integer(env_val) : nil
@@ -112,13 +115,13 @@ module SignalWire
         end
       end
 
-      def _validate_credentials
-        raise ArgumentError, 'project is required' if @project_id.empty?
-        raise ArgumentError, 'token or jwt_token is required' if @token.empty? && @jwt_token.nil?
-        raise ArgumentError, 'host is required' if @space.empty?
+      def validate_credentials
+        raise ArgumentError, 'project is required' if project_id.empty?
+        raise ArgumentError, 'token or jwt_token is required' if token.empty? && jwt_token.nil?
+        raise ArgumentError, 'host is required' if space.empty?
       end
 
-      def _init_correlation_state
+      def init_correlation_state
         # Correlation mechanisms
         @pending       = {} # id -> { mutex:, cv:, result:, error: }
         @pending_mutex = Mutex.new
@@ -130,7 +133,7 @@ module SignalWire
         @messages_mutex = Mutex.new
       end
 
-      def _init_session_state
+      def init_session_state
         # Session state
         @protocol            = nil
         @authorization_state = nil
@@ -151,10 +154,10 @@ module SignalWire
         # Reconnection backoff
         @reconnect_delay = RECONNECT_MIN_DELAY
         @should_restart  = false
-        _init_handlers
+        init_handlers
       end
 
-      def _init_handlers
+      def init_handlers
         @on_call_handler    = nil
         @on_message_handler = nil
         @on_event_handler   = nil
@@ -231,11 +234,11 @@ module SignalWire
       def run
         @running = true
         while @running
-          _connect_and_run_guarded
+          connect_and_run_guarded
           break unless @running
 
-          _reject_all_pending('Disconnected')
-          _backoff_reconnect
+          reject_all_pending('Disconnected')
+          backoff_reconnect
         end
       end
 
@@ -245,7 +248,7 @@ module SignalWire
       # disconnect()/stop() to tear down.
       def connect
         @running = true
-        _connect_and_run_guarded
+        connect_and_run_guarded
         self
       end
 
@@ -255,14 +258,14 @@ module SignalWire
         @running = false
         # Snapshot under the mutex, close outside it. The websocket-client
         # gem fires the `:close` callback synchronously inside `close`,
-        # which re-enters _on_ws_close → tries to take @ws_mutex and
+        # which re-enters on_ws_close → tries to take @ws_mutex and
         # deadlocks if we're still holding it.
         ws_to_close = nil
         @ws_mutex.synchronize do
           ws_to_close = @ws if @connected
         end
         ws_to_close&.close
-        _reject_all_pending('Client stopped')
+        reject_all_pending('Client stopped')
       end
 
       # ------------------------------------------------------------------
@@ -277,8 +280,8 @@ module SignalWire
         entry = { mutex: Mutex.new, cv: ConditionVariable.new, call: nil, error: nil }
         @dials_mutex.synchronize { @pending_dials[dial_tag] = entry }
 
-        _send_dial_rpc(dial_tag, devices, kwargs)
-        _await_dial(dial_tag, entry, timeout)
+        send_dial_rpc(dial_tag, devices, kwargs)
+        await_dial(dial_tag, entry, timeout)
         @dials_mutex.synchronize { @pending_dials.delete(dial_tag) }
         raise RelayError.new(-1, entry[:error]) if entry[:error]
 
@@ -295,14 +298,14 @@ module SignalWire
       # exactly. At least one of body: or media: is required.
       def send_message(to_number:, from_number:, context: nil, body: nil,
                        media: nil, tags: nil, region: nil, on_completed: nil)
-        _validate_message_payload(body, media)
-        msg_context = context || @contexts.first || 'default'
-        params = _build_message_params(msg_context, to_number, from_number, body: body, media: media,
-                                                                            tags: tags, region: region)
+        validate_message_payload(body, media)
+        msg_context = context || contexts.first || 'default'
+        params = build_message_params(msg_context, to_number, from_number, body: body, media: media,
+                                                                           tags: tags, region: region)
         message_id = execute('messaging.send', params)['message_id'] || ''
 
-        msg = _build_outbound_message(message_id, msg_context, to_number, from_number,
-                                      body: body, media: media, tags: tags)
+        msg = build_outbound_message(message_id, msg_context, to_number, from_number,
+                                     body: body, media: media, tags: tags)
         msg._set_on_completed(on_completed) if on_completed
         @messages_mutex.synchronize { @messages[message_id] = msg } unless message_id.empty?
         msg
@@ -332,37 +335,37 @@ module SignalWire
         @pending_mutex.synchronize { @pending[id] = entry }
 
         # Python parity: params are sent VERBATIM. The protocol is only carried
-        # on the signalwire.connect handshake (see _apply_session_restore), NOT
+        # on the signalwire.connect handshake (see apply_session_restore), NOT
         # injected into every calling.*/messaging.* frame.
         _send_json('jsonrpc' => '2.0', 'id' => id, 'method' => method,
                    'params' => params)
-        _await_response(id, entry, method)
+        await_response(id, entry, method)
 
         @pending_mutex.synchronize { @pending.delete(id) }
         raise entry[:error] if entry[:error]
 
-        _check_result_code(method, entry[:result])
+        check_result_code(method, entry[:result])
         entry[:result]
       end
 
       private
 
-      def _connect_and_run_guarded
-        _connect_and_run
+      def connect_and_run_guarded
+        connect_and_run
       rescue StandardError => e
         warn "[RELAY] Connection error: #{e.message}"
       end
 
       # Exponential backoff between reconnect attempts.
-      def _backoff_reconnect
+      def backoff_reconnect
         warn "[RELAY] Reconnecting in #{@reconnect_delay}s..."
         sleep(@reconnect_delay)
         @reconnect_delay = [@reconnect_delay * RECONNECT_BACKOFF_FACTOR, RECONNECT_MAX_DELAY].min
       end
 
       # Wait for the calling.call.dial event (or error/timeout) for a dial.
-      def _await_dial(dial_tag, entry, timeout)
-        _wait_on_entry(entry, timeout, -> { entry[:call].nil? && entry[:error].nil? }) do
+      def await_dial(dial_tag, entry, timeout)
+        wait_on_entry(entry, timeout, -> { entry[:call].nil? && entry[:error].nil? }) do
           @dials_mutex.synchronize { @pending_dials.delete(dial_tag) }
           raise ActionTimeoutError, "Dial timed out after #{timeout}s"
         end
@@ -370,7 +373,7 @@ module SignalWire
 
       # Block on entry[:cv] under entry[:mutex] until +pending+ returns false or
       # the timeout elapses; on timeout, run the +on_timeout+ block.
-      def _wait_on_entry(entry, timeout, pending)
+      def wait_on_entry(entry, timeout, pending)
         entry[:mutex].synchronize do
           deadline = Time.now + timeout
           while pending.call
@@ -381,13 +384,13 @@ module SignalWire
         end
       end
 
-      def _validate_message_payload(body, media)
+      def validate_message_payload(body, media)
         return unless (body.nil? || body.empty?) && (media.nil? || media.empty?)
 
         raise ArgumentError, 'body or media is required'
       end
 
-      def _send_dial_rpc(dial_tag, devices, kwargs)
+      def send_dial_rpc(dial_tag, devices, kwargs)
         params = { 'tag' => dial_tag, 'devices' => devices }
         kwargs.each { |k, v| params[k.to_s] = v }
         execute('calling.dial', params)
@@ -396,7 +399,7 @@ module SignalWire
         raise
       end
 
-      def _build_message_params(msg_context, to_number, from_number, body:, media:, tags:, region:)
+      def build_message_params(msg_context, to_number, from_number, body:, media:, tags:, region:)
         params = { 'context' => msg_context, 'to_number' => to_number, 'from_number' => from_number }
         params['body']   = body   if body
         params['media']  = media  if media
@@ -405,7 +408,7 @@ module SignalWire
         params
       end
 
-      def _build_outbound_message(message_id, msg_context, to_number, from_number, body:, media:, tags:)
+      def build_outbound_message(message_id, msg_context, to_number, from_number, body:, media:, tags:)
         Message.new(
           message_id: message_id, context: msg_context, direction: 'outbound',
           from_number: from_number, to_number: to_number,
@@ -414,14 +417,14 @@ module SignalWire
       end
 
       # Wait for a JSON-RPC response (10s timeout to detect half-open connections).
-      def _await_response(id, entry, method)
-        _wait_on_entry(entry, 10, -> { entry[:result].nil? && entry[:error].nil? }) do
+      def await_response(id, entry, method)
+        wait_on_entry(entry, 10, -> { entry[:result].nil? && entry[:error].nil? }) do
           @pending_mutex.synchronize { @pending.delete(id) }
           raise RelayError.new(-1, "Request #{method} timed out")
         end
       end
 
-      def _check_result_code(method, result)
+      def check_result_code(method, result)
         return if method == METHOD_SIGNALWIRE_CONNECT
 
         code = result['code']
@@ -432,25 +435,25 @@ module SignalWire
       # WebSocket connection lifecycle
       # ------------------------------------------------------------------
 
-      def _connect_and_run
-        scheme = _relay_scheme
-        url = "#{scheme}://#{_relay_endpoint_host}"
+      def connect_and_run
+        scheme = relay_scheme
+        url = "#{scheme}://#{relay_endpoint_host}"
         # Secure-by-default WSS verification options (empty for plain ws://).
-        _open_websocket(url, _wss_tls_options(scheme))
+        open_websocket(url, wss_tls_options(scheme))
 
         @ws_mutex.synchronize { @connected = true }
         @reconnect_delay = RECONNECT_MIN_DELAY
-        _authenticate
+        authenticate
 
         # Keep reading until disconnected
         sleep 1 while @running && @connected
       end
 
       # Open the WebSocket and block until it reports open, raising on error.
-      def _open_websocket(url, ws_options)
+      def open_websocket(url, ws_options)
         # Shared open/error signalling between the connect callbacks and here.
         ready = { mutex: Mutex.new, cv: ConditionVariable.new, flag: false, error: nil }
-        @ws = WebSocket::Client::Simple.connect(url, ws_options) { |ws| _wire_ws_callbacks(ws, ready) }
+        @ws = WebSocket::Client::Simple.connect(url, ws_options) { |ws| wire_ws_callbacks(ws, ready) }
         ready[:mutex].synchronize { ready[:cv].wait(ready[:mutex], 15) until ready[:flag] }
         raise ready[:error] if ready[:error]
       end
@@ -459,35 +462,35 @@ module SignalWire
       # ephemeral port on 127.0.0.1 and serves plain ws://; SIGNALWIRE_RELAY_HOST
       # and SIGNALWIRE_RELAY_SCHEME let the audit harness redirect the client
       # there without touching production credential resolution.
-      def _relay_scheme
+      def relay_scheme
         scheme = ENV.fetch('SIGNALWIRE_RELAY_SCHEME', nil)
         scheme.nil? || scheme.empty? ? 'wss' : scheme
       end
 
-      def _relay_endpoint_host
+      def relay_endpoint_host
         host_override = ENV.fetch('SIGNALWIRE_RELAY_HOST', nil)
-        host_override.nil? || host_override.empty? ? @host : host_override
+        host_override.nil? || host_override.empty? ? host : host_override
       end
 
       # Wire the open/message/error/close callbacks onto the websocket. +ready+
-      # is the shared signalling hash (see _connect_and_run).
-      def _wire_ws_callbacks(socket, ready)
+      # is the shared signalling hash (see connect_and_run).
+      def wire_ws_callbacks(socket, ready)
         client_ref = self
-        socket.on(:message) { |msg| client_ref.send(:_on_ws_message, msg.data) }
-        socket.on(:open)  { client_ref.send(:_on_ws_lifecycle, :_on_ws_open, ready) }
-        socket.on(:close) { client_ref.send(:_on_ws_lifecycle, :_on_ws_close, ready) }
+        socket.on(:message) { |msg| client_ref.send(:on_ws_message, msg.data) }
+        socket.on(:open)  { client_ref.send(:on_ws_lifecycle, :on_ws_open, ready) }
+        socket.on(:close) { client_ref.send(:on_ws_lifecycle, :on_ws_close, ready) }
         socket.on(:error) do |err|
           ready[:error] = err
-          client_ref.send(:_signal_ready, ready)
+          client_ref.send(:signal_ready, ready)
         end
       end
 
-      def _on_ws_lifecycle(hook, ready)
+      def on_ws_lifecycle(hook, ready)
         send(hook)
-        _signal_ready(ready)
+        signal_ready(ready)
       end
 
-      def _signal_ready(ready)
+      def signal_ready(ready)
         ready[:mutex].synchronize do
           ready[:flag] = true
           ready[:cv].signal
@@ -507,7 +510,7 @@ module SignalWire
       # @param scheme [String] the URL scheme ("wss" or "ws")
       # @return [Hash] connect options ({} for plain ws://)
       # @api private
-      def _wss_tls_options(scheme)
+      def wss_tls_options(scheme)
         return {} unless scheme == 'wss'
 
         require 'openssl'
@@ -519,11 +522,11 @@ module SignalWire
         { verify_mode: OpenSSL::SSL::VERIFY_PEER, cert_store: store }
       end
 
-      def _on_ws_open
+      def on_ws_open
         # Connection opened
       end
 
-      def _on_ws_message(data)
+      def on_ws_message(data)
         return if data.nil? || data.empty?
 
         begin
@@ -533,10 +536,10 @@ module SignalWire
           return
         end
 
-        _handle_message(msg)
+        handle_message(msg)
       end
 
-      def _on_ws_close
+      def on_ws_close
         @ws_mutex.synchronize { @connected = false }
       end
 
@@ -552,12 +555,12 @@ module SignalWire
       # Authentication
       # ------------------------------------------------------------------
 
-      def _authenticate
+      def authenticate
         params = { 'version' => PROTOCOL_VERSION, 'agent' => AGENT_STRING, 'event_acks' => true }
-        _apply_auth_credentials(params)
-        params['contexts'] = @contexts unless @contexts.empty?
-        _apply_session_restore(params)
-        _clear_restart_state if @should_restart
+        apply_auth_credentials(params)
+        params['contexts'] = contexts unless contexts.empty?
+        apply_session_restore(params)
+        clear_restart_state if @should_restart
 
         result = execute(METHOD_SIGNALWIRE_CONNECT, params)
         @protocol = result['protocol'] if result['protocol']
@@ -568,28 +571,28 @@ module SignalWire
         @session_id = result['sessionid'] if result['sessionid']
       end
 
-      def _apply_session_restore(params)
+      def apply_session_restore(params)
         return if @should_restart
 
         params['protocol'] = @protocol if @protocol
         params['authorization_state'] = @authorization_state if @authorization_state
       end
 
-      def _apply_auth_credentials(params)
-        if @jwt_token
-          params['authentication'] = { 'jwt_token' => @jwt_token }
+      def apply_auth_credentials(params)
+        if jwt_token
+          params['authentication'] = { 'jwt_token' => jwt_token }
           return
         end
 
-        params['authentication'] = { 'project' => @project_id, 'token' => @token }
+        params['authentication'] = { 'project' => project_id, 'token' => token }
         # Audit fixtures and Blade-aware servers also accept the credentials at
         # the top level. Python's RELAY emits them in `authentication`; the audit
         # harness watches the top level. Emit both to satisfy both consumers.
-        params['project'] = @project_id
-        params['token']   = @token
+        params['project'] = project_id
+        params['token']   = token
       end
 
-      def _clear_restart_state
+      def clear_restart_state
         @protocol = nil
         @authorization_state = nil
         @should_restart = false
@@ -599,26 +602,26 @@ module SignalWire
       # Message dispatch
       # ------------------------------------------------------------------
 
-      def _handle_message(msg)
+      def handle_message(msg)
         # A frame with no method is a response to a pending request.
-        return _handle_response(msg) if msg['method'].nil?
+        return handle_response(msg) if msg['method'].nil?
 
-        _dispatch_method(msg)
+        dispatch_method(msg)
       end
 
-      def _dispatch_method(msg)
+      def dispatch_method(msg)
         id = msg['id']
         case msg['method']
         when METHOD_SIGNALWIRE_EVENT      then _handle_event(msg)
         when METHOD_SIGNALWIRE_PING       then _send_json({ 'jsonrpc' => '2.0', 'id' => id, 'result' => {} })
-        when METHOD_SIGNALWIRE_DISCONNECT then _handle_disconnect(msg)
+        when METHOD_SIGNALWIRE_DISCONNECT then handle_disconnect(msg)
         else
           # Unknown method, send empty result
           _send_json({ 'jsonrpc' => '2.0', 'id' => id, 'result' => {} }) if id
         end
       end
 
-      def _handle_response(msg)
+      def handle_response(msg)
         id = msg['id']
         return unless id
 
@@ -627,13 +630,13 @@ module SignalWire
 
         if msg['error']
           err = msg['error']
-          _settle_pending(entry, error: RelayError.new(err['code'], err['message'] || 'Unknown error'))
+          settle_pending(entry, error: RelayError.new(err['code'], err['message'] || 'Unknown error'))
         else
-          _settle_pending(entry, result: msg['result'] || {})
+          settle_pending(entry, result: msg['result'] || {})
         end
       end
 
-      def _settle_pending(entry, result: nil, error: nil, call: nil)
+      def settle_pending(entry, result: nil, error: nil, call: nil)
         entry[:mutex].synchronize do
           entry[:result] = result unless result.nil?
           entry[:error]  = error unless error.nil?
@@ -651,15 +654,15 @@ module SignalWire
         event_params = outer_params['params'] || {}
         call_id      = event_params['call_id'] || ''
 
-        _invoke_event_hook(event_type, event_params, outer_params)
-        return if _dispatch_typed_event(event_type, event_params, outer_params, call_id)
+        invoke_event_hook(event_type, event_params, outer_params)
+        return if dispatch_typed_event(event_type, event_params, outer_params, call_id)
 
-        _route_event_to_call(call_id, outer_params)
+        route_event_to_call(call_id, outer_params)
       end
 
       # Generic event hook (audit harnesses, integration tests). Runs BEFORE
       # type-specific dispatch so a probe can observe every event the SDK saw.
-      def _invoke_event_hook(event_type, event_params, outer_params)
+      def invoke_event_hook(event_type, event_params, outer_params)
         return unless @on_event_handler
 
         @on_event_handler.call(event_type, event_params, outer_params)
@@ -671,20 +674,20 @@ module SignalWire
       # when the event was fully handled (caller should stop), false otherwise.
       # EVENT_CALL_STATE pre-registers a dial leg then returns false so the
       # caller falls through to normal call routing.
-      def _dispatch_typed_event(event_type, event_params, outer_params, call_id)
+      def dispatch_typed_event(event_type, event_params, outer_params, call_id)
         case event_type
         when EVENT_AUTHORIZATION_STATE
           @authorization_state = event_params['authorization_state']
           true
         when EVENT_CALL_STATE
-          _maybe_register_dial_leg(event_params, call_id)
+          maybe_register_dial_leg(event_params, call_id)
           false
         else
-          _dispatch_outer_param_event(event_type, outer_params)
+          dispatch_outer_param_event(event_type, outer_params)
         end
       end
 
-      def _dispatch_outer_param_event(event_type, outer_params)
+      def dispatch_outer_param_event(event_type, outer_params)
         handler = OUTER_PARAM_EVENT_HANDLERS[event_type]
         return false unless handler
 
@@ -692,17 +695,17 @@ module SignalWire
         true
       end
 
-      def _maybe_register_dial_leg(event_params, call_id)
+      def maybe_register_dial_leg(event_params, call_id)
         tag = event_params['tag'] || ''
         return if tag.empty?
         return unless @dials_mutex.synchronize { @pending_dials.key?(tag) }
 
         has_call = @calls_mutex.synchronize { @calls.key?(call_id) }
-        _register_dial_leg(tag, event_params) unless has_call || call_id.empty?
+        register_dial_leg(tag, event_params) unless has_call || call_id.empty?
       end
 
       # Normal routing by call_id.
-      def _route_event_to_call(call_id, outer_params)
+      def route_event_to_call(call_id, outer_params)
         return if call_id.empty?
 
         call = @calls_mutex.synchronize { @calls[call_id] }
@@ -714,7 +717,7 @@ module SignalWire
         @calls_mutex.synchronize { @calls.delete(call_id) }
       end
 
-      def _handle_disconnect(msg)
+      def handle_disconnect(msg)
         id = msg['id']
         params = msg['params'] || {}
 
@@ -728,9 +731,9 @@ module SignalWire
         @ws_mutex.synchronize { @connected = false }
       end
 
-      def _handle_inbound_call(payload)
+      def handle_inbound_call(payload)
         event_params = payload['params'] || {}
-        call = _build_inbound_call(event_params)
+        call = build_inbound_call(event_params)
         @calls_mutex.synchronize { @calls[call.call_id] = call }
 
         return unless @on_call_handler
@@ -742,47 +745,47 @@ module SignalWire
         end
       end
 
-      def _build_inbound_call(event_params)
-        kwargs = _extract_fields(event_params, INBOUND_CALL_FIELDS)
+      def build_inbound_call(event_params)
+        kwargs = extract_fields(event_params, INBOUND_CALL_FIELDS)
         kwargs[:context] = event_params['context'] || event_params['protocol'] || ''
         Call.new(self, **kwargs)
       end
 
       # Pull mapped keys out of +params+, applying defaults. Centralizes the
       # nil-coalescing so the per-builder methods stay simple.
-      def _extract_fields(params, field_map)
+      def extract_fields(params, field_map)
         field_map.transform_values { |key, default| params[key] || default }
       end
 
-      def _handle_dial_event(payload)
+      def handle_dial_event(payload)
         event_params = payload['params'] || {}
         tag = event_params['tag'] || ''
         entry = @dials_mutex.synchronize { @pending_dials[tag] }
         return unless entry
 
         case event_params['dial_state']
-        when 'answered' then _dial_answered(entry, tag, event_params['call'] || {})
-        when 'failed'   then _settle_pending(entry, error: 'Dial failed')
+        when 'answered' then dial_answered(entry, tag, event_params['call'] || {})
+        when 'failed'   then settle_pending(entry, error: 'Dial failed')
         end
       end
 
-      def _dial_answered(entry, tag, call_info)
+      def dial_answered(entry, tag, call_info)
         call_id = call_info['call_id'] || ''
         call = @calls_mutex.synchronize { @calls[call_id] }
         unless call
-          call = _build_dialed_call(call_id, tag, call_info)
+          call = build_dialed_call(call_id, tag, call_info)
           @calls_mutex.synchronize { @calls[call_id] = call }
         end
         call.state = CALL_STATE_ANSWERED
-        _settle_pending(entry, call: call)
+        settle_pending(entry, call: call)
       end
 
-      def _build_dialed_call(call_id, tag, call_info)
+      def build_dialed_call(call_id, tag, call_info)
         Call.new(
           self,
           call_id: call_id,
           node_id: call_info['node_id'] || '',
-          project_id: @project_id,
+          project_id: project_id,
           tag: call_info['tag'] || tag,
           direction: 'outbound',
           device: call_info['device'] || {},
@@ -790,20 +793,20 @@ module SignalWire
         )
       end
 
-      def _register_dial_leg(tag, event_params)
+      def register_dial_leg(tag, event_params)
         call_id = event_params['call_id'] || ''
         return if call_id.empty?
 
         call = Call.new(
-          self, call_id: call_id, project_id: @project_id, tag: tag, direction: 'outbound',
+          self, call_id: call_id, project_id: project_id, tag: tag, direction: 'outbound',
                 node_id: event_params['node_id'] || '', device: event_params['device'] || {},
                 state: event_params['call_state'] || ''
         )
         @calls_mutex.synchronize { @calls[call_id] = call }
       end
 
-      def _handle_inbound_message(payload)
-        msg = _build_inbound_message(payload['params'] || {})
+      def handle_inbound_message(payload)
+        msg = build_inbound_message(payload['params'] || {})
 
         return unless @on_message_handler
 
@@ -814,11 +817,11 @@ module SignalWire
         end
       end
 
-      def _build_inbound_message(event_params)
-        Message.new(direction: 'inbound', **_extract_fields(event_params, INBOUND_MESSAGE_FIELDS))
+      def build_inbound_message(event_params)
+        Message.new(direction: 'inbound', **extract_fields(event_params, INBOUND_MESSAGE_FIELDS))
       end
 
-      def _handle_message_state(payload)
+      def handle_message_state(payload)
         event_params = payload['params'] || {}
         message_id = event_params['message_id'] || ''
 
@@ -833,24 +836,44 @@ module SignalWire
         @messages_mutex.synchronize { @messages.delete(message_id) }
       end
 
-      def _reject_all_pending(reason)
+      def reject_all_pending(reason)
         @pending_mutex.synchronize do
-          @pending.each_value { |entry| _reject_entry(entry, RelayError.new(-1, reason)) }
+          @pending.each_value { |entry| reject_entry(entry, RelayError.new(-1, reason)) }
           @pending.clear
         end
 
         @dials_mutex.synchronize do
-          @pending_dials.each_value { |entry| _reject_entry(entry, reason) }
+          @pending_dials.each_value { |entry| reject_entry(entry, reason) }
           @pending_dials.clear
         end
       end
 
-      def _reject_entry(entry, error)
+      def reject_entry(entry, error)
         entry[:mutex].synchronize do
           entry[:error] ||= error
           entry[:cv].signal
         end
       end
+
+      # Internal helpers (formerly leading-underscore by convention). Not part
+      # of the public/Python surface -- declared private so the cross-port
+      # surface enumerator continues to exclude them. _send_json / _connected? /
+      # _calls_snapshot / _set_protocol / _authorization_state / _session_id stay
+      # public+underscored (invoked cross-instance by tests / the send_json wrapper).
+      private :apply_auth_credentials, :apply_session_restore, :authenticate, :await_dial,
+              :await_response, :backoff_reconnect, :build_dialed_call, :build_inbound_call,
+              :build_inbound_message, :build_message_params, :build_outbound_message, :check_result_code,
+              :clear_restart_state, :connect_and_run, :connect_and_run_guarded, :dial_answered,
+              :dispatch_method, :dispatch_outer_param_event, :dispatch_typed_event, :extract_fields,
+              :handle_dial_event, :handle_disconnect, :handle_inbound_call,
+              :handle_inbound_message, :handle_message, :handle_message_state, :handle_response,
+              :init_correlation_state, :init_handlers, :init_session_state, :invoke_event_hook,
+              :maybe_register_dial_leg, :on_ws_close, :on_ws_lifecycle, :on_ws_message,
+              :on_ws_open, :open_websocket, :register_dial_leg, :reject_all_pending,
+              :reject_entry, :relay_endpoint_host, :relay_scheme, :resolve_credentials,
+              :resolve_max_active_calls, :route_event_to_call, :send_dial_rpc, :settle_pending,
+              :signal_ready, :validate_credentials, :validate_message_payload, :value_or_env,
+              :wait_on_entry, :wire_ws_callbacks, :wss_tls_options
     end
   end
 end

--- a/lib/signalwire/relay/relay_event.rb
+++ b/lib/signalwire/relay/relay_event.rb
@@ -25,7 +25,7 @@ module SignalWire
     #     Set members and Hash keys.
     #
     # Subclasses contribute their typed fields by overriding the private
-    # +#_event_fields+ hook (underscore-prefixed, so it stays off the
+    # +#event_fields+ hook (underscore-prefixed, so it stays off the
     # public surface); they never redefine +#to_h+/+#==+/etc. themselves.
     class RelayEvent
       attr_reader :event_type, :params, :call_id, :timestamp
@@ -84,7 +84,7 @@ module SignalWire
           event_type: @event_type,
           call_id: @call_id,
           timestamp: @timestamp
-        }.merge(_event_fields)
+        }.merge(event_fields)
       end
 
       # @return [String] JSON serialization of {#to_h}.
@@ -136,7 +136,7 @@ module SignalWire
       # @api private — set @<key> = value for each kwarg, so wide-field
       # subclasses keep their full +initialize+ signature without a long
       # assignment body. Keys must match the subclass's +attr_reader+ names.
-      def _assign_fields(**fields)
+      def assign_fields(**fields)
         fields.each { |key, value| instance_variable_set("@#{key}", value) }
       end
 
@@ -144,7 +144,7 @@ module SignalWire
       # The base event has none beyond the shared envelope.
       #
       # @return [Hash{Symbol => Object}]
-      def _event_fields
+      def event_fields
         {}
       end
     end
@@ -184,7 +184,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { call_state: @call_state, end_reason: @end_reason,
           direction: @direction, device: @device }
       end
@@ -222,7 +222,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { call_state: @call_state, direction: @direction, device: @device,
           node_id: @node_id, project_id: @project_id, context: @context,
           segment_id: @segment_id, tag: @tag }
@@ -251,7 +251,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { control_id: @control_id, state: @state }
       end
     end
@@ -285,7 +285,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { control_id: @control_id, state: @state, url: @url,
           duration: @duration, size: @size, record: @record }
       end
@@ -318,7 +318,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { control_id: @control_id, state: @state,
           result: @result, final: @final }
       end
@@ -346,7 +346,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { connect_state: @connect_state, peer: @peer }
       end
     end
@@ -373,7 +373,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { control_id: @control_id, detect: @detect }
       end
     end
@@ -400,7 +400,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { control_id: @control_id, fax: @fax }
       end
     end
@@ -431,7 +431,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { control_id: @control_id, state: @state, tap: @tap, device: @device }
       end
     end
@@ -462,7 +462,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { control_id: @control_id, state: @state, url: @url, name: @name }
       end
     end
@@ -489,7 +489,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { control_id: @control_id, state: @state }
       end
     end
@@ -537,7 +537,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { tag: @tag, dial_state: @dial_state, call_data: @call_data }
       end
     end
@@ -570,7 +570,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { state: @state, sip_refer_to: @sip_refer_to,
           sip_refer_response_code: @sip_refer_response_code,
           sip_notify_response_code: @sip_notify_response_code }
@@ -597,7 +597,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { denoised: @denoised }
       end
     end
@@ -624,7 +624,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { control_id: @control_id, state: @state }
       end
     end
@@ -657,7 +657,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { control_id: @control_id, status: @status, queue_id: @queue_id,
           queue_name: @queue_name, position: @position, size: @size }
       end
@@ -683,7 +683,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { state: @state }
       end
     end
@@ -714,7 +714,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { control_id: @control_id, state: @state, url: @url,
           recording_id: @recording_id, duration: @duration, size: @size }
       end
@@ -740,7 +740,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { state: @state }
       end
     end
@@ -769,7 +769,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { conference_id: @conference_id, name: @name, status: @status }
       end
     end
@@ -796,7 +796,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { code: @code, message: @message }
       end
     end
@@ -820,14 +820,14 @@ module SignalWire
                      to_number: '', body: '', media: [], segments: 0,
                      message_state: '', tags: [], **base)
         super(**base)
-        _assign_fields(message_id: message_id, context: context, direction: direction,
-                       from_number: from_number, to_number: to_number, body: body,
-                       media: media, segments: segments, message_state: message_state, tags: tags)
+        assign_fields(message_id: message_id, context: context, direction: direction,
+                      from_number: from_number, to_number: to_number, body: body,
+                      media: media, segments: segments, message_state: message_state, tags: tags)
       end
 
       private
 
-      def _event_fields
+      def event_fields
         { message_id: @message_id, context: @context, direction: @direction,
           from_number: @from_number, to_number: @to_number, body: @body,
           media: @media, segments: @segments, message_state: @message_state,
@@ -854,10 +854,10 @@ module SignalWire
                      to_number: '', body: '', media: [], segments: 0,
                      message_state: '', reason: '', tags: [], **base)
         super(**base)
-        _assign_fields(message_id: message_id, context: context, direction: direction,
-                       from_number: from_number, to_number: to_number, body: body,
-                       media: media, segments: segments, message_state: message_state,
-                       reason: reason, tags: tags)
+        assign_fields(message_id: message_id, context: context, direction: direction,
+                      from_number: from_number, to_number: to_number, body: body,
+                      media: media, segments: segments, message_state: message_state,
+                      reason: reason, tags: tags)
       end
 
       # Typed predicate over {#message_state}, alongside the bare string.
@@ -871,7 +871,7 @@ module SignalWire
 
       private
 
-      def _event_fields
+      def event_fields
         { message_id: @message_id, context: @context, direction: @direction,
           from_number: @from_number, to_number: @to_number, body: @body,
           media: @media, segments: @segments, message_state: @message_state,

--- a/lib/signalwire/rest/http_client.rb
+++ b/lib/signalwire/rest/http_client.rb
@@ -50,46 +50,46 @@ module SignalWire
       end
 
       def get(path, params = nil)
-        _request('GET', path, params: params)
+        request('GET', path, params: params)
       end
 
       def post(path, body = nil, params: nil)
-        _request('POST', path, body: body, params: params)
+        request('POST', path, body: body, params: params)
       end
 
       def put(path, body = nil)
-        _request('PUT', path, body: body)
+        request('PUT', path, body: body)
       end
 
       def patch(path, body = nil)
-        _request('PATCH', path, body: body)
+        request('PATCH', path, body: body)
       end
 
       def delete(path)
-        _request('DELETE', path)
+        request('DELETE', path)
       end
 
       private
 
-      def _request(method, path, body: nil, params: nil)
-        uri = _build_uri(path, params)
-        req = _build_request(method, uri)
-        _apply_headers(req)
+      def request(method, path, body: nil, params: nil)
+        uri = build_uri(path, params)
+        req = build_request(method, uri)
+        apply_headers(req)
         req.body = JSON.generate(body) if body && %w[POST PUT PATCH].include?(method)
 
         http = Net::HTTP.new(uri.host, uri.port)
-        _configure_ssl(http) if uri.scheme == 'https'
+        configure_ssl(http) if uri.scheme == 'https'
 
-        _handle_response(http.request(req), path, method)
+        handle_response(http.request(req), path, method)
       end
 
-      def _build_uri(path, params)
+      def build_uri(path, params)
         uri = URI("#{@base_url}#{path}")
         uri.query = URI.encode_www_form(params) if params && !params.empty?
         uri
       end
 
-      def _build_request(method, uri)
+      def build_request(method, uri)
         klass = {
           'GET' => Net::HTTP::Get, 'POST' => Net::HTTP::Post, 'PUT' => Net::HTTP::Put,
           'PATCH' => Net::HTTP::Patch, 'DELETE' => Net::HTTP::Delete
@@ -99,14 +99,14 @@ module SignalWire
         klass.new(uri)
       end
 
-      def _apply_headers(req)
+      def apply_headers(req)
         req['Authorization'] = @auth_header
         req['Content-Type']  = 'application/json'
         req['Accept']        = 'application/json'
         req['User-Agent']    = 'signalwire-agents-ruby-rest/1.0'
       end
 
-      def _configure_ssl(http)
+      def configure_ssl(http)
         http.use_ssl = true
         # Always verify the server certificate. When an explicit CA bundle
         # was supplied, trust it in addition to the OpenSSL defaults (which
@@ -122,9 +122,9 @@ module SignalWire
         http.cert_store = store
       end
 
-      def _handle_response(response, path, method)
+      def handle_response(response, path, method)
         unless response.is_a?(Net::HTTPSuccess)
-          raise SignalWireRestError.new(response.code.to_i, _parse_error_body(response), path, method)
+          raise SignalWireRestError.new(response.code.to_i, parse_error_body(response), path, method)
         end
 
         return {} if response.code.to_i == 204 || response.body.nil? || response.body.empty?
@@ -132,7 +132,7 @@ module SignalWire
         JSON.parse(response.body)
       end
 
-      def _parse_error_body(response)
+      def parse_error_body(response)
         JSON.parse(response.body)
       rescue StandardError
         response.body

--- a/lib/signalwire/security/session_manager.rb
+++ b/lib/signalwire/security/session_manager.rb
@@ -164,30 +164,30 @@ module SignalWire
         return { 'error' => 'debug mode not enabled' } unless @debug_mode
 
         parts = Base64.urlsafe_decode64(token).split('.')
-        return _malformed_debug(token, parts) unless parts.length == 5
+        return malformed_debug(token, parts) unless parts.length == 5
 
-        _decoded_debug(token, parts)
+        decoded_debug(token, parts)
       rescue ArgumentError, TypeError => e
         { 'valid_format' => false, 'error' => e.message, 'token_length' => token ? token.length : 0 }
       end
 
       private
 
-      def _malformed_debug(token, parts)
+      def malformed_debug(token, parts)
         { 'valid_format' => false, 'parts_count' => parts.length,
           'token_length' => token ? token.length : 0 }
       end
 
-      def _decoded_debug(_token, parts)
-        status = _expiry_status(parts[2], Time.now.to_i)
+      def decoded_debug(_token, parts)
+        status = expiry_status(parts[2], Time.now.to_i)
         {
           'valid_format' => true,
-          'components' => _debug_components(parts, status.delete('expiry_date')),
+          'components' => debug_components(parts, status.delete('expiry_date')),
           'status' => status
         }
       end
 
-      def _debug_components(parts, expiry_date)
+      def debug_components(parts, expiry_date)
         {
           'call_id' => truncate(parts[0]), 'function' => parts[1],
           'expiry' => parts[2], 'expiry_date' => expiry_date,
@@ -197,7 +197,7 @@ module SignalWire
 
       # Build the wire-shaped status sub-hash (current_time/is_expired/
       # expires_in_seconds) plus a transient 'expiry_date' the caller extracts.
-      def _expiry_status(token_expiry, current_time)
+      def expiry_status(token_expiry, current_time)
         expiry     = Integer(token_expiry)
         is_expired = expiry < current_time
         { 'current_time' => current_time, 'is_expired' => is_expired,

--- a/lib/signalwire/security/webhook_middleware.rb
+++ b/lib/signalwire/security/webhook_middleware.rb
@@ -133,15 +133,15 @@ module SignalWire
         return @app.call(env) unless _applies?(env)
 
         # Capture raw body BEFORE any other middleware reads the stream.
-        raw_body = _read_raw_body(env)
+        raw_body = read_raw_body(env)
         env[RAW_BODY_ENV_KEY] = raw_body
 
-        url = _reconstruct_url(env)
+        url = reconstruct_url(env)
         # Delegate the pass/reject decision to the framework-free decomposed
         # core (the cross-port contract). It returns nil to pass or a Rack
         # [status, headers, body] triple to reject.
         rejection = self.class.validate(
-          env['REQUEST_METHOD'].to_s, url, _rack_signature_headers(env), raw_body,
+          env['REQUEST_METHOD'].to_s, url, rack_signature_headers(env), raw_body,
           signing_key: @signing_key
         )
         return rejection if rejection
@@ -154,7 +154,7 @@ module SignalWire
       # @api private — surface the signature header(s) from the Rack env as a
       # plain header Hash the decomposed #validate can read (both the canonical
       # and the legacy-compat header name, un-CGI-mangled).
-      def _rack_signature_headers(env)
+      def rack_signature_headers(env)
         {
           'X-SignalWire-Signature' => env[SIGNALWIRE_SIGNATURE_HEADER],
           'X-Twilio-Signature' => env[TWILIO_COMPAT_SIGNATURE_HEADER]
@@ -176,7 +176,7 @@ module SignalWire
       end
 
       # @api private
-      def _read_raw_body(env)
+      def read_raw_body(env)
         input = env['rack.input']
         return '' if input.nil?
 
@@ -198,20 +198,20 @@ module SignalWire
       # 2. ``X-Forwarded-Proto`` / ``X-Forwarded-Host`` headers, when
       #    ``trust_proxy`` is true and X-Forwarded-Host is present.
       # 3. ``scheme://host[:port]/path?query`` derived from the rack env.
-      def _reconstruct_url(env)
+      def reconstruct_url(env)
         path = env['PATH_INFO'].to_s
         path = '/' if path.empty?
         query = env['QUERY_STRING'].to_s
         path_and_query = query.empty? ? path : "#{path}?#{query}"
 
-        _proxy_base_url(path_and_query) ||
-          _forwarded_url(env, path_and_query) ||
-          _rack_derived_url(env, path_and_query)
+        proxy_base_url(path_and_query) ||
+          forwarded_url(env, path_and_query) ||
+          rack_derived_url(env, path_and_query)
       end
 
       # @api private
       # Strategy 1: explicit SWML_PROXY_URL_BASE env var (highest priority).
-      def _proxy_base_url(path_and_query)
+      def proxy_base_url(path_and_query)
         proxy_base = ENV.fetch('SWML_PROXY_URL_BASE', nil)
         return unless proxy_base && !proxy_base.empty?
 
@@ -220,7 +220,7 @@ module SignalWire
 
       # @api private
       # Strategy 2: X-Forwarded-Proto / X-Forwarded-Host (when trust_proxy).
-      def _forwarded_url(env, path_and_query)
+      def forwarded_url(env, path_and_query)
         return unless @trust_proxy
 
         fwd_host = env['HTTP_X_FORWARDED_HOST']
@@ -232,10 +232,10 @@ module SignalWire
 
       # @api private
       # Strategy 3: scheme://host[:port]/path?query derived from the rack env.
-      def _rack_derived_url(env, path_and_query)
+      def rack_derived_url(env, path_and_query)
         scheme = env['rack.url_scheme'] || 'http'
         host = env['HTTP_HOST'] || env['SERVER_NAME']
-        host_with_port = _host_with_port(scheme, host, env['SERVER_PORT'])
+        host_with_port = host_with_port(scheme, host, env['SERVER_PORT'])
         "#{scheme}://#{host_with_port}#{path_and_query}"
       end
 
@@ -243,7 +243,7 @@ module SignalWire
       # Only include the port if it's non-standard AND not already in HTTP_HOST.
       # The "already has a port" and "no port needed" cases both yield host but
       # are distinct conditions; keeping them separate reads clearer than merging.
-      def _host_with_port(scheme, host, port)
+      def host_with_port(scheme, host, port)
         return host if host&.include?(':')
         return "#{host}:#{port}" if port && _nonstandard_port?(scheme, port)
 

--- a/lib/signalwire/server/agent_server.rb
+++ b/lib/signalwire/server/agent_server.rb
@@ -78,7 +78,7 @@ module SignalWire
       @mutex  = Mutex.new
 
       @logger = Logging.logger('AgentServer')
-      _apply_log_level(@logger, @log_level)
+      apply_log_level(@logger, @log_level)
     end
 
     # Map a Python-style log level string to the underlying logger's
@@ -91,10 +91,10 @@ module SignalWire
     # ``::Logger`` constant from Ruby's stdlib (``require 'logger'``)
     # exposes DEBUG/INFO/WARN/ERROR/FATAL constants we mirror.
     # @api private
-    def _apply_log_level(logger, level)
+    def apply_log_level(logger, level)
       require 'logger'
-      mapped = _map_log_level(level)
-      _set_logger_level(logger, mapped)
+      mapped = map_log_level(level)
+      set_logger_level(logger, mapped)
       mapped
     rescue StandardError
       begin
@@ -108,7 +108,7 @@ module SignalWire
     # Apply +mapped+ to +logger+. SignalWire::Logging::Logger doesn't expose
     # level=; attach via instance_variable (plus a singleton reader) so .level
     # reads return the mapped value.
-    def _set_logger_level(logger, mapped)
+    def set_logger_level(logger, mapped)
       if logger.respond_to?(:level=)
         logger.level = mapped
       else
@@ -121,7 +121,7 @@ module SignalWire
     # 'info' and the else fallback both map to INFO; the explicit 'info' arm
     # documents it as a known level rather than an unrecognized default.
     # @api private
-    def _map_log_level(level)
+    def map_log_level(level)
       case level
       when 'debug'             then ::Logger::DEBUG
       when 'info'              then ::Logger::INFO
@@ -256,10 +256,10 @@ module SignalWire
     # - **Server mode** — starts WEBrick (Ruby's stdlib HTTP server)
     #   bound to ``host``/``port`` (overrides honoured if supplied).
     # - **Lambda mode** (``AWS_LAMBDA_FUNCTION_NAME`` env var present)
-    #   — invokes ``_handle_lambda_request(event, context)`` and
+    #   — invokes ``handle_lambda_request(event, context)`` and
     #   returns the Lambda response Hash.
     # - **CGI mode** (``GATEWAY_INTERFACE`` env var present) — invokes
-    #   ``_handle_cgi_request`` and returns the CGI response String.
+    #   ``handle_cgi_request`` and returns the CGI response String.
     #
     # @param event [Object, nil] serverless event (Lambda)
     # @param context [Object, nil] serverless context (Lambda)
@@ -272,11 +272,11 @@ module SignalWire
 
       case mode
       when 'lambda'
-        _handle_lambda_request(event, context)
+        handle_lambda_request(event, context)
       when 'cgi'
-        _handle_cgi_request
+        handle_cgi_request
       else
-        _run_server(host, port)
+        run_server(host, port)
       end
     end
 
@@ -289,10 +289,10 @@ module SignalWire
     end
 
     # @api private
-    def _run_server(host = nil, port = nil)
+    def run_server(host = nil, port = nil)
       bind_host = host || @host
       bind_port = port || @port
-      server = _build_webrick(bind_host, bind_port)
+      server = build_webrick(bind_host, bind_port)
       server.mount('/', Rack::Handler::WEBrick, rack_app) if defined?(Rack::Handler::WEBrick)
       trap('INT') { server.shutdown }
       trap('TERM') { server.shutdown }
@@ -301,7 +301,7 @@ module SignalWire
     end
 
     # @api private
-    def _build_webrick(bind_host, bind_port)
+    def build_webrick(bind_host, bind_port)
       require 'webrick'
       WEBrick::HTTPServer.new(
         Host: bind_host,
@@ -314,7 +314,7 @@ module SignalWire
     # @api private
     # Handle a CGI request. Reads ``PATH_INFO``, dispatches to the
     # matching agent, and returns a CGI-formatted response string.
-    def _handle_cgi_request
+    def handle_cgi_request
       require 'stringio'
       env = {
         'PATH_INFO' => (ENV['PATH_INFO'] || '').strip,
@@ -324,12 +324,12 @@ module SignalWire
         'rack.errors' => $stderr
       }
       status, headers, body = rack_app.call(env)
-      _format_cgi_response(status, headers, _body_to_string(body))
+      format_cgi_response(status, headers, body_to_string(body))
     end
 
     # @api private
     # Render a Rack triple as a CGI response string.
-    def _format_cgi_response(status, headers, body_str)
+    def format_cgi_response(status, headers, body_str)
       out = "Status: #{status}\r\n"
       headers.each { |k, v| out << "#{k}: #{v}\r\n" }
       out << "\r\n"
@@ -339,7 +339,7 @@ module SignalWire
 
     # @api private
     # Collapse a Rack response body (Array or other) into a String.
-    def _body_to_string(body)
+    def body_to_string(body)
       body.respond_to?(:join) ? body.join : body.to_s
     end
 
@@ -347,22 +347,22 @@ module SignalWire
     # Handle a Lambda invocation event. Translates the Lambda event
     # shape into a Rack env, dispatches, and returns a Lambda
     # response Hash (statusCode/headers/body).
-    def _handle_lambda_request(event, _context)
+    def handle_lambda_request(event, _context)
       require 'stringio'
-      status, headers, response_body = rack_app.call(_lambda_env(event || {}))
+      status, headers, response_body = rack_app.call(lambda_env(event || {}))
       {
         'statusCode' => Integer(status),
         'headers' => headers,
-        'body' => _body_to_string(response_body)
+        'body' => body_to_string(response_body)
       }
     end
 
     # @api private
     # Translate a Lambda event Hash into a Rack env.
-    def _lambda_env(event)
+    def lambda_env(event)
       {
-        'PATH_INFO' => _lambda_path(event),
-        'REQUEST_METHOD' => _lambda_method(event),
+        'PATH_INFO' => lambda_path(event),
+        'REQUEST_METHOD' => lambda_method(event),
         'QUERY_STRING' => '',
         'rack.input' => StringIO.new(event['body'] || ''),
         'rack.errors' => $stderr
@@ -370,12 +370,12 @@ module SignalWire
     end
 
     # @api private
-    def _lambda_path(event)
+    def lambda_path(event)
       event['path'] || event['rawPath'] || event['pathParameters']&.dig('proxy') || '/'
     end
 
     # @api private
-    def _lambda_method(event)
+    def lambda_method(event)
       event['httpMethod'] || event.dig('requestContext', 'http', 'method') || 'GET'
     end
 
@@ -397,16 +397,16 @@ module SignalWire
 
       case path
       when '/health', '/healthz'
-        _json_response('200', { status: 'ok', agents: agents.keys })
+        json_response('200', { status: 'ok', agents: agents.keys })
       when '/'
-        _json_response('200', _root_payload(agents))
+        json_response('200', root_payload(agents))
       else
-        _try_serve_static(path, static_routes) || _dispatch_agent(env, path, agents)
+        try_serve_static(path, static_routes) || dispatch_agent(env, path, agents)
       end
     end
 
     # @api private
-    def _root_payload(agents)
+    def root_payload(agents)
       {
         service: 'SignalWire Agent Server',
         agents: agents.keys,
@@ -417,30 +417,30 @@ module SignalWire
     # @api private
     # Dispatch to the agent whose registered route is the longest prefix of
     # +path+, or a 404 JSON response when nothing matches.
-    def _dispatch_agent(env, path, agents)
-      matched_route, agent = _match_agent(path, agents)
-      return _json_response('404', { error: 'Not found', path: path }) unless agent
+    def dispatch_agent(env, path, agents)
+      matched_route, agent = match_agent(path, agents)
+      return json_response('404', { error: 'Not found', path: path }) unless agent
 
-      _invoke_agent(agent, matched_route, env)
+      invoke_agent(agent, matched_route, env)
     end
 
     # @api private
     # Invoke a matched agent: prefer #call, then #rack_app, else a stub
     # "registered" response.
-    def _invoke_agent(agent, matched_route, env)
+    def invoke_agent(agent, matched_route, env)
       if agent.respond_to?(:call)
         agent.call(env)
       elsif agent.respond_to?(:rack_app)
         agent.rack_app.call(env)
       else
-        _json_response('200', { agent: matched_route, status: 'registered' })
+        json_response('200', { agent: matched_route, status: 'registered' })
       end
     end
 
     # @api private
     # Longest-prefix match of +path+ against registered agent routes.
     # @return [Array(String, Object)] [matched_route, agent] or [nil, nil].
-    def _match_agent(path, agents)
+    def match_agent(path, agents)
       matched_route = nil
       agent = nil
       agents.each do |route, a|
@@ -461,31 +461,31 @@ module SignalWire
 
     # @api private
     # Build a Rack JSON response triple from a status and a Hash payload.
-    def _json_response(status, payload)
+    def json_response(status, payload)
       [status, { 'Content-Type' => 'application/json' }, [payload.to_json]]
     end
 
     # @api private
     # Attempt to serve a static file. Returns a Rack response or nil.
-    def _try_serve_static(path, static_routes)
-      matched_route, matched_dir = _match_static_route(path, static_routes)
+    def try_serve_static(path, static_routes)
+      matched_route, matched_dir = match_static_route(path, static_routes)
       return nil unless matched_dir
 
-      relative = _static_relative_path(path, matched_route)
+      relative = static_relative_path(path, matched_route)
       # Path traversal protection: reject any path containing "..".
-      return _static_forbidden if relative.include?('..')
+      return static_forbidden if relative.include?('..')
 
       resolved = File.expand_path(File.join(matched_dir, relative))
       # Ensure resolved path is still under the served directory.
-      return _static_forbidden unless _under_directory?(resolved, matched_dir)
+      return static_forbidden unless _under_directory?(resolved, matched_dir)
       return unless File.file?(resolved) && File.readable?(resolved)
 
-      _static_file_response(resolved)
+      static_file_response(resolved)
     end
 
     # @api private
     # Relative path after the route prefix, defaulting to /index.html.
-    def _static_relative_path(path, matched_route)
+    def static_relative_path(path, matched_route)
       relative = path.sub(matched_route, '')
       relative.empty? || relative == '/' ? '/index.html' : relative
     end
@@ -498,7 +498,7 @@ module SignalWire
     # @api private
     # Longest-prefix match of +path+ against the static route prefixes.
     # @return [Array(String, String)] [matched_route, directory] or [nil, nil].
-    def _match_static_route(path, static_routes)
+    def match_static_route(path, static_routes)
       matched_route = nil
       matched_dir   = nil
       static_routes.each do |route, directory|
@@ -512,14 +512,14 @@ module SignalWire
     end
 
     # @api private
-    def _static_forbidden
+    def static_forbidden
       body = JSON.generate({ error: 'Forbidden' })
       ['403', STATIC_SECURITY_HEADERS.merge('Content-Type' => 'application/json'), [body]]
     end
 
     # @api private
     # Read a resolved file and build its Rack response with MIME + security headers.
-    def _static_file_response(resolved)
+    def static_file_response(resolved)
       ext = File.extname(resolved).downcase
       content_type = MIME_TYPES[ext] || 'application/octet-stream'
       content = File.binread(resolved)
@@ -527,5 +527,15 @@ module SignalWire
                                               'Content-Length' => content.bytesize.to_s)
       ['200', headers, [content]]
     end
+
+    # Internal helpers (formerly leading-underscore by convention). Not part of
+    # the public/Python surface — declared private so the cross-port surface
+    # enumerator continues to exclude them.
+    private :apply_log_level, :set_logger_level, :map_log_level,
+            :run_server, :build_webrick, :handle_cgi_request, :format_cgi_response,
+            :body_to_string, :handle_lambda_request, :lambda_env, :lambda_path,
+            :lambda_method, :root_payload, :dispatch_agent, :invoke_agent, :match_agent,
+            :json_response, :try_serve_static, :static_relative_path, :match_static_route,
+            :static_forbidden, :static_file_response
   end
 end

--- a/lib/signalwire/server/agent_server.rb
+++ b/lib/signalwire/server/agent_server.rb
@@ -23,7 +23,9 @@ module SignalWire
     # can mount it on their own server or pass it to Rack-compatible test
     # harnesses.
     def app
-      @app ||= rack_app
+      return @app if defined?(@app)
+
+      @app = rack_app
     end
 
     # MIME types for static file serving.

--- a/lib/signalwire/skills/builtin/datasphere.rb
+++ b/lib/signalwire/skills/builtin/datasphere.rb
@@ -36,7 +36,7 @@ module SignalWire
 
         def prompt_section_bullets
           [
-            "Use the #{@tool_name} tool when users ask for information that might be in the knowledge base",
+            "Use the #{tool_name} tool when users ask for information that might be in the knowledge base",
             'Search for relevant information using clear, specific queries',
             'Summarize search results in a clear, helpful way',
             'If no results are found, suggest the user try rephrasing their question'
@@ -47,7 +47,7 @@ module SignalWire
         # the host (the `/api/datasphere/...` path is preserved so the audit
         # can match on `datasphere` in req.path).
         def datasphere_host_url
-          resolved_base_url('DATASPHERE_BASE_URL', "https://#{@space_name}.signalwire.com")
+          resolved_base_url('DATASPHERE_BASE_URL', "https://#{space_name}.signalwire.com")
         end
 
         def handle_search(args, _raw_data)
@@ -66,12 +66,12 @@ module SignalWire
 
         def post_search(query)
           payload = {
-            'document_id' => @document_id, 'query_string' => query,
-            'distance' => @distance, 'count' => @count
+            'document_id' => document_id, 'query_string' => query,
+            'distance' => distance, 'count' => count
           }
-          payload['tags'] = @tags if @tags
+          payload['tags'] = tags if tags
 
-          uri = URI(@api_url)
+          uri = URI(api_url)
           http_for(uri).request(build_search_request(uri, payload))
         end
 
@@ -85,7 +85,7 @@ module SignalWire
           req = Net::HTTP::Post.new(uri.path)
           req['Content-Type'] = 'application/json'
           req['Accept']       = 'application/json'
-          req.basic_auth(@project_id, @token)
+          req.basic_auth(project_id, token)
           req.body = payload.to_json
           req
         end
@@ -94,7 +94,7 @@ module SignalWire
           # Real DataSphere uses `chunks`; audit fixtures also serve `results`
           # (real-shape upstream-response variation). Accept both shapes.
           chunks = data['chunks'] || data['results'] || []
-          return Swaig::FunctionResult.new(@no_results_msg) if chunks.empty?
+          return Swaig::FunctionResult.new(no_results_msg) if chunks.empty?
 
           Swaig::FunctionResult.new(
             "I found #{chunks.size} result(s) for '#{query}':\n\n#{format_chunks(chunks)}"
@@ -130,7 +130,7 @@ module SignalWire
           true
         end
 
-        def instance_key = "datasphere_#{@tool_name}"
+        def instance_key = "datasphere_#{tool_name}"
 
         # Tears down the skill. A fresh Net::HTTP connection is opened per
         # request (no persistent session to close), so teardown drops the
@@ -145,7 +145,7 @@ module SignalWire
         def register_tools
           [
             {
-              name: @tool_name,
+              name: tool_name,
               description: TOOL_DESCRIPTION,
               parameters: {
                 'query' => { 'type' => 'string', 'description' => 'The search query' }
@@ -161,7 +161,7 @@ module SignalWire
         def get_global_data
           {
             'datasphere_enabled' => true,
-            'document_id' => @document_id,
+            'document_id' => document_id,
             'knowledge_provider' => 'SignalWire DataSphere'
           }
         end
@@ -170,7 +170,7 @@ module SignalWire
           [
             {
               'title' => 'Knowledge Search Capability',
-              'body' => "You can search a knowledge base for information using the #{@tool_name} tool.",
+              'body' => "You can search a knowledge base for information using the #{tool_name} tool.",
               'bullets' => prompt_section_bullets
             }
           ]
@@ -187,6 +187,11 @@ module SignalWire
             'distance' => { 'type' => 'number', 'default' => 3.0 }
           }
         end
+
+        private
+
+        attr_reader :space_name, :project_id, :token, :document_id, :count,
+                    :distance, :tool_name, :tags, :no_results_msg, :api_url
       end
     end
   end

--- a/lib/signalwire/skills/builtin/joke.rb
+++ b/lib/signalwire/skills/builtin/joke.rb
@@ -23,11 +23,11 @@ module SignalWire
         end
 
         def register_tools
-          dm = DataMap.new(@tool_name)
+          dm = DataMap.new(tool_name)
                       .description('Get a random joke from API Ninjas')
                       .parameter('type', 'string', 'Type of joke to get', required: true, enum: %w[jokes dadjokes])
                       .webhook('GET', 'https://api.api-ninjas.com/v1/${args.type}',
-                               headers: { 'X-Api-Key' => @api_key })
+                               headers: { 'X-Api-Key' => api_key })
                       .output(Swaig::FunctionResult.new("Here's a joke: ${array[0].joke}"))
                       .error_keys(%w[error])
                       .fallback_output(Swaig::FunctionResult.new(FALLBACK_MESSAGE))
@@ -54,12 +54,15 @@ module SignalWire
 
         def joke_telling_bullets
           [
-            "Use #{@tool_name || 'get_joke'} to tell jokes when users ask for humor",
+            "Use #{tool_name || 'get_joke'} to tell jokes when users ask for humor",
             'You can tell regular jokes or dad jokes',
             'Be enthusiastic and fun when sharing jokes'
           ]
         end
         private :joke_telling_bullets
+
+        attr_reader :api_key, :tool_name
+        private :api_key, :tool_name
 
         def get_parameter_schema
           {

--- a/lib/signalwire/skills/builtin/weather_api.rb
+++ b/lib/signalwire/skills/builtin/weather_api.rb
@@ -35,7 +35,7 @@ module SignalWire
         def get_tools
           [
             {
-              'function' => @tool_name,
+              'function' => tool_name,
               'description' => 'Get current weather information for any location',
               'parameters' => tool_parameters,
               'data_map' => tool_data_map
@@ -48,6 +48,8 @@ module SignalWire
         end
 
         private
+
+        attr_reader :api_key, :tool_name, :temp_unit
 
         def tool_parameters
           {
@@ -70,14 +72,14 @@ module SignalWire
 
         def weather_webhook
           {
-            'url' => "#{base_url}/v1/current.json?key=#{@api_key}&q=${lc:enc:args.location}&aqi=no",
+            'url' => "#{base_url}/v1/current.json?key=#{api_key}&q=${lc:enc:args.location}&aqi=no",
             'method' => 'GET',
             'output' => Swaig::FunctionResult.new(response_template).to_h
           }
         end
 
         def temperature_fields
-          if @temp_unit == 'celsius'
+          if temp_unit == 'celsius'
             { temp: 'temp_c', feels: 'feelslike_c', unit: 'Celsius' }
           else
             { temp: 'temp_f', feels: 'feelslike_f', unit: 'Fahrenheit' }

--- a/lib/signalwire/skills/builtin/web_search.rb
+++ b/lib/signalwire/skills/builtin/web_search.rb
@@ -22,17 +22,17 @@ module SignalWire
         # webhook responses around 55s; once it fires, in-flight scrapes are
         # abandoned and we fall back to CSE snippets. THIS IS THE CONTRACT.
         def run_search(query)
-          deadline_at = monotonic_now + @overall_deadline
-          results = google_search(query, @num_results)
-          return @no_results_msg if results.empty?
+          deadline_at = monotonic_now + overall_deadline
+          results = google_search(query, num_results)
+          return no_results_msg if results.empty?
 
           # snippets_only fast path: skip page scraping entirely. Sub-second.
-          return format_snippet_results(query, results, @num_results) if @snippets_only
+          return format_snippet_results(query, results, num_results) if snippets_only
 
           processed = scrape_candidates(query, results, deadline_at)
           # Time ran out or every page was below quality threshold: fall back to
           # snippet-only results so we return SOMETHING useful (Python parity).
-          return format_snippet_results(query, results, @num_results) if processed.empty?
+          return format_snippet_results(query, results, num_results) if processed.empty?
 
           wrap_response(format_scraped_results(query, processed))
         end
@@ -40,7 +40,7 @@ module SignalWire
         # Sort by quality score descending, keep the best num_results, render.
         def format_scraped_results(query, processed)
           processed.sort_by! { |p| -p['quality_score'] }
-          formatted = processed.first(@num_results).map.with_index(1) do |r, i|
+          formatted = processed.first(num_results).map.with_index(1) do |r, i|
             "=== RESULT #{i} ===\nTitle: #{r['title']}\nURL: #{r['url']}\n" \
               "Snippet: #{r['snippet']}\nContent: #{r['content']}\n#{'=' * 50}"
           end.join("\n\n")
@@ -52,7 +52,7 @@ module SignalWire
         # met the quality threshold. The overall_deadline is enforced in both
         # parallel and sequential modes.
         def scrape_candidates(query, results, deadline_at)
-          if @parallel_scrape
+          if parallel_scrape
             scrape_parallel(query, results, deadline_at)
           else
             scrape_sequential(query, results, deadline_at)
@@ -67,7 +67,7 @@ module SignalWire
 
             item = scrape_one(query, r, deadline_at)
             processed << item if item
-            sleep(@default_delay) if @default_delay.positive?
+            sleep(default_delay) if default_delay.positive?
           end
           processed
         end
@@ -106,7 +106,7 @@ module SignalWire
           return nil if text.nil? || text.empty?
 
           metrics = calculate_content_quality(text, result['url'], query)
-          return nil if metrics['quality_score'] < @min_quality_score
+          return nil if metrics['quality_score'] < min_quality_score
 
           { 'title' => result['title'], 'url' => result['url'], 'snippet' => result['snippet'],
             'content' => text, 'quality_score' => metrics['quality_score'],
@@ -143,8 +143,8 @@ module SignalWire
         def fetch_page(uri)
           http = Net::HTTP.new(uri.host, uri.port)
           http.use_ssl = (uri.scheme == 'https')
-          http.open_timeout = @per_page_timeout
-          http.read_timeout = @per_page_timeout
+          http.open_timeout = per_page_timeout
+          http.read_timeout = per_page_timeout
 
           req = Net::HTTP::Get.new(uri)
           req['User-Agent'] = 'SignalWire-WebSearch/2.0'
@@ -194,7 +194,7 @@ module SignalWire
         # CSE returned anything at all, so the kernel never sees a webhook
         # timeout. Mirrors Python's _format_snippet_results.
         def format_snippet_results(query, results, num_results)
-          return @no_results_msg if results.empty?
+          return no_results_msg if results.empty?
 
           top = results.first([num_results, 1].max)
           lines = ["Snippet-only results for '#{query}' (page content not scraped):\n"]
@@ -214,8 +214,8 @@ module SignalWire
         # non-empty result body. Shared by the scraped-result and snippet-
         # fallback paths; the error and no-results branches stay unwrapped.
         def wrap_response(response)
-          response = "#{@response_prefix}\n\n#{response}"  unless @response_prefix.nil?  || @response_prefix.empty?
-          response = "#{response}\n\n#{@response_postfix}" unless @response_postfix.nil? || @response_postfix.empty?
+          response = "#{response_prefix}\n\n#{response}"  unless response_prefix.nil?  || response_prefix.empty?
+          response = "#{response}\n\n#{response_postfix}" unless response_postfix.nil? || response_postfix.empty?
           response
         end
 
@@ -243,7 +243,7 @@ module SignalWire
           base = resolved_base_url('WEB_SEARCH_BASE_URL', 'https://www.googleapis.com')
           uri = URI("#{base}/customsearch/v1")
           uri.query = URI.encode_www_form(
-            key: @api_key, cx: @search_engine_id, q: query, num: [num, 10].min
+            key: api_key, cx: search_engine_id, q: query, num: [num, 10].min
           )
           uri
         end
@@ -270,9 +270,15 @@ module SignalWire
 
         private
 
+        # Config ivars populated by #read_core_params / #read_latency_params.
+        attr_reader :api_key, :search_engine_id, :num_results, :tool_name,
+                    :min_quality_score, :default_delay, :no_results_msg,
+                    :response_prefix, :response_postfix, :per_page_timeout,
+                    :overall_deadline, :parallel_scrape, :snippets_only
+
         def prompt_section_bullets
           [
-            "Use the #{@tool_name} tool when users ask for information you need to look up",
+            "Use the #{tool_name} tool when users ask for information you need to look up",
             'The search automatically filters out low-quality results like empty pages',
             'Results are ranked by content quality, relevance, and domain reputation',
             'Summarize the high-quality results in a clear, helpful way'
@@ -352,7 +358,7 @@ module SignalWire
         # get_param's `||` chain can't be used for booleans because a literal
         # +false+ would fall through to the default.
         def bool_param(key, default)
-          raw = @params[key.to_s]
+          raw = params[key.to_s]
           return default if raw.nil?
 
           case raw
@@ -382,18 +388,18 @@ module SignalWire
           read_core_params
           read_latency_params
 
-          return false unless @api_key && !@api_key.empty?
-          return false unless @search_engine_id && !@search_engine_id.empty?
+          return false unless api_key && !api_key.empty?
+          return false unless search_engine_id && !search_engine_id.empty?
 
           true
         end
 
-        def instance_key = "web_search_#{@tool_name}"
+        def instance_key = "web_search_#{tool_name}"
 
         def register_tools
           [
             {
-              name: @tool_name,
+              name: tool_name,
               description: TOOL_DESCRIPTION,
               parameters: { 'query' => { 'type' => 'string', 'description' => QUERY_PARAM_DESC } },
               handler: method(:handle_search)
@@ -412,7 +418,7 @@ module SignalWire
           [
             {
               'title' => 'Web Search Capability (Quality Enhanced)',
-              'body' => "You can search the internet for high-quality information using the #{@tool_name} tool.",
+              'body' => "You can search the internet for high-quality information using the #{tool_name} tool.",
               'bullets' => prompt_section_bullets
             }
           ]

--- a/lib/signalwire/skills/builtin/wikipedia_search.rb
+++ b/lib/signalwire/skills/builtin/wikipedia_search.rb
@@ -41,7 +41,7 @@ module SignalWire
 
         def get_prompt_sections
           body = 'You can search Wikipedia for factual information using search_wiki. ' \
-                 "This will return up to #{@num_results || 1} Wikipedia article summaries."
+                 "This will return up to #{num_results} Wikipedia article summaries."
           bullets = [
             'Use search_wiki for factual, encyclopedic information',
             'Great for answering questions about people, places, concepts, and history',
@@ -61,22 +61,32 @@ module SignalWire
         # (search, then per-title extract) and returns the formatted article
         # text (or the no-results message). Public so callers/tests can invoke
         # the lookup directly; the tool handler delegates to this method.
-        # ``@num_results``/``@no_results_msg`` are populated by #setup; fall
-        # back to defaults if called before setup.
+        # #num_results / #no_results_msg fall back to defaults if read before
+        # #setup populates their ivars.
         def search_wiki(query)
-          @num_results    ||= 1
-          @no_results_msg ||= DEFAULT_NO_RESULTS_MSG
-
           results = wiki_search_results(query)
-          return @no_results_msg if results.nil? || results.empty?
+          return no_results_msg if results.nil? || results.empty?
 
-          articles = results.first(@num_results).filter_map { |r| article_for(r) }
-          return @no_results_msg if articles.empty?
+          articles = results.first(num_results).filter_map { |r| article_for(r) }
+          return no_results_msg if articles.empty?
 
           articles.join("\n\n#{'=' * 50}\n\n")
         end
 
         private
+
+        # Populated by #setup; fall back to defaults if read before setup.
+        def num_results
+          return @num_results if defined?(@num_results) && @num_results
+
+          @num_results = 1
+        end
+
+        def no_results_msg
+          return @no_results_msg if defined?(@no_results_msg) && @no_results_msg
+
+          @no_results_msg = DEFAULT_NO_RESULTS_MSG
+        end
 
         # Default to en.wikipedia.org host; WIKIPEDIA_BASE_URL overrides
         # for tests and the audit fixture. The env var is the *host*; the
@@ -91,7 +101,7 @@ module SignalWire
         def wiki_search_results(query)
           search_uri = URI(
             "#{api_endpoint}?action=query&list=search&format=json" \
-            "&srsearch=#{URI.encode_www_form_component(query)}&srlimit=#{@num_results}"
+            "&srsearch=#{URI.encode_www_form_component(query)}&srlimit=#{num_results}"
           )
           search_resp = Net::HTTP.get_response(search_uri)
           return nil unless search_resp.is_a?(Net::HTTPSuccess)

--- a/lib/signalwire/skills/skill_registry.rb
+++ b/lib/signalwire/skills/skill_registry.rb
@@ -17,7 +17,7 @@ module SignalWire
     module SkillIntrospection
       # { 'name', ('description'), ('version') } for one skill; name-only when
       # the factory needs constructor args.
-      def _skill_summary(skill_name)
+      def skill_summary(skill_name)
         entry = { 'name' => skill_name }
         factory = @factories[skill_name]
         return entry unless factory.respond_to?(:call)
@@ -34,7 +34,7 @@ module SignalWire
 
       # Names of skill subdirectories (containing skill.rb) directly under
       # +path+, sorted; [] when +path+ isn't a directory.
-      def _skill_dirs_under(path)
+      def skill_dirs_under(path)
         return [] unless File.directory?(path)
 
         Dir.children(path).sort.select do |entry|
@@ -46,13 +46,13 @@ module SignalWire
 
       # { 'name', 'parameters', ('description'), ('version') } for one skill;
       # minimal entry when it can't be instantiated bare.
-      def _skill_schema_entry(name)
+      def skill_schema_entry(name)
         entry = { 'name' => name, 'parameters' => {} }
         factory = @factories[name]
         return entry unless factory.respond_to?(:call)
 
         begin
-          _enrich_schema_entry(entry, factory.call({}))
+          enrich_schema_entry(entry, factory.call({}))
         rescue StandardError
           # Can't instantiate without params; fall back to the minimal entry.
         end
@@ -61,7 +61,7 @@ module SignalWire
 
       # Fold parameter_schema / description / version off a bare skill instance
       # into +entry+ (only when the instance exposes them).
-      def _enrich_schema_entry(entry, instance)
+      def enrich_schema_entry(entry, instance)
         entry['parameters'] = instance.parameter_schema || {} if instance.respond_to?(:parameter_schema)
         entry['description'] = instance.class.skill_description if instance.class.respond_to?(:skill_description)
         entry['version'] = instance.class.skill_version if instance.class.respond_to?(:skill_version)
@@ -108,7 +108,7 @@ module SignalWire
       # @return [Array<String>]
       def external_paths
         paths = @inst_mutex.synchronize { @external_paths.dup }
-        self.class._env_skill_paths.each { |p| paths << p unless paths.include?(p) }
+        self.class.send(:env_skill_paths).each { |p| paths << p unless paths.include?(p) }
         paths
       end
 
@@ -152,7 +152,7 @@ module SignalWire
       # without arguments.
       #
       # @return [Array<Hash>]
-      def list_skills = self.class.send(:_list_skills_full)
+      def list_skills = self.class.send(:list_skills_full)
 
       # Ensure built-in skills are discovered/registered (instance form).
       #
@@ -190,7 +190,7 @@ module SignalWire
         end
 
         skill_class = skill_class_or_name
-        name = _require_skill_name(skill_class)
+        name = require_skill_name(skill_class)
         self.class.register_skill(name, ->(params = {}) { skill_class.new(params) })
         @inst_mutex.synchronize { @last_registered = name }
         self
@@ -198,24 +198,24 @@ module SignalWire
 
       # Resolve and validate the registrable name for +skill_class+ (raising
       # ArgumentError when the class can't be constructed or named).
-      def _require_skill_name(skill_class)
+      def require_skill_name(skill_class)
         unless skill_class.respond_to?(:new)
           raise ArgumentError, 'register_skill expects a class with .new or a (name, factory) pair'
         end
 
-        name = _resolve_skill_name(skill_class)
+        name = resolve_skill_name(skill_class)
         raise ArgumentError, "Cannot determine skill name for #{skill_class}" if name.nil?
 
         name.to_s
       end
-      private :_require_skill_name
+      private :require_skill_name
 
       # The most recently registered skill name (instance form).
       attr_reader :last_registered
 
       # Pull the skill name from a class-level method, a SKILL_NAME constant,
       # or (Ruby idiom) a no-arg instance's #name. Returns nil if none apply.
-      def _resolve_skill_name(skill_class)
+      def resolve_skill_name(skill_class)
         return skill_class.skill_name if skill_class.respond_to?(:skill_name)
         return skill_class.const_get(:SKILL_NAME) if skill_class.const_defined?(:SKILL_NAME)
 
@@ -225,7 +225,7 @@ module SignalWire
           nil
         end
       end
-      private :_resolve_skill_name
+      private :resolve_skill_name
 
       class << self
         # Register a skill factory.
@@ -255,9 +255,9 @@ module SignalWire
         # Returns one dict per skill with name + description + version when
         # available.
         # @api private
-        def _list_skills_full
+        def list_skills_full
           register_builtins! # parity: Python auto-discovers builtins (idempotent)
-          @mutex.synchronize { @factories.keys.sort.map { |skill_name| _skill_summary(skill_name) } }
+          @mutex.synchronize { @factories.keys.sort.map { |skill_name| skill_summary(skill_name) } }
         end
 
         # Check if a skill is registered.
@@ -278,7 +278,7 @@ module SignalWire
         # takes effect, matching Python's search-time read.
         #
         # @return [Array<String>]
-        def _env_skill_paths
+        def env_skill_paths
           ENV.fetch('SIGNALWIRE_SKILL_PATHS', '').split(File::PATH_SEPARATOR).reject(&:empty?)
         end
 
@@ -300,7 +300,7 @@ module SignalWire
         def builtin_skill_names = SkillName::ALL.dup
         # Internal helper — not part of the Python surface; reached via
         # discover_skills / list_all_skill_sources.
-        private :builtin_skill_names
+        private :builtin_skill_names, :list_skills_full, :env_skill_paths
 
         # Ensure built-in skills are registered and return their names.
         #
@@ -329,7 +329,7 @@ module SignalWire
           builtins = builtin_skill_names
           {
             'built-in' => builtins,
-            'external_paths' => external_paths.flat_map { |path| _skill_dirs_under(path) },
+            'external_paths' => external_paths.flat_map { |path| skill_dirs_under(path) },
             'entry_points' => [],
             'registered' => list_skills.reject { |name| builtins.include?(name) }
           }
@@ -349,7 +349,7 @@ module SignalWire
         def get_all_skills_schema
           register_builtins! # parity: Python auto-discovers builtins here (idempotent)
           @mutex.synchronize do
-            @factories.keys.sort.to_h { |name| [name, _skill_schema_entry(name)] }
+            @factories.keys.sort.to_h { |name| [name, skill_schema_entry(name)] }
           end
         end
       end

--- a/lib/signalwire/swaig/parameter_schema.rb
+++ b/lib/signalwire/swaig/parameter_schema.rb
@@ -103,25 +103,25 @@ module SignalWire
       # @param format [String, nil] JSON-Schema +format+ hint
       # @return [self]
       def string(name, description = nil, required: false, default: nil, enum: nil, format: nil)
-        _add(name, STRING, description, required: required, default: default, enum: enum, format: format)
+        add(name, STRING, description, required: required, default: default, enum: enum, format: format)
       end
 
       # Add a +number+ (floating-point) property. Same options as {#string}.
       # @return [self]
       def number(name, description = nil, required: false, default: nil, enum: nil, format: nil)
-        _add(name, NUMBER, description, required: required, default: default, enum: enum, format: format)
+        add(name, NUMBER, description, required: required, default: default, enum: enum, format: format)
       end
 
       # Add an +integer+ property. Same options as {#string}.
       # @return [self]
       def integer(name, description = nil, required: false, default: nil, enum: nil, format: nil)
-        _add(name, INTEGER, description, required: required, default: default, enum: enum, format: format)
+        add(name, INTEGER, description, required: required, default: default, enum: enum, format: format)
       end
 
       # Add a +boolean+ property. Same options as {#string}.
       # @return [self]
       def boolean(name, description = nil, required: false, default: nil)
-        _add(name, BOOLEAN, description, required: required, default: default)
+        add(name, BOOLEAN, description, required: required, default: default)
       end
 
       # Add a closed-set property (a +string+-typed schema carrying an
@@ -144,7 +144,7 @@ module SignalWire
       def enum(name, values, description = nil, required: false, default: nil, type: STRING)
         # Copy the closed set so a frozen constant ALL array is never aliased
         # into (and thus mutable through) the produced schema.
-        _add(name, type, description, required: required, default: default, enum: Array(values).dup)
+        add(name, type, description, required: required, default: default, enum: Array(values).dup)
       end
 
       # Add an +array+ property. The element kind is given by +of:+ (a JSON
@@ -171,7 +171,7 @@ module SignalWire
       def array(name, description = nil, of: nil, required: false, default: nil, enum: nil, &)
         extra = {}
         extra['items'] = build_array_items(of.to_s, enum, &) if of
-        _add(name, ARRAY, description, required: required, default: default, extra: extra)
+        add(name, ARRAY, description, required: required, default: default, extra: extra)
       end
 
       # Add a nested +object+ property whose sub-properties are defined in
@@ -202,7 +202,7 @@ module SignalWire
         else
           extra['properties'] = {}
         end
-        _add(name, OBJECT, description, required: required, extra: extra)
+        add(name, OBJECT, description, required: required, extra: extra)
       end
 
       # Mark one or more already-declared (or to-be-declared) properties as
@@ -280,9 +280,9 @@ module SignalWire
       # (+type+, +description+, then +enum+ / +format+ / +default+ / +items+
       # / +properties+) and register the name. When +required:+ is truthy the
       # name folds into the top-level required list.
-      def _add(name, type, description, required: false, default: nil, enum: nil, format: nil, extra: {})
+      def add(name, type, description, required: false, default: nil, enum: nil, format: nil, extra: {})
         key = name.to_s
-        @properties[key] = _build_prop(type, description, default: default, enum: enum, format: format, extra: extra)
+        @properties[key] = build_prop(type, description, default: default, enum: enum, format: format, extra: extra)
         required(key) if required
         self
       end
@@ -292,7 +292,7 @@ module SignalWire
       # +properties+), and +default+ last. +default+ is emitted whenever the
       # caller passed one (including +false+), so the nil-guard ordering above
       # can't shadow an explicit nil-able default.
-      def _build_prop(type, description, default:, enum:, format:, extra:)
+      def build_prop(type, description, default:, enum:, format:, extra:)
         prop = { 'type' => type }
         prop['description'] = description unless description.nil?
         prop['enum']   = enum   unless enum.nil?

--- a/lib/signalwire/swml/schema.rb
+++ b/lib/signalwire/swml/schema.rb
@@ -63,7 +63,9 @@ module SignalWire
 
     # Module-level singleton so the schema is loaded at most once.
     def self.schema
-      @schema ||= Schema.new
+      return @schema if defined?(@schema)
+
+      @schema = Schema.new
     end
 
     # Allow resetting for tests

--- a/lib/signalwire/swml/service.rb
+++ b/lib/signalwire/swml/service.rb
@@ -297,37 +297,37 @@ module SignalWire
       #   document; a routing redirect → 307 with a +Location+ header and empty
       #   body; an auth failure → 401 with a +WWW-Authenticate: Basic+ header.
       def handle_request(method, url, headers, body = nil)
-        callback_path = _callback_path_for_url(url)
-        _handle_request_core(method, url, headers, body || {}, callback_path)
+        callback_path = callback_path_for_url(url)
+        handle_request_core(method, url, headers, body || {}, callback_path)
       end
 
       # Shared decomposed dispatch logic over primitives. Both +handle_request+
       # and the Rack +handle_main_route+ delegate here so dispatch behavior has a
       # single source. Returns a +[status, headers, body_string]+ triple.
-      def _handle_request_core(method, url, headers, body, callback_path)
-        _detect_proxy_from_primitives(url, headers)
-        return _unauthorized_triple unless _check_basic_auth_headers(headers)
+      def handle_request_core(method, url, headers, body, callback_path)
+        detect_proxy_from_primitives(url, headers)
+        return unauthorized_triple unless check_basic_auth_headers(headers)
 
-        redirect = _routing_redirect(method, body, headers, callback_path)
+        redirect = routing_redirect(method, body, headers, callback_path)
         return redirect if redirect
 
         modifications = on_request(body, callback_path)
-        _render_dispatch_triple(modifications)
+        render_dispatch_triple(modifications)
       end
 
       # 401 triple with the standard WWW-Authenticate header.
-      def _unauthorized_triple
+      def unauthorized_triple
         [401, { 'WWW-Authenticate' => 'Basic' }, JSON.generate('error' => 'Unauthorized')]
       end
 
       # Run the routing callback for a POST with a non-empty body on a path that
       # has one registered; a non-nil return is a redirect route → 307 (preserves
       # the POST method + body). Returns the 307 triple, or nil to continue.
-      def _routing_redirect(method, body, headers, callback_path)
+      def routing_redirect(method, body, headers, callback_path)
         return nil unless method == 'POST' && body && !body.empty? && callback_path
         return nil unless @routing_callbacks.key?(callback_path)
 
-        route = _invoke_routing_callback(@routing_callbacks[callback_path], body, headers)
+        route = invoke_routing_callback(@routing_callbacks[callback_path], body, headers)
         return nil if route.nil?
 
         [307, { 'Location' => route }, '']
@@ -337,7 +337,7 @@ module SignalWire
       # single parameter still work — arity 1 is called with +body+ only.
       # Swallows callback errors (a raising callback does not 500 the request),
       # returning nil so dispatch falls through to render.
-      def _invoke_routing_callback(callback, body, headers)
+      def invoke_routing_callback(callback, body, headers)
         if callback.arity == 1
           callback.call(body)
         else
@@ -351,7 +351,7 @@ module SignalWire
       # Turn an +on_request+ modification result into the 200 SWML triple. A Hash
       # of modifications is shallow-merged over the current document; otherwise the
       # default rendered document is returned.
-      def _render_dispatch_triple(modifications)
+      def render_dispatch_triple(modifications)
         if modifications.is_a?(Hash) && !modifications.empty?
           document = get_document
           modifications.each { |k, v| document[k] = v if document.key?(k) }
@@ -364,7 +364,7 @@ module SignalWire
       # The Rack path gets the callback path from PATH_INFO directly; the
       # primitive +handle_request+ recovers the equivalent by matching the URL's
       # normalized path against the registered callbacks.
-      def _callback_path_for_url(url)
+      def callback_path_for_url(url)
         return nil if @routing_callbacks.nil? || @routing_callbacks.empty?
 
         path = _url_path(url)
@@ -393,8 +393,8 @@ module SignalWire
       # Framework-free basic-auth check over a plain headers Hash — the primitive
       # the Rack TimingSafeBasicAuth and +handle_request+ share. Tolerates common
       # Authorization header casings.
-      def _check_basic_auth_headers(headers)
-        username, password = _decode_basic_auth(_header_lookup(headers, 'Authorization'))
+      def check_basic_auth_headers(headers)
+        username, password = decode_basic_auth(header_lookup(headers, 'Authorization'))
         return false if username.nil? || password.nil?
 
         validate_basic_auth(username, password)
@@ -404,7 +404,7 @@ module SignalWire
 
       # Decode a +Basic <base64>+ Authorization header value into a
       # +[username, password]+ pair, or +[nil, nil]+ when absent/malformed.
-      def _decode_basic_auth(auth)
+      def decode_basic_auth(auth)
         return [nil, nil] if auth.nil? || auth.empty?
 
         scheme, credentials = auth.split(' ', 2)
@@ -415,43 +415,43 @@ module SignalWire
       end
 
       # Framework-free proxy detection over a URL + plain headers Hash, mirroring
-      # python's +_detect_proxy_from_primitives+: honor an already-set proxy base,
+      # python's +detect_proxy_from_primitives+: honor an already-set proxy base,
       # else auto-configure +@proxy_url_base+ from X-Forwarded-* (then RFC-7239
       # Forwarded). No-op when neither is present.
-      def _detect_proxy_from_primitives(_url, headers)
+      def detect_proxy_from_primitives(_url, headers)
         return if @proxy_url_base && !@proxy_url_base.empty?
 
-        forwarded_host = _header_lookup(headers, 'X-Forwarded-Host')
+        forwarded_host = header_lookup(headers, 'X-Forwarded-Host')
         if forwarded_host && !forwarded_host.empty?
-          proto = _header_lookup(headers, 'X-Forwarded-Proto') || 'http'
+          proto = header_lookup(headers, 'X-Forwarded-Proto') || 'http'
           @proxy_url_base = "#{proto}://#{forwarded_host}"
           return
         end
 
-        _detect_proxy_from_rfc7239(_header_lookup(headers, 'Forwarded'))
+        detect_proxy_from_rfc7239(header_lookup(headers, 'Forwarded'))
       end
 
       # Parse an RFC-7239 +Forwarded: for=..;host=..;proto=..+ header and set the
       # proxy base from its host/proto directives.
-      def _detect_proxy_from_rfc7239(forwarded)
+      def detect_proxy_from_rfc7239(forwarded)
         return if forwarded.nil? || forwarded.empty?
 
         parts = forwarded.split(';').map(&:strip)
-        host  = _rfc7239_directive(parts, 'host')
-        proto = _rfc7239_directive(parts, 'proto') || 'http'
+        host  = rfc7239_directive(parts, 'host')
+        proto = rfc7239_directive(parts, 'proto') || 'http'
         @proxy_url_base = "#{proto}://#{host}" if host && !host.empty?
       end
 
       # Extract a single +name=value+ directive value (quotes stripped) from a
       # split RFC-7239 Forwarded header, or nil when absent.
-      def _rfc7239_directive(parts, name)
+      def rfc7239_directive(parts, name)
         prefix = "#{name}="
         parts.find { |p| p.start_with?(prefix) }&.delete_prefix(prefix)&.delete('"')
       end
 
       # Case-tolerant header lookup over a plain Hash (accepts the header's
       # conventional casing, its lowercase form, or the Rack HTTP_ env form).
-      def _header_lookup(headers, name)
+      def header_lookup(headers, name)
         return nil unless headers.is_a?(Hash)
 
         headers[name] || headers[name.downcase] || headers[name.upcase] ||
@@ -670,6 +670,14 @@ module SignalWire
         [200, { 'content-type' => 'application/json' }, [JSON.generate({ status: status })]]
       end
 
+      # Request-handling internals (formerly leading-underscore by convention).
+      # Not part of the public/Python surface — declared private so the
+      # cross-port surface enumerator continues to exclude them.
+      private :handle_request_core, :unauthorized_triple, :routing_redirect,
+              :invoke_routing_callback, :render_dispatch_triple, :callback_path_for_url,
+              :check_basic_auth_headers, :decode_basic_auth, :detect_proxy_from_primitives,
+              :detect_proxy_from_rfc7239, :rfc7239_directive, :header_lookup
+
       # ------------------------------------------------------------------
       private
 
@@ -870,7 +878,7 @@ module SignalWire
         return override if override.is_a?(Hash) && !override.empty?
 
         if @routing_callbacks.key?(callback_path)
-          _invoke_routing_callback(@routing_callbacks[callback_path], request_data, headers)
+          invoke_routing_callback(@routing_callbacks[callback_path], request_data, headers)
         else
           @document.to_h
         end
@@ -912,21 +920,21 @@ module SignalWire
         request_data = parse_json_body(request)
 
         # /swaig — handled by Service itself (lifted from AgentBase).
-        return _handle_swaig_endpoint(request, request_data, env) if sub_path == '/swaig'
+        return handle_swaig_endpoint(request, request_data, env) if sub_path == '/swaig'
 
         # Subclass extension hook for /post_prompt, /debug_events, /mcp, etc.
         extra = handle_additional_route(sub_path, request_data, env)
         return extra if extra
 
         # Fallback: customization hook, routing-callback, then SWML doc.
-        result = dispatch_request(request_data, sub_path, _rack_headers(env))
+        result = dispatch_request(request_data, sub_path, rack_headers(env))
         [200, { 'content-type' => 'application/json' }, [JSON.generate(result)]]
       end
 
       # Extract request headers from a Rack +env+ as a plain Hash of the
       # conventional header names (so routing callbacks receive the same
       # +(body, headers)+ shape the primitive +handle_request+ passes).
-      def _rack_headers(env)
+      def rack_headers(env)
         env.each_with_object({}) do |(k, v), acc|
           next unless k.is_a?(String) && k.start_with?('HTTP_')
 
@@ -950,7 +958,7 @@ module SignalWire
       # GET — returns the rendered SWML doc via render_main_swml.
       # POST — parses {function, argument, call_id}, validates, runs the
       # swaig_pre_dispatch hook, dispatches via on_function_call.
-      def _handle_swaig_endpoint(request, request_data, env)
+      def handle_swaig_endpoint(request, request_data, env)
         return swaig_json(200, render_main_swml(request_data, request: request)) if request.get?
 
         func_name = request_data && request_data['function']

--- a/lib/signalwire/swml/service.rb
+++ b/lib/signalwire/swml/service.rb
@@ -571,7 +571,9 @@ module SignalWire
 
       # The lazily-built verb-handler registry bound to this service.
       def verb_registry
-        @verb_registry ||= ::SignalWire::SWML::VerbHandlerRegistry.new
+        return @verb_registry if defined?(@verb_registry)
+
+        @verb_registry = ::SignalWire::SWML::VerbHandlerRegistry.new
       end
 
       # Whether full JSON-schema validation is active for this service.
@@ -615,10 +617,10 @@ module SignalWire
       # self.schema_utils public instance attribute on SWMLService.
       # Built lazily on first access.
       def schema_utils
-        @schema_utils ||= begin
-          require_relative '../utils/schema_utils'
-          ::SignalWire::Utils::SchemaUtils.new
-        end
+        return @schema_utils if defined?(@schema_utils)
+
+        require_relative '../utils/schema_utils'
+        @schema_utils = ::SignalWire::Utils::SchemaUtils.new
       end
 
       # ------------------------------------------------------------------
@@ -627,7 +629,9 @@ module SignalWire
 
       # Returns a Rack-compatible application.
       def rack_app
-        @rack_app ||= build_rack_app
+        return @rack_app if defined?(@rack_app)
+
+        @rack_app = build_rack_app
       end
 
       # Start serving (blocking).


### PR DESCRIPTION
Resolves #41 — the idiomatic Ruby alignment pass. Three mechanical, behavior- and
surface-neutral transformations, one concern (mostly one file) per commit.

## (a) `@ivar` reads outside `initialize` → private `attr_reader`s
Reads are routed through readers; **assignments and genuinely-mutable concurrency
state are left as raw ivars** (mutexes/condvars/sockets, `@state`, the RELAY
`@pending*`/`@calls*`/`@messages*` maps, agent builder collections, handler
blocks, `@basic_auth`).

- **Skills** (one commit each): `joke`, `weather_api`, `datasphere`, `web_search`
  — config ivars (`api_key`, `tool_name`, …) via new private `attr_reader`s.
- **`relay/call.rb`**: `@client` (new private reader) + `@call_id`/`@node_id`/
  `@direction` via the existing public readers.
- **`relay/client.rb`**: `@project_id`/`@host` via public readers; `@space`/
  `@token`/`@jwt_token`/`@contexts` via new private readers. All socket/session/
  reconnect/mutex state left raw.
- **`agent/agent_base.rb`**: `@name`/`@route`/`@host`/`@port` via inherited
  `SWMLService` readers; 14 config scalars via new private readers; the two nested
  Rack middleware classes read `@app`/`@max_size` via private readers. `#serve`'s
  `host/port` fallback keeps raw ivars (params shadow the readers).

## (b) leading-underscore "private" methods → real `private`/`protected`, underscore dropped
Every candidate was checked for cross-instance / test / `bin`-dump / symbol
references before conversion. Methods invoked with an explicit receiver from an
unrelated class (or via `:sym`/`send`/`assert_predicate` in tests, or by the
`bin/*-dump` tools) **keep their underscore and stay public** — dropping it would
either break the caller or, because the surface enumerator excludes single-`_`
names, *add* a public method and break cross-port parity. Examples left alone:
`Call#_execute`/`_dispatch_event`/`_wait_for_state` (Action/RelayClient/tests),
`Client#_send_json`/`_connected?`/`_handle_event`/`_calls_snapshot`/`_set_protocol`/
`_session_id`, `AgentServer#_lookup_sip_route` (bin/state-dump), the serverless
`_run_*` dispatch table, `_render_swml_internal` (polymorphic).

Converted: `HttpClient` (6), `SWMLService` (12), `AgentServer` (23), `SkillRegistry`
(2), `Call` (16), `Client` (54), `AgentBase` (37), plus the already-`private`
helpers in `context_builder`, `prompt_object_model`, `receptionist`,
`relay/action`, `relay/relay_event`, `session_manager`, `webhook_middleware`,
`parameter_schema`. Where a converted method sat in a public region, an explicit
`private :sym…` declaration keeps it off the surface.

## (c) `||=` lazy-init memoization → `return @x if defined?(@x)` form
`_signalwire_singleton_registry`, `SecurityConfig#logger`, `AuthHandler#logger`,
`AgentServer#app`, `AgentBase#rack_app`, `SWMLService#{verb_registry,schema_utils,
rack_app}`, `Schema.schema`; `ContextBuilder#add_{enter,exit}_filler` use the
`unless defined?` guard equivalent. Non-memoization `||=` (local-var defaults,
hash-key inits, accumulators, `define_contexts`' documented multi-mode shared
ivar) left as-is.

## Verification
- **Public surface unchanged** — the regenerated `port_surface.json` is
  byte-identical to the committed one (0 symbols added/removed); SURFACE-FRESH,
  SIGNATURES, DOC-AUDIT pass.
- `bundle exec rake test`: **2472 runs, 0 failures, 0 errors**.
- `bundle exec rubocop`: **1333 files, 0 offenses** (LINT + FMT green).

The only red `run-ci.sh` gates (DRIFT / SURFACE-DIFF / GEN-FRESH / SPEC-PARITY /
REST-COVERAGE) are a **pre-existing** upstream drift — the porting-sdk oracle
gained a `Messages` REST resource this week that the port hasn't regenerated for.
It fails identically on plain `main` (base `9bb765b` has no `Messages` resource)
and is unrelated to this idiom pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
