### PR TITLE
fix(relay): read SIGNALWIRE_JWT_TOKEN env var (doc-gate perimeter reconcile)

### DIFF
--- a/lib/signalwire/relay/client.rb
+++ b/lib/signalwire/relay/client.rb
@@ -65,6 +65,7 @@ module SignalWire
       # @param project [String, nil] project ID (env: SIGNALWIRE_PROJECT_ID)
       # @param token [String, nil] API token (env: SIGNALWIRE_API_TOKEN)
       # @param jwt_token [String, nil] JWT token alternative
+      #   (env: SIGNALWIRE_JWT_TOKEN)
       # @param host [String, nil] RELAY host (env: SIGNALWIRE_SPACE).
       #   Either a bare space subdomain (``myspace``) or full hostname
       #   (``myspace.signalwire.com``).
@@ -76,7 +77,7 @@ module SignalWire
       def initialize(project: nil, token: nil, jwt_token: nil, host: nil,
                      contexts: ['default'], max_active_calls: nil,
                      space: nil)
-        @jwt_token  = jwt_token
+        @jwt_token  = value_or_env(jwt_token, 'SIGNALWIRE_JWT_TOKEN')
         @contexts   = contexts
         @max_active_calls = resolve_max_active_calls(max_active_calls)
         resolve_credentials(project, token, host, space)
@@ -116,8 +117,17 @@ module SignalWire
       end
 
       def validate_credentials
+        # JWT auth (env: SIGNALWIRE_JWT_TOKEN or the jwt_token: kwarg) is a
+        # self-contained alternative to project/token — the project id lives
+        # inside the token, so only the host is still required. Mirrors the
+        # Python reference's truthiness check (an empty jwt_token is no token).
+        unless jwt_token.empty?
+          raise ArgumentError, 'host is required' if space.empty?
+
+          return
+        end
         raise ArgumentError, 'project is required' if project_id.empty?
-        raise ArgumentError, 'token or jwt_token is required' if token.empty? && jwt_token.nil?
+        raise ArgumentError, 'token or jwt_token is required' if token.empty?
         raise ArgumentError, 'host is required' if space.empty?
       end
 
@@ -579,7 +589,10 @@ module SignalWire
       end
 
       def apply_auth_credentials(params)
-        if jwt_token
+        # An unset jwt_token is the empty string (env fallback), not nil — and
+        # in Ruby '' is truthy, so guard on emptiness to match Python's
+        # truthiness check (`if self.jwt_token:`).
+        unless jwt_token.empty?
           params['authentication'] = { 'jwt_token' => jwt_token }
           return
         end

--- a/tests/relay/client_dial_test.rb
+++ b/tests/relay/client_dial_test.rb
@@ -13,7 +13,9 @@ class RelayClientDialTest < Minitest::Test
     assert defined?(SignalWire::Relay::Client)
   end
 
-  CREDENTIAL_ENV_VARS = %w[SIGNALWIRE_PROJECT_ID SIGNALWIRE_API_TOKEN SIGNALWIRE_SPACE].freeze
+  CREDENTIAL_ENV_VARS = %w[
+    SIGNALWIRE_PROJECT_ID SIGNALWIRE_API_TOKEN SIGNALWIRE_SPACE SIGNALWIRE_JWT_TOKEN
+  ].freeze
 
   def test_client_requires_credentials
     without_credential_env do
@@ -22,13 +24,49 @@ class RelayClientDialTest < Minitest::Test
     end
   end
 
