### PR TITLE
feat: gate-enforcement plan (ruby) — flat-tts + doc red-list burn + end naming + wire quartet

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,12 @@ AllCops:
     - 'bin/state-dump'
     - 'bin/http-dump'
     - 'bin/wire-relay-dump'
+    - 'bin/wait-liveness-dump'
+    # Cross-port gate fixture-replay tooling, same category as the bin/*-dump
+    # programs above: doc_wire_runner.rb only DRIVES the documented REST calls
+    # against the DOC-WIRE flag-mode mock so it journals the wire shape. Not
+    # audited library surface.
+    - 'scripts/doc_wire_runner.rb'
     # NOTE: the machine-generated trees (REST resource layer, READ-SIDE typed
     # payload trees, and the full-mock REST wire-test suite) are DELIBERATELY NOT
     # excluded here — generated code is linted like hand-written code so a

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -198,7 +198,7 @@ Agents completing this checklist have historically left gaps by treating ambiguo
 - [ ] CrudResource (List, Create, Get, Update, Delete)
 - [ ] Pagination support
 - [ ] SignalWireRestError
-- [ ] **All 20 REST namespaces** — exact stems below. Every one must be accessible as `client.<stem>` (Python) / `client.<CamelStem>` (Go/Java/etc.) in the port. Enforced by `scripts/audit_checklist.py`. (The Twilio-compatibility/LAML namespace was excised matrix-wide, so it is not one of them.)
+- [ ] **All REST namespaces** — exact stems below. Every one must be accessible as `client.<stem>` (Python) / `client.<CamelStem>` (Go/Java/etc.) in the port. Enforced by `scripts/audit_checklist.py`. (The Twilio-compatibility/LAML namespace was excised matrix-wide, so it is not one of them.)
   - [ ] Fabric — **exactly 16 sub-resources**: `swml_scripts`, `swml_webhooks`, `ai_agents`, `relay_applications`, `call_flows`, `conference_rooms`, `freeswitch_connectors`, `subscribers`, `sip_endpoints`, `sip_gateways`, `cxml_scripts`, `cxml_webhooks`, `cxml_applications`, `resources`, `addresses`, `tokens`
   - [ ] Calling (**exactly 37 commands** — see the OpenAPI spec at `rest-apis/calling/openapi.yaml`)
   - [ ] PhoneNumbers — see § Phone-number binding below for the 7 typed helpers
@@ -486,7 +486,7 @@ Tests are proof of implementation. The port must test **everything the Python SD
 - [ ] All 41 SwaigFunctionResult action methods present (plus the non-action basics: set_response, set_post_process, add_action, add_actions, to_dict, and the 3 payment helpers). **Proof:** grep the port's equivalent file for the 41 action names in SWAIG_FUNCTION_RESULT_REFERENCE.md; every one resolves, or the omission is justified in PORT_OMISSIONS.md.
 - [ ] All 38 SWML verb methods present and schema-validated
 - [ ] RELAY client: all 4 correlation mechanisms implemented (JSON-RPC id, call_id, control_id, tag)
-- [ ] REST client: all 20 namespaces initialized with correct paths (see Phase 8 for the enumerated list)
+- [ ] REST client: all namespaces initialized with correct paths (see Phase 8 for the enumerated list)
 - [ ] Skills registry: all 17 built-in skills registered (per Phase 4 enumerated list)
 - [ ] agent.AddSkill() one-liner integration works (not just manual SkillManager)
 - [ ] SIP username extraction utility exists

--- a/DOC_AUDIT_IGNORE.md
+++ b/DOC_AUDIT_IGNORE.md
@@ -36,6 +36,7 @@ sub: `String#sub` — Ruby stdlib (by orchestrator, 2026-07-06)
 transform_keys: `Hash#transform_keys` — Ruby stdlib, Ruby 2.5+ (by orchestrator, 2026-07-06)
 clamp: `Comparable#clamp` / `Integer#clamp` — Ruby stdlib, constrain a number to a range (by orchestrator, 2026-07-06)
 HTTP: `Net::HTTP` stdlib constant named in an examples/skills_audit_harness.rb prose comment ("issues real HTTP through Net::HTTP"), not a method call (by orchestrator, 2026-07-08)
+contains: appears only in CHECKLIST.md prose as an illustrative BANNED anti-pattern (`assert err.contains("not available")` — the rule forbidding stub-asserting tests); not a SignalWire API reference (by orchestrator, 2026-07-15)
 
 ## Python syntax retained verbatim in contrast/migration example blocks
 

--- a/PORT_ADDITIONS.md
+++ b/PORT_ADDITIONS.md
@@ -41,9 +41,10 @@ spot drift from the Python reference.
   `SWMLService` split into three cohesive classes under
   `SignalWire::SWML::*`. The Python counterparts are omitted.
 - **Ruby-keyword workarounds**: `Call.pass_call` (Python `Call.pass_`),
-  `Call.tap_audio` (Python `Call.tap`), `CallingNamespace.end_call`
-  (Python `CallingNamespace.end`), `Message.on_event`/`on_completed`
+  `Call.tap_audio` (Python `Call.tap`), `Message.on_event`/`on_completed`
   (Python `Message.on`), `Action.is_done?`/`done?` (Python `is_done`).
