### PR TITLE
ci(live-smoke): fix invalid secrets-in-step-if (workflow never ran)

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   live-smoke:
     runs-on: ubuntu-latest
+    env:
+      HAS_CREDS: ${{ secrets.SIGNALWIRE_TEST_TOKEN }}
     steps:
       - name: Checkout signalwire-ruby
         uses: actions/checkout@v7
@@ -33,7 +35,7 @@ jobs:
       # secrets → the step is skipped and the job stays green (no false red on
       # forks / un-provisioned repos).
       - name: Live smoke against the real platform
-        if: ${{ secrets.SIGNALWIRE_TEST_TOKEN != '' }}
+        if: ${{ env.HAS_CREDS != '' }}
         env:
           SWSDK_LIVE_TESTS: '1'
           SIGNALWIRE_PROJECT_ID: ${{ secrets.SIGNALWIRE_TEST_PROJECT }}
@@ -42,5 +44,5 @@ jobs:
         run: ruby scripts/live_smoke.rb
 
       - name: No secrets — live smoke skipped
-        if: ${{ secrets.SIGNALWIRE_TEST_TOKEN == '' }}
+        if: ${{ env.HAS_CREDS == '' }}
         run: echo "SIGNALWIRE_TEST_TOKEN not configured; live smoke skipped (green)."


### PR DESCRIPTION
`if: ${{ secrets.SIGNALWIRE_TEST_TOKEN != '' }}` at step level is invalid GHA (secrets aren't in the step `if:` context), so the live-smoke workflow was rejected — 0 jobs, 'workflow file issue' — on every run. Fixed by mapping the secret to a job-level `env: HAS_CREDS` and gating steps on `env.HAS_CREDS`. actionlint clean; the lane now parses and skips cleanly when the secret is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)