### PR TITLE
ci: unpin porting-sdk checkout to main (post-merge)

### DIFF
--- a/.github/workflows/multi-os.yml
+++ b/.github/workflows/multi-os.yml
@@ -64,7 +64,7 @@ jobs:
           # PINNED to wave/1-aplus: the Wave-1 gate engines + the mcp_gateway client-skill
           # oracle (MCPGatewaySkill) + request_options oracle live there.
           # REVERT to main (drop this ref:) when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 
       - name: Set up Ruby

--- a/.github/workflows/surface-audit.yml
+++ b/.github/workflows/surface-audit.yml
@@ -42,7 +42,7 @@ jobs:
           # PINNED to wave/1-aplus: the mcp_gateway client-skill surface (+ request_options
           # oracle) lives there; against main the symbol-parity check misses MCPGatewaySkill.
           # REVERT to main (drop this ref:) when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           # main yet, so main makes BEHAVIORAL crash on unknown-rule and SEMVER/
           # DRIFT diff against a stale oracle.
           # REVERT to main (drop this ref:) when porting-sdk wave/1-aplus merges.
-          ref: wave/1-aplus
+          ref: main
           token: ${{ secrets.PORTING_SDK_TOKEN }}
 
       # The EMISSION gate compares this port's to_dict() output against the


### PR DESCRIPTION
Wave 1 merged; wave/1-aplus deleted. Revert workflow pins to `ref: main`. 0 residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)