-  # Clear the credential env vars for the duration of the block, restoring
-  # any previously-set values afterward.
+  # SIGNALWIRE_JWT_TOKEN is a documented auth knob (relay/README.md, the
+  # client reference, getting-started): jwt_token falls back to it, and JWT
+  # auth is a self-contained alternative to project+token. Mirrors the Python
+  # reference (`self.jwt_token = jwt_token or os.environ["SIGNALWIRE_JWT_TOKEN"]`).
+  # without_credential_env clears SIGNALWIRE_JWT_TOKEN too, so a value set
+  # inside the block is restored (deleted) on exit — no inline teardown needed.
+  def test_jwt_token_env_var_fallback_satisfies_credentials
+    without_credential_env do
+      ENV['SIGNALWIRE_JWT_TOKEN'] = 'env-jwt-eyJ.aaa.bbb'
+      # No project/token needed: the JWT env var alone satisfies validation.
+      client = SignalWire::Relay::Client.new(space: 'example.signalwire.com')
+      params = auth_params(client)
+
+      assert_equal({ 'jwt_token' => 'env-jwt-eyJ.aaa.bbb' }, params['authentication'])
+    end
+  end
+
+  # An explicit jwt_token: kwarg wins over the env var.
+  def test_jwt_token_kwarg_overrides_env
+    without_credential_env do
+      ENV['SIGNALWIRE_JWT_TOKEN'] = 'env-jwt'
+      client = SignalWire::Relay::Client.new(
+        jwt_token: 'explicit-jwt', space: 'example.signalwire.com'
+      )
+
+      assert_equal({ 'jwt_token' => 'explicit-jwt' }, auth_params(client)['authentication'])
+    end
+  end
+
+  # Drive the private auth-frame builder to read the resolved credentials.
+  def auth_params(client)
+    {}.tap { |params| client.send(:apply_auth_credentials, params) }
+  end
+
+  # Clear the credential env vars for the duration of the block, then fully
+  # restore the prior state afterward. Full restore matters because a block may
+  # SET one of these vars (e.g. the JWT-fallback tests): a var that was absent
+  # before the block must be deleted again, not left leaking into later tests.
   def without_credential_env
     saved = CREDENTIAL_ENV_VARS.to_h { |k| [k, ENV.delete(k)] }
     yield
   ensure
-    saved.each { |k, v| ENV[k] = v if v }
+    saved.each { |k, v| v.nil? ? ENV.delete(k) : ENV.store(k, v) }
   end
 
   def test_client_creation_with_options


### PR DESCRIPTION
## Why

porting-sdk hygiene PR #99 widens the doc-gate perimeter (`accessor_truth` / `doc_env` now read ALL tracked markdown). With the widened perimeter, `doc_env.py --port ruby` flags:

> `SIGNALWIRE_JWT_TOKEN` documented but never read by the SDK

## Finding → truth-in-source

The RELAY docs (`relay/README.md`, `relay/docs/client-reference.md`, `relay/docs/getting-started.md`) all promise `jwt_token` falls back to the `SIGNALWIRE_JWT_TOKEN` env var. The **Python reference does exactly that**:

```python
self.jwt_token = jwt_token or os.environ.get("SIGNALWIRE_JWT_TOKEN", "")
```

The Ruby client stored only the kwarg (`@jwt_token = jwt_token`) with **no env fallback**. So the doc was correct and the **SDK had a real Python-parity gap** — it ignored a knob three docs promise. Per RULES.md (match Python's functionality), the fix is to make the code read the var, not to delete the doc.

## Fix

- Wire the env fallback via the existing `value_or_env` helper: `@jwt_token = value_or_env(jwt_token, 'SIGNALWIRE_JWT_TOKEN')`.
- That makes an unset `jwt_token` the empty string, not `nil` — and `''` is truthy in Ruby. Fixed the two truthiness sites to guard on `.empty?`, matching Python's `if self.jwt_token:`:
  - `validate_credentials` — a JWT alone now satisfies auth (project/token no longer required), as in Python.
  - `apply_auth_credentials` — only emit `jwt_token` authentication when it's actually present (previously an empty-string jwt would wrongly send `{jwt_token: ""}` instead of project/token).
- Fixed the test helper `without_credential_env` to fully restore env (delete keys absent before the block) so a test that SETS a credential var can't leak it into later tests.

Added two tests covering the documented behavior: JWT env-var fallback satisfies credentials, and an explicit `jwt_token:` kwarg overrides the env var.

## Verification (ruby, pr tier)

- `doc_env.py --port ruby` → clean (was 1 finding)
- `accessor_truth.py --port ruby` → clean
- DRIFT → 0 (no surface change; `port_signatures.json` unchanged)
- Full test suite → 2483 runs, 0 failures, 0 errors
- FMT `--check` / LINT → 0 offenses
- `audit_no_cheat_tests` → clean

Unblocks porting-sdk #99 landing green for the ruby lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqshDQajCmDHD3xPo4CXMC
