### PR TITLE
ci: unpin porting-sdk checkout back to main (post-merge)

### DIFF
--- a/.github/workflows/multi-os.yml
+++ b/.github/workflows/multi-os.yml
@@ -63,7 +63,7 @@ jobs:
           path: porting-sdk
           # Plan window: depends on porting-sdk plan-branch gate engines. REVERT
           # to main (drop this ref:) when plan/a-bar-2026-07-18 merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 
       - name: Set up Ruby

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,7 +88,7 @@ jobs:
           path: porting-sdk
           # Plan window: depends on porting-sdk plan-branch gate engines. REVERT
           # to main (drop this ref:) when plan/a-bar-2026-07-18 merges.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 
       # The EMISSION gate compares this port's to_dict() output against the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           # check_wired_modes.py) that live on porting-sdk's plan branch, not yet
           # on main. REVERT to main (drop this ref:) when plan/a-bar-2026-07-18
           # merges to porting-sdk main.
-          ref: plan/a-bar-2026-07-18
+          ref: main
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 
       # The EMISSION gate compares this port's to_dict() output against the


### PR DESCRIPTION
The `plan/a-bar-2026-07-18` branch merged and was deleted; workflows still pinned to it fail at the porting-sdk checkout step (gone branch), reddening main CI. Reverts all pins to `ref: main` per the REVERT-on-merge comments. Same mechanical fix as perl #50 / porting-sdk #106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqhUoqrbptHNS3cypq9s6t