+  (The REST `CallingNamespace.end` needs no workaround — `def end` is a valid
+  Ruby method definition, so the port exposes `end` at exact parity with Python.)
 - **Module-level helpers**: `SignalWire::Logging`, `SignalWire::SWML`,
   `SignalWire::Contexts`, `SignalWire::Runtime` module functions. These
   mirror behaviour Python keeps inside classes or separate files.

--- a/PORT_OMISSIONS.md
+++ b/PORT_OMISSIONS.md
@@ -307,7 +307,6 @@ signalwire.relay.client.RelayClient.__del__: impossible: Python finalizer dunder
 signalwire.relay.client.RelayClient.relay_protocol: impossible: Python property exposing the internal relay-protocol object; Ruby keeps the protocol object private (no public accessor) — internal plumbing, not public surface (TS/PHP omit identically)
 signalwire.relay.message.Message.__repr__: impossible: Python object-repr dunder; Ruby provides the equivalent via the shared MessageSerialization module's inspect/to_s, but the __repr__ NAME itself has no standalone Ruby form (mirrors Call.__repr__; TS/PHP omit identically)
 signalwire.rest.call_handler.PhoneCallHandler: Ruby SignalWire::REST::PhoneCallHandler is an empty marker (matches Python - no methods on either)
-signalwire.rest.namespaces.calling.CallingNamespace.end: Ruby uses SignalWire::REST::Namespaces::CallingNamespace#end_call - end is a Ruby keyword
 signalwire.search.document_processor.DocumentProcessor: approved: Python-only RAG/vector-search subsystem, not ported to any SDK — user, 2026-07 pass (§I.1)
 signalwire.search.document_processor.DocumentProcessor.__init__: approved: Python-only RAG/vector-search subsystem, not ported to any SDK — user, 2026-07 pass (§I.1)
 signalwire.search.document_processor.DocumentProcessor.create_chunks: approved: Python-only RAG/vector-search subsystem, not ported to any SDK — user, 2026-07 pass (§I.1)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ _Build AI voice agents, control live calls over WebSocket, and manage every Sign
 |-----------|-------------|------------|
 | **AI Agents** | Build voice agents that handle calls autonomously -- the platform runs the AI pipeline, your code defines the persona, tools, and call flow | [Agent Guide](#ai-agents) |
 | **RELAY Client** | Control live calls and SMS/MMS in real time over WebSocket -- answer, play, record, collect DTMF, conference, transfer, and more | [RELAY docs](relay/README.md) |
-| **REST Client** | Manage SignalWire resources over HTTP -- phone numbers, SIP endpoints, Fabric AI agents, video rooms, messaging, and 20 API namespaces | [REST docs](rest/README.md) |
+| **REST Client** | Manage SignalWire resources over HTTP -- phone numbers, SIP endpoints, Fabric AI agents, video rooms, messaging, and the full set of API namespaces | [REST docs](rest/README.md) |
 
 ```bash
 gem install signalwire-sdk
@@ -174,12 +174,12 @@ client = SignalWire::REST::RestClient.new(
 )
 
 client.fabric.ai_agents.create(name: 'Support Bot', prompt: { 'text' => 'You are helpful.' })
-client.calling.play(call_id, play: [{ 'type' => 'tts', 'text' => 'Hello!' }])
+client.calling.play(call_id, play: [{ 'type' => 'tts', 'params' => { 'text' => 'Hello!' } }])
 client.phone_numbers.search(areacode: '512')
 client.datasphere.documents.search(query_string: 'billing policy')
 ```
 
-- 20 namespaced API surfaces: Fabric (13 resource types), Calling (37 commands), Video, Datasphere, Phone Numbers, SIP, Queues, Recordings, and more
+- Full namespaced API surface: Fabric (13 resource types), Calling (37 commands), Video, Datasphere, Phone Numbers, SIP, Queues, Recordings, and more
 - Hash returns -- raw JSON, no wrapper objects to learn
 - Single `RestClient` with namespaced sub-objects for every API
 

--- a/SNIPPET_RUN_ALLOW.md
+++ b/SNIPPET_RUN_ALLOW.md
@@ -26,5 +26,5 @@ themselves are exercised by EXAMPLES-RUN; here they each start a blocking server
 make a live REST call and so cannot run standalone under SNIPPET-RUN.
 
 - README.md:49 — quickstart_agent: ends with agent.run (blocking WEBrick server) (burn-ruby, 2026-07-09)
-- README.md:119 — quickstart_relay: client.run connects to a live RELAY WebSocket (burn-ruby, 2026-07-09)
-- README.md:154 — quickstart_rest: makes live REST calls; base URL derives from the space host, no loopback-mock override (burn-ruby, 2026-07-09)
+- README.md:131 — quickstart_relay: client.run connects to a live RELAY WebSocket (burn-ruby, 2026-07-09; line re-synced 2026-07-15)
+- README.md:166 — quickstart_rest: makes live REST calls; base URL derives from the space host, no loopback-mock override; the #rest region also references call_id defined outside the region (burn-ruby, 2026-07-09; line re-synced 2026-07-15)

--- a/bin/wait-liveness-dump
+++ b/bin/wait-liveness-dump
@@ -1,0 +1,184 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) 2025 SignalWire
+#
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+
+#
+# wait-liveness-dump — the Ruby port's WAIT-LIVENESS dump program for the
+# cross-port behavioral differ (porting-sdk/scripts/diff_port_wait_liveness.py).
+#
+# The differ runs the wait_liveness_corpus against signalwire-python to build the
+# golden LIVENESS classification, then runs THIS program (which embeds the same
+# corpus) and structurally compares our per-case classification. The artifact is a
+# CLASSIFICATION (not raw ms), so the golden is deterministic while the timing
+# that produces it is real and unfakeable: a wait() that is a no-op returns at
+# t~=0 (blocked_until_event=false → RED); a wait() that hangs blows the deadline
+# (timed_out=true → RED); a correct wait() blocks until the deferred completing
+# event arrives, then returns with the finished state (the golden → GREEN).
+#
+# Unlike wire-relay-dump (which RECORDS the send-side frame with no socket), this
+# gate MUST exercise real liveness — so we drive the SDK against a real mock_relay
+# server and arm the completing event as a DEFERRED (delay_ms) scenario. That
+# delivers the event through the SAME socket-read → event-dispatch path the real
+# server drives; a wait() that never pumps the loop cannot observe it. This is the
+# exact mechanism tests/relay/actions_mock_test.rb#test_play_resolves_on_finished_event
+# uses.
+#
+# Protocol: stdout = ONE JSON object mapping case_id → classification. Only stdout
+# carries JSON. The corpus cases are embedded here (mirroring
+# porting-sdk/scripts/wait_liveness_corpus.py) exactly as bin/wire-relay-dump
+# embeds the wire_relay corpus — the differ does not feed the corpus in; it keys
+# our output by case-id against the python oracle.
+#
+# Run from the signalwire-ruby repo root (with a mock_relay reachable via
+# MOCK_RELAY_PORT / MOCK_RELAY_HTTP_PORT, or auto-spawned by the harness):
+#
+#   ruby bin/wait-liveness-dump
+
+require 'json'
+
+# Keep stdout PURE JSON: the differ does json.loads(proc.stdout). Save the real
+# stdout, point $stdout at stderr for all setup/logging, restore only to emit.
+REAL_STDOUT = $stdout.dup
+$stdout.reopen($stderr)
+
+require_relative '../tests/relay/mock_test'
+
+# Classification tolerances — must match porting-sdk/scripts/diff_port_wait_liveness.py.
+DEADLINE_S   = 5.0
+BLOCK_TOL_MS = 40
+
+# The deferred-event delay — must match wait_liveness_corpus.DELAY_MS.
+DELAY_MS = 150
+CID = 'ctl-live-1'
+
+# The corpus, mirroring porting-sdk/scripts/wait_liveness_corpus.py CORPUS. Two
+# distinct action types (play, record) so a port can't hardcode one surface.
+CORPUS = [
+  {
+    'id' => 'live_play_wait',
+    'verb' => 'play',
+    'kwargs' => {
+      'media' => [{ 'type' => 'audio', 'params' => { 'url' => 'https://x/a.mp3' } }],
+      'control_id' => CID
+    },
+    'delay_ms' => DELAY_MS,
+    'terminal' => { 'event_type' => 'calling.call.play', 'state' => 'finished' }
+  },
+  {
+    'id' => 'live_record_wait',
+    'verb' => 'record',
+    'kwargs' => { 'audio' => { 'format' => 'mp3' }, 'control_id' => CID },
+    'delay_ms' => DELAY_MS,
+    'terminal' => { 'event_type' => 'calling.call.record', 'state' => 'finished' }
+  }
+].freeze
+
+# Map a corpus verb to the RELAY method whose scenario carries its terminal event.
+VERB_METHOD = {
+  'play' => 'calling.play',
+  'record' => 'calling.record'
+}.freeze
+
+# Derive the deterministic liveness classification from the measured instants.
+# Mirrors classify_liveness() in the differ byte-for-byte.
+def classify(delay_ms, t_wait_start, t_return, completed_state, timed_out)
+  if timed_out || t_return.nil?
+    return {
+      'blocked_until_event' => false,
+      'returned_after_event' => false,
+      'completed_state' => '',
+      'timed_out' => true
+    }
+  end
+  elapsed_ms = (t_return - t_wait_start) * 1000.0
+  blocked = elapsed_ms >= (delay_ms - BLOCK_TOL_MS)
+  {
+    'blocked_until_event' => blocked,
+    'returned_after_event' => true,
+    'completed_state' => completed_state,
+    'timed_out' => false
+  }
+end
+
+# Start the Action-returning verb for a case against an answered call.
+def start_action(call, verb, kwargs)
+  control_id = kwargs['control_id']
+  case verb
+  when 'play'
+    call.play(kwargs['media'], control_id: control_id)
+  when 'record'
+    call.record(audio: kwargs['audio'], control_id: control_id)
+  else
+    raise "wait-liveness-dump: unsupported verb #{verb.inspect}"
+  end
+end
+
+# Drive ONE liveness case against the real mock and return its classification.
+def run_case(handle, kase)
+  client = handle[:client]
+  mock   = handle[:mock]
+  delay_ms = kase['delay_ms'].to_i
+  terminal = kase['terminal']
+  verb     = kase['verb']
+  method   = VERB_METHOD.fetch(verb)
+
+  # Establish an answered inbound call (mirrors RelayActionsTestBase helper).
+  captured = Queue.new
+  done = Queue.new
+  client.on_call do |call|
+    captured.push(call)
+    call.answer
+    done.push(true)
+  end
+  mock.inbound_call(call_id: "live-#{verb}", auto_states: ['created'])
+  Timeout.timeout(DEADLINE_S) { done.pop }
+  call = Timeout.timeout(DEADLINE_S) { captured.pop }
+  call.state = 'answered'
+
+  # Arm the DEFERRED completing event: the mock emits {state: terminal.state}
+  # for this method after delay_ms, delivered through the SDK's real socket-read
+  # event-dispatch path. A no-op / non-pumping wait() cannot observe it.
+  mock.arm_method(method, [{ 'emit' => { 'state' => terminal['state'] }, 'delay_ms' => delay_ms }])
+
+  action = start_action(call, verb, kase['kwargs'] || {})
+
+  t_wait_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  timed_out = false
+  t_return = nil
+  completed_state = ''
+  event = nil
+  begin
+    event = action.wait(timeout: DEADLINE_S)
+    t_return = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    completed_state = (event && event.params ? event.params['state'].to_s : '')
+  rescue SignalWire::Relay::ActionTimeoutError, Timeout::Error
+    timed_out = true
+  end
+  # A wait() that returns nil (no event) within the deadline is a no-op / hung
+  # equivalent: treat a nil return as timed_out so the classification is honest.
+  timed_out = true if t_return && event.nil?
+
+  classify(delay_ms, t_wait_start, t_return, completed_state, timed_out)
+end
+
+def main
+  out = {}
+  # A fresh client/session per case so a scoped scenario/journal never crosses
+  # between cases (mirrors the per-test client isolation in actions_mock_test.rb).
+  CORPUS.each do |kase|
+    handle = RelayMockTest.client
+    begin
+      out[kase['id']] = run_case(handle, kase)
+    ensure
+      RelayMockTest.shutdown_client(handle) if handle
+    end
+  end
+  REAL_STDOUT.puts(JSON.generate(out))
+  0
+end
+
+exit(main) if $PROGRAM_NAME == __FILE__

--- a/examples/README.md
+++ b/examples/README.md
@@ -121,4 +121,4 @@ API_NINJAS_KEY=your-key ruby examples/joke_agent.rb
 Additional examples for the RELAY and REST clients are in their respective directories:
 
 - [relay/examples/](../relay/examples/) -- RELAY WebSocket examples (answer, dial, IVR)
-- [rest/examples/](../rest/examples/) -- REST API examples (all 12 namespaces)
+- [rest/examples/](../rest/examples/) -- REST API examples across the client namespaces

--- a/examples/quickstart_rest.rb
+++ b/examples/quickstart_rest.rb
@@ -19,7 +19,7 @@ client = SignalWire::REST::RestClient.new(
 )
 
 client.fabric.ai_agents.create(name: 'Support Bot', prompt: { 'text' => 'You are helpful.' })
-client.calling.play(call_id, play: [{ 'type' => 'tts', 'text' => 'Hello!' }])
+client.calling.play(call_id, play: [{ 'type' => 'tts', 'params' => { 'text' => 'Hello!' } }])
 client.phone_numbers.search(areacode: '512')
 client.datasphere.documents.search(query_string: 'billing policy')
 # endregion: rest

--- a/port_signatures.baseline.json
+++ b/port_signatures.baseline.json
@@ -1,6 +1,7 @@
 {
   "version": "2",
   "generated_from": "signalwire-ruby via Method#parameters reflection",
+  "generated_from_commit": "f7f8601651e01388b1a55793cfe945226a963379",
   "modules": {
     "signalwire": {
       "functions": {

--- a/rest/README.md
+++ b/rest/README.md
@@ -59,9 +59,9 @@ client.fabric.ai_agents.delete(agent['id'])
 call = client.calling.dial(from: '+15559876543', to: '+15551234567', url: 'https://example.com/handler')
 call_id = call['id']
 
-client.calling.play(call_id, play: [{ 'type' => 'tts', 'text' => 'Hello!' }])
-client.calling.record(call_id, beep: true, format: 'mp3')
-client.calling.end_call(call_id, reason: 'hangup')
+client.calling.play(call_id, play: [{ 'type' => 'tts', 'params' => { 'text' => 'Hello!' } }])
+client.calling.record(call_id, audio: { 'format' => 'mp3', 'beep' => true })
+client.calling.end(call_id, reason: 'hangup')
 ```
 
 ### Phone Numbers

--- a/rest/docs/calling.md
+++ b/rest/docs/calling.md
@@ -74,7 +74,7 @@ Play audio, TTS, silence, or ringtone.
 
 ```ruby
 client.calling.play(call_id,
-  play: [{ 'type' => 'tts', 'text' => 'Hello!' }],
+  play: [{ 'type' => 'tts', 'params' => { 'text' => 'Hello!' } }],
   volume: 5.0
 )
 ```
@@ -212,8 +212,8 @@ client.calling.ai_stop(call_id, control_id: 'ai-1')
 ## Live Transcribe & Translate
 
 ```ruby
-client.calling.live_transcribe(call_id, action: 'start', lang: 'en')
-client.calling.live_translate(call_id, action: 'start', from_lang: 'en', to_lang: 'es')
+client.calling.live_transcribe(call_id, action: { 'start' => { 'lang' => 'en-US' } })
+client.calling.live_translate(call_id, action: { 'start' => { 'from_lang' => 'en-US', 'to_lang' => 'es-ES' } })
 ```
 
 ## Fax
@@ -239,7 +239,7 @@ client.calling.user_event(call_id, event: { 'type' => 'custom', 'data' => { 'key
 |--------|---------|:-:|
 | `dial(**params)` | `dial` | No |
 | `update(**params)` | `update` | No |
-| `end_call(call_id, **params)` | `calling.end` | Yes |
+| `end(call_id, **params)` | `calling.end` | Yes |
 | `transfer(call_id, **params)` | `calling.transfer` | Yes |
 | `disconnect(call_id)` | `calling.disconnect` | Yes |
 | `play(call_id, **params)` | `calling.play` | Yes |

--- a/rest/docs/namespaces.md
+++ b/rest/docs/namespaces.md
@@ -10,7 +10,7 @@ numbers = client.phone_numbers.list
 numbers = client.phone_numbers.list(name: 'Main')
 
 # Search available numbers to purchase
-available = client.phone_numbers.search(area_code: '512', number_type: 'local')
+available = client.phone_numbers.search(areacode: '512', number_type: 'local')
 
 # Purchase a number
 number = client.phone_numbers.create(number: '+15551234567')

--- a/rest/examples/rest_calling_ivr_and_ai.rb
+++ b/rest/examples/rest_calling_ivr_and_ai.rb
@@ -32,7 +32,7 @@ safe('Collect') do
   client.calling.collect(
     CALL_ID,
     digits: { 'max' => 4, 'terminators' => '#' },
-    play:   [{ 'type' => 'tts', 'text' => 'Enter your PIN followed by pound.' }]
+    play:   [{ 'type' => 'tts', 'params' => { 'text' => 'Enter your PIN followed by pound.' } }]
   )
 end
 safe('Start input timers') { client.calling.collect_start_input_timers(CALL_ID) }

--- a/rest/examples/rest_calling_play_and_record.rb
+++ b/rest/examples/rest_calling_play_and_record.rb
@@ -33,7 +33,7 @@ end
 # 2. Play TTS audio
 puts "\nPlaying TTS on call..."
 begin
-  client.calling.play(call_id, play: [{ 'type' => 'tts', 'text' => 'Welcome to SignalWire.' }])
+  client.calling.play(call_id, play: [{ 'type' => 'tts', 'params' => { 'text' => 'Welcome to SignalWire.' } }])
   puts '  Play started'
 rescue SignalWire::REST::SignalWireRestError => e
   puts "  Play failed (expected in demo): #{e.status_code}"
@@ -58,7 +58,7 @@ end
 # 4. Record the call
 puts "\nRecording call..."
 begin
-  client.calling.record(call_id, beep: true, format: 'mp3')
+  client.calling.record(call_id, audio: { 'format' => 'mp3', 'beep' => true })
   puts '  Recording started'
 rescue SignalWire::REST::SignalWireRestError => e
   puts "  Record failed (expected in demo): #{e.status_code}"

--- a/scripts/doc_wire_runner.rb
+++ b/scripts/doc_wire_runner.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# doc_wire_runner.rb — the DOC-WIRE fixture runner for signalwire-ruby.
+#
+# The DOC-WIRE gate (porting-sdk scripts/doc_wire.py) spawns mock_signalwire in
+# flag mode, exports MOCK_SIGNALWIRE_PORT, then runs THIS command; it then reads
+# the mock journal and fails on any wire_violations. Our job is only to DRIVE the
+# documented REST calls against the mock so the mock journals what the documented
+# fixtures actually put on the wire.
+#
+# We replay the REST calls shown in the README / rest quickstart + rest/docs +
+# rest/examples (the wire-bearing doc fixtures) — the exact kwargs the docs teach
+# — so a doc lie like area_code= (spec areacode) or a flat {type:tts,text} play
+# item shows up as a journaled violation and fails the gate. The blocking
+# agent/relay quickstarts are covered by EXAMPLES-RUN, not here.
+#
+# RestClient.new accepts base_url: directly, so we point it at the mock exactly
+# as tests/rest/mock_test.rb does.
+
+require 'base64'
+require 'securerandom'
+require_relative '../lib/signalwire/rest/rest_client'
+
+def build_client(base_url)
+  project = "test_proj_#{SecureRandom.hex(6)}"
+  SignalWire::REST::RestClient.new(
+    project: project, token: 'test_tok', base_url: base_url
+  )
+end
+
+def main
+  port = ENV.fetch('MOCK_SIGNALWIRE_PORT', nil)
+  if port.nil? || port.empty?
+    warn 'doc_wire_runner: MOCK_SIGNALWIRE_PORT not set'
+    return 2
+  end
+  base_url = ENV.fetch('SIGNALWIRE_MOCK_URL', "http://127.0.0.1:#{port}")
+  client = build_client(base_url)
+
+  call_id = 'call-doc-wire'
+
+  # --- README.md + examples/quickstart_rest.rb (region: rest) ----------------
+  client.fabric.ai_agents.create(name: 'Support Bot', prompt: { 'text' => 'You are helpful.' })
+  client.calling.play(call_id, play: [{ 'type' => 'tts', 'params' => { 'text' => 'Hello!' } }])
+  client.phone_numbers.search(areacode: '512')
+  client.datasphere.documents.search(query_string: 'billing policy')
+
+  # --- rest/README.md + rest/docs/namespaces.md phone-number search ----------
+  client.phone_numbers.search(areacode: '512', number_type: 'local')
+
+  # --- rest/docs/calling.md play (nested params:{text}) ----------------------
+  client.calling.play(call_id, play: [{ 'type' => 'tts', 'params' => { 'text' => 'Hello!' } }], volume: 5.0)
+
+  # --- rest/examples/rest_calling_play_and_record.rb + ivr_and_ai.rb ---------
+  client.calling.play(call_id, play: [{ 'type' => 'tts', 'params' => { 'text' => 'Welcome to SignalWire.' } }])
+  client.calling.play(call_id,
+                      play: [{ 'type' => 'tts', 'params' => { 'text' => 'Enter your PIN followed by pound.' } }])
+
+  # --- rest/README.md end + rest/docs/calling.md end/record ------------------
+  client.calling.record(call_id, audio: { 'format' => 'mp3', 'beep' => true })
+  client.calling.end(call_id, reason: 'hangup')
+
+  # --- rest/docs/calling.md live transcribe & translate (action:{start:{}}) --
+  client.calling.live_transcribe(call_id, action: { 'start' => { 'lang' => 'en-US' } })
+  client.calling.live_translate(call_id, action: { 'start' => { 'from_lang' => 'en-US', 'to_lang' => 'es-ES' } })
+
+  puts 'doc_wire_runner: replayed documented REST fixtures against the mock'
+  0
+end
+
+exit(main) if $PROGRAM_NAME == __FILE__

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -58,7 +58,13 @@ source "$PORTING_SDK_DIR/scripts/gate_scheduler.sh"
 
 cd "$PORT_ROOT"
 
+# Gate-enforcement plan (Part D): ruby's red list is burned, so its widened
+# (wave-A) gate findings BLOCK rather than report-only. Default OFF here; a
+# caller may still set SW_WAVE_A_REPORT_ONLY=1 to inspect the report-only view.
+export SW_WAVE_A_REPORT_ONLY="${SW_WAVE_A_REPORT_ONLY:-0}"
+
 echo "==> running CI gates for $PORT_NAME (porting-sdk at $PORTING_SDK_DIR)"
+echo "==> wave-A gate findings are ${SW_WAVE_A_REPORT_ONLY:+BLOCKING (SW_WAVE_A_REPORT_ONLY=$SW_WAVE_A_REPORT_ONLY)}"
 
 pick_free_port() {
     python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'
@@ -361,15 +367,52 @@ sched_gate COUNT-CLAIM desc="numeric doc claims (skills/namespaces) match realit
 sched_gate ACCESSOR-TRUTH desc="documented backtick method() refs exist in source" \
     -- python3 "$PORTING_SDK_DIR/scripts/accessor_truth.py" --port ruby --repo "$PORT_ROOT"
 
+# DOC-WIRE (§A1) — the documented REST doc fixtures are wire-clean against the
+# spec (strict-flag mock journals wire_violations; the runner replays the exact
+# doc calls). Cheap → per-PR tier. The runner drives the wire-bearing REST doc
+# fixtures (README/rest quickstart + rest/docs + rest/examples) so a doc lie like
+# area_code (spec areacode), a flat {type:tts,text} play item, or flat record
+# beep/format shows up as a journaled violation and fails the gate.
+sched_gate DOC-WIRE desc="documented REST doc fixtures put the spec wire shape on the wire (areacode/params:{text}/audio:{})" \
+    -- python3 "$PORTING_SDK_DIR/scripts/doc_wire.py" --port ruby --repo "$PORT_ROOT" \
+        --runner "ruby $PORT_ROOT/scripts/doc_wire_runner.rb"
+
+# STATUS-CLAIM (§C2) — no false capability/status claims in docs (e.g. "not
+# implemented" / "transport pending" for surface that exists). Cheap → per-PR.
+sched_gate STATUS-CLAIM desc="doc status/capability claims match the shipped surface" \
+    -- python3 "$PORTING_SDK_DIR/scripts/status_claim.py" --port ruby --repo "$PORT_ROOT" \
+        --surface "$PORTING_SDK_DIR/python_surface.json"
+
+# NOTE: §1.11b (GATE-INVENTORY freshness) is intentionally NOT wired here.
+# gen_gate_inventory.py resolves its reference port as a SIBLING checkout
+# (DEFAULT_REFERENCE=signalwire-typescript), which does not exist in a port's CI
+# layout (porting-sdk is a subdir of the port workspace, so ../signalwire-
+# typescript is absent → exit 2). The check is inherently porting-sdk-side and
+# already runs in porting-sdk's own CI (.github/workflows/test.yml). Wiring it
+# per-port would require each port to also check out the TS reference — not worth it.
+
 # SNIPPET-RUN is BLOCKING: every runnable ruby doc snippet must execute to a zero
 # exit against the mock. Non-runnable blocks carry a `<!-- snippet: no-run … -->`
 # (or no-compile) marker; credential/live-network cases are ledgered in
-# SNIPPET_RUN_ALLOW.md. Backlog burned to 0.
-sched_gate SNIPPET-RUN tier=nightly defer=1 desc="dynamic-port doc snippets run to a zero exit against the mock" \
-    -- python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port ruby --repo "$PORT_ROOT"
+# SNIPPET_RUN_ALLOW.md. Backlog burned to 0. STRICT-MOCKS (§2.x): MOCK_RELAY_STRICT=1
+# makes the mock reject unknown wire keys/frames so a snippet that puts a bad shape
+# on the wire fails here (nightly, where the heavy mock-backed execution runs).
+sched_gate SNIPPET-RUN tier=nightly defer=1 desc="dynamic-port doc snippets run to a zero exit against the mock (STRICT-MOCKS: MOCK_RELAY_STRICT=1)" \
+    -- env MOCK_RELAY_STRICT=1 python3 "$PORTING_SDK_DIR/scripts/snippet_run.py" --port ruby --repo "$PORT_ROOT"
 
-sched_gate EXAMPLES-RUN tier=nightly defer=1 desc="shipped examples load/start against the mock (modulo EXAMPLES_RUN_ALLOW.md)" \
-    -- python3 "$PORTING_SDK_DIR/scripts/examples_run.py" --port ruby --repo "$PORT_ROOT"
+sched_gate EXAMPLES-RUN tier=nightly defer=1 desc="shipped examples load/start against the mock (modulo EXAMPLES_RUN_ALLOW.md; STRICT-MOCKS: MOCK_RELAY_STRICT=1)" \
+    -- env MOCK_RELAY_STRICT=1 python3 "$PORTING_SDK_DIR/scripts/examples_run.py" --port ruby --repo "$PORT_ROOT"
+
+# WAIT-LIVENESS (§2.4) — the RELAY Action#wait() liveness contract: wait() BLOCKS
+# until the deferred completing event arrives, then returns with the finished
+# state (never a no-op that returns at t~=0, never a hang). bin/wait-liveness-dump
+# drives the corpus against a real mock_relay with the completing event armed as a
+# delay_ms scenario, prints the classification per case; the differ builds the
+# python golden and compares. Nightly (spawns a mock + the dump; needs the
+# signalwire-python oracle, present in nightly).
+sched_gate WAIT-LIVENESS tier=nightly defer=1 desc="RELAY Action#wait() blocks-until-event liveness matches the python golden" \
+    -- python3 "$PORTING_SDK_DIR/scripts/diff_port_wait_liveness.py" --port ruby \
+        --dump-cmd "bundle exec ruby $PORT_ROOT/bin/wait-liveness-dump"
 
 # ---- §G anti-laundering ledger + §D1 packaging -------------------------------
 sched_gate SUPPRESSION-LEDGER res=dayone desc="no un-ledgered analyzer suppressions (rubocop:disable) outside the ledger" \


### PR DESCRIPTION
Ruby's single PR for the cross-port gate-enforcement plan. Python reference already merged (flat-tts fixed there; no oracle regen needed).

## Part A — flat-tts ripple

Server + spec both require the play `text` INSIDE `params`. Fixed 6 sites `{type:'tts', text:…}` → `{type:'tts', params:{text:…}}`:

- `README.md`, `examples/quickstart_rest.rb`, `rest/README.md`, `rest/docs/calling.md`, `rest/examples/rest_calling_play_and_record.rb`, `rest/examples/rest_calling_ivr_and_ai.rb`.
- (`README.md`'s RELAY `call.play` media was already `params`-nested.)

## Part B — Wave-B doc red-list burn (fixed real; no mass-allowlist)

**`end`/`end_call` reconciliation.** The REST namespace's real blessed method is `Calling#end` — `def end` is valid Ruby and it is **parity-equal** to the python oracle `CallingNamespace.end` (the port enumerator records `Calling.methods.end`; DRIFT is clean). There is no `end_call` anywhere. So:
- Deleted `PORT_OMISSIONS.md:310` — it was **doubly false**: `end` IS implemented (not omitted) and the port has no `end_call`.
- Removed the phantom `CallingNamespace.end_call` from `PORT_ADDITIONS.md` (kept the genuine `Call.pass_call`/`Call.tap_audio` keyword renames; noted `end` needs no workaround).
- Fixed the docs (`rest/README.md`, `rest/docs/calling.md`) to reference `end`.
- (The SWAIG native-function `end_call` in `docs/api_reference.md` `toggle_functions` is unrelated and correctly left as-is.)

**count_claim (2 reds).** Reworded bare namespace counts the gate structurally cannot measure for ruby's collapsed `generated/` layout (its ns glob `lib/**/rest/namespaces/*.rb` matches 1 file). `README.md`/`examples/README.md`/`CHECKLIST.md` — one claim (`12 namespaces` for `rest/examples`) was also inaccurate. Green in both report-only and blocking modes.

**DOC-WIRE §2.1.** `live_translate`/`live_transcribe` docs corrected from flat top-level params to the spec wire shape `action:{start:{…}}` (`rest/docs/calling.md`).

**Two more real wire bugs** surfaced building the DOC-WIRE runner: `area_code`→`areacode` (`rest/docs/namespaces.md`) and `record(beep:,format:)` flat→`audio:{format,beep}` nesting (`rest/README.md`, `rest/examples/rest_calling_play_and_record.rb`).

**audit_docs widened perimeter.** Ledgered `contains` (an illustrative BANNED anti-pattern in `CHECKLIST.md` prose — `err.contains("not available")` — not a SignalWire API) in `DOC_AUDIT_IGNORE.md`.

## Part C — wire the quartet at the right tier

| gate | tier | how |
|---|---|---|
| DOC-WIRE | per-PR | new `scripts/doc_wire_runner.rb` replays the wire-bearing REST doc fixtures against the flag-mode mock (12 requests, 0 violations) |
| STATUS-CLAIM | per-PR | `status_claim.py --surface python_surface.json` |
| STRICT-MOCKS | nightly | `env MOCK_RELAY_STRICT=1` on SNIPPET-RUN + EXAMPLES-RUN |
| WAIT-LIVENESS | nightly | new `bin/wait-liveness-dump` drives the corpus against a real `mock_relay` with the completing event armed as a `delay_ms` scenario; proves `Action#wait()` blocks-until-event then returns (matches the python golden) |

- **GATE-INVENTORY intentionally NOT wired** — porting-sdk-side; resolves its reference as a sibling `signalwire-typescript` checkout absent in port CI (→ exit 2). NOTE added; it already runs in porting-sdk's own CI.
- **Burned the newly-wired red list:** SNIPPET-RUN's stale allowlist LINE (README quickstart drifted +12 lines: rest `154→166`, relay `119→131`) re-synced in `SNIPPET_RUN_ALLOW.md`.

`bin/wait-liveness-dump` + `scripts/doc_wire_runner.rb` are rubocop-excluded like the other `bin/*-dump` cross-port tooling (tutorial-style, not audited library surface); GEN-IDIOM + SUPPRESSION-LEDGER stay clean.

## Part D — flip to blocking

`export SW_WAVE_A_REPORT_ONLY="${SW_WAVE_A_REPORT_ONLY:-0}"` in `scripts/run-ci.sh` (mirrors python).

## Verification

Full `run-ci.sh` per-PR tier: **all gates PASS** except SEMVER-DIFF (below). Nightly: **WAIT-LIVENESS PASS**; **SNIPPET-RUN + EXAMPLES-RUN clean under STRICT-MOCKS** (34 examples ran, 0 crashed; the 12 "port-in-use" skips were a concurrent sibling `examples_run`, not example bugs). rubocop full-tree clean; TEST/FMT/LINT/REST-COVERAGE/SPEC-PARITY all PASS.

## ⚠️ One blocker needs human sign-off — NOT fixed here

**SEMVER-DIFF item-1.9 baseline anchor.** Under the Part D flip, `semver_diff.py`'s wave-A finding blocks: `port_signatures.baseline.json` has no `generated_from_tag`/`tag_sha` header, and **no `v3.x` release tag exists** to anchor to (ruby's tags stop at `v2.0.0`; the baseline captures the 3.0.2 surface). The **surface diff itself is clean** — `3.0.2 → 3.2.0`, actual bump `minor`, required `minor` `[ok]` (the 8 additions are the already-merged Messages/Projects work).

This is a **cross-port design tension**, not a ruby-specific defect:
- The 2026-07-13 user decision made the baseline a committed FILE **explicitly decoupled from git tags**; item 1.9 later requires a resolvable tag anchor. These contradict for any port without a matching 3.x tag.
- `cpp` and `dotnet` baselines lack the anchor identically.

Fixing it needs either a **release-tag action** (tag the 3.0.2 release — a publish action requiring approval; I do not push release tags autonomously) or a **porting-sdk decision** to reconcile item 1.9 with the decoupled-baseline design. I did **not** fake an anchor or allowlist it to go green. **Please advise.**

## Do NOT merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
