### PR TITLE
feat(ai-chat): port the SignalWire AI Chat client to Ruby

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,7 @@ AllCops:
     - 'bin/relay-liveness-dump'
     - 'bin/pagination-dump'
     - 'bin/secret-scrub-dump'
+    - 'bin/ai-chat-dump'
     # Cross-port gate fixture-replay tooling, same category as the bin/*-dump
     # programs above: doc_wire_runner.rb only DRIVES the documented REST calls
     # against the DOC-WIRE flag-mode mock so it journals the wire shape. Not
@@ -135,6 +136,11 @@ Metrics/ClassLength:
     # drop those methods from the enumerated surface and break DRIFT (same
     # rationale as the classes below).
     - 'lib/signalwire/rest/http_client.rb'
+    # AI Chat client: its 6 public methods (create_conversation / chat / end /
+    # delete / log / summarize) + the JSON-RPC wire path ARE the cross-port
+    # parity surface, 1:1 with signalwire.ai_chat.AIChatClient. Same
+    # surface-bearing-unit rationale as http_client.rb above.
+    - 'lib/signalwire/ai_chat/client.rb'
     # 1:1 parity classes ported from the Python core.* modules whose public
     # method surface IS the cross-port parity contract (config_loader.py 266
     # lines / security_config.py 390 lines). Same surface-bearing-unit

--- a/PORT_OMISSIONS.md
+++ b/PORT_OMISSIONS.md
@@ -70,7 +70,6 @@ port surface; the diff tool will fail the build on unexcused drift.
 
 signalwire.ai_chat.client.AIChatClient.__aenter__: impossible: Python async-context-manager protocol dunder; Ruby's AIChatClient is stateless per-request (Net::HTTP, no persistent aiohttp session to enter) — no __aenter__ equivalent (mirrors RelayClient.__aenter__; TS/PHP omit identically)
 signalwire.ai_chat.client.AIChatClient.__aexit__: impossible: Python async-context-manager protocol dunder; Ruby's AIChatClient holds no persistent session to exit/close (Net::HTTP is per-request) — no __aexit__ equivalent (mirrors RelayClient.__aexit__; TS/PHP omit identically)
-signalwire.ai_chat.client.AIChatClient.close: impossible: closes the reference's persistent aiohttp session; Ruby's AIChatClient opens a fresh Net::HTTP connection per request and owns no long-lived session, so there is nothing to close — no ruby analog
 signalwire.cli.build_search.console_entry_point: Ruby SDK does not ship a CLI; Python CLI is a separate tool
 signalwire.cli.build_search.main: Ruby SDK does not ship a CLI; Python CLI is a separate tool
 signalwire.cli.build_search.migrate_command: Ruby SDK does not ship a CLI; Python CLI is a separate tool

--- a/PORT_OMISSIONS.md
+++ b/PORT_OMISSIONS.md
@@ -68,6 +68,9 @@ port surface; the diff tool will fail the build on unexcused drift.
 
 # Omitted symbols
 
+signalwire.ai_chat.client.AIChatClient.__aenter__: impossible: Python async-context-manager protocol dunder; Ruby's AIChatClient is stateless per-request (Net::HTTP, no persistent aiohttp session to enter) — no __aenter__ equivalent (mirrors RelayClient.__aenter__; TS/PHP omit identically)
+signalwire.ai_chat.client.AIChatClient.__aexit__: impossible: Python async-context-manager protocol dunder; Ruby's AIChatClient holds no persistent session to exit/close (Net::HTTP is per-request) — no __aexit__ equivalent (mirrors RelayClient.__aexit__; TS/PHP omit identically)
+signalwire.ai_chat.client.AIChatClient.close: impossible: closes the reference's persistent aiohttp session; Ruby's AIChatClient opens a fresh Net::HTTP connection per request and owns no long-lived session, so there is nothing to close — no ruby analog
 signalwire.cli.build_search.console_entry_point: Ruby SDK does not ship a CLI; Python CLI is a separate tool
 signalwire.cli.build_search.main: Ruby SDK does not ship a CLI; Python CLI is a separate tool
 signalwire.cli.build_search.migrate_command: Ruby SDK does not ship a CLI; Python CLI is a separate tool

--- a/PORT_SIGNATURE_OMISSIONS.md
+++ b/PORT_SIGNATURE_OMISSIONS.md
@@ -56,10 +56,6 @@ signalwire.relay.client.RelayClient.on_call: kwargs-idiom — Ruby keyword args 
 signalwire.relay.client.RelayClient.on_message: kwargs-idiom — Ruby keyword args ≡ Python positional with default
 signalwire.rest.client.RestClient.__init__: kwargs-idiom — Ruby keyword constructor ≡ Python positional with default
 
-# Python-only aiohttp session-injection param (no Ruby analog)
-
-signalwire.ai_chat.client.AIChatClient.__init__: impossible — the reference's 5th param `session: aiohttp.ClientSession | None = None` injects a shared aiohttp connection-pool session; Ruby's AIChatClient uses Net::HTTP with a fresh per-request connection (no injectable session object), so it exposes no `session` param. Optional in the reference (default None), so callers never need it; Ruby instead trails its own optional `connect_timeout`/`read_idle_timeout` idioms (mirrors RelayClient's Python-only DI params). NEEDS HUMAN APPROVAL.
-
 # from_payload classmethod — Ruby static method has no explicit cls receiver
 
 

--- a/PORT_SIGNATURE_OMISSIONS.md
+++ b/PORT_SIGNATURE_OMISSIONS.md
@@ -56,6 +56,10 @@ signalwire.relay.client.RelayClient.on_call: kwargs-idiom — Ruby keyword args 
 signalwire.relay.client.RelayClient.on_message: kwargs-idiom — Ruby keyword args ≡ Python positional with default
 signalwire.rest.client.RestClient.__init__: kwargs-idiom — Ruby keyword constructor ≡ Python positional with default
 
+# Python-only aiohttp session-injection param (no Ruby analog)
+
+signalwire.ai_chat.client.AIChatClient.__init__: impossible — the reference's 5th param `session: aiohttp.ClientSession | None = None` injects a shared aiohttp connection-pool session; Ruby's AIChatClient uses Net::HTTP with a fresh per-request connection (no injectable session object), so it exposes no `session` param. Optional in the reference (default None), so callers never need it; Ruby instead trails its own optional `connect_timeout`/`read_idle_timeout` idioms (mirrors RelayClient's Python-only DI params). NEEDS HUMAN APPROVAL.
+
 # from_payload classmethod — Ruby static method has no explicit cls receiver
 
 

--- a/bin/ai-chat-dump
+++ b/bin/ai-chat-dump
@@ -1,0 +1,141 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) 2026 SignalWire
+#
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+
+#
+# ai-chat-dump — the Ruby port's AI-CHAT dump program for the cross-port
+# wire-behavioral gate (porting-sdk/scripts/diff_port_ai_chat.py, on the
+# `ai-chat-client` branch — a COORDINATED pass).
+#
+# The gate boots the in-process mock_ai_chat server, exports MOCK_AI_CHAT_URL +
+# SIGNALWIRE_PROJECT_ID / SIGNALWIRE_API_TOKEN into this program's env, runs it,
+# and asserts the JSON it prints (+ the wire requests the mock recorded) speak the
+# AI Chat protocol per the vendored spec (ai-chat-specs/ai-chat.yaml).
+#
+# This mirrors porting-sdk/scripts/ai_chat_dump_reference.py EXACTLY: it drives the
+# Ruby AIChatClient through the shared ai_chat_corpus and emits ONE JSON object to
+# stdout (nothing else), keyed by corpus step:
+#
+#   success steps (create/chat/end/delete/log/summarize):
+#       { wire_method, decoded: { <spec result fields> } }
+#   summarize_failed (the summarize {error} one_of branch — must SURFACE, not swallow):
+#       { wire_method:"summarize", raised:true, error_type, message }
+#   error steps (err_notfound/err_ratelimit/err_inprogress/err_auth/err_unmapped):
+#       { raised:true, error_code, error_type }
+#
+# The corpus (steps + SUMMARIZE_ERROR_ID + ERROR_STEPS + force_error_id) is data,
+# identical for every language; it is mirrored inline here from ai_chat_corpus.py.
+#
+# Run from the signalwire-ruby repo root against a running mock:
+#
+#   MOCK_AI_CHAT_URL=http://127.0.0.1:PORT/api/ai/chat ruby bin/ai-chat-dump
+#
+# Nothing but the JSON object is written to stdout on success.
+
+require 'json'
+
+# Keep stdout PURE JSON: the gate does json.loads(proc.stdout), so any stray byte
+# written to stdout during require/setup (a gem notice, a banner, a logger that
+# lands on stdout) corrupts the parse. Point $stdout at stderr for setup, restore
+# only to emit the final JSON.
+REAL_STDOUT = $stdout.dup
+$stdout.reopen($stderr)
+
+require_relative '../lib/signalwire/ai_chat'
+
+# ── the shared corpus (mirror of porting-sdk/scripts/ai_chat_corpus.py) ──────
+
+# The sentinel conversation id that makes summarize return its {error} branch.
+SUMMARIZE_ERROR_ID = '__summarize_error'
+
+# error step id -> the JSON-RPC code the port's raised error MUST carry.
+ERROR_STEPS = {
+  'err_notfound' => -32_001,   # ConversationNotFound
+  'err_ratelimit' => -32_005,  # RateLimit
+  'err_inprogress' => -32_007, # ChatInProgress
+  'err_auth' => -32_009,       # Authentication
+  'err_unmapped' => -32_602    # base AIChatError (unmapped code)
+}.freeze
+
+# The sentinel conversation id that makes the mock return <code>.
+def force_error_id(code)
+  "__err_#{code}"
+end
+
+def run(url)
+  out = {}
+  client = SignalWire::AIChatClient.new(url: url)
+
+  # ── success steps ──────────────────────────────────────────────────
+  info = client.create_conversation('conv-1', config_url: 'http://cfg', timeout: 30, reinit: true)
+  out['create'] = {
+    'wire_method' => 'create_conversation',
+    'decoded' => { 'status' => info.status, 'id' => info.id, 'initial_message' => info.initial_message }
+  }
+
+  reply = client.chat('conv-1', 'hello', timeout: 30, reinit: true)
+  out['chat'] = {
+    'wire_method' => 'chat',
+    'decoded' => { 'response' => reply.text, 'user_event' => reply.user_event }
+  }
+
+  # end/delete return bool idiomatically; the wire result also carries the
+  # conversation id (the caller's own input, echoed). Report both the derived
+  # status and the id operated on — mirroring the reference dump.
+  ended = client.end('conv-1')
+  out['end'] = {
+    'wire_method' => 'end_conversation',
+    'decoded' => { 'status' => ended ? 'ended' : '?', 'id' => 'conv-1' }
+  }
+
+  deleted = client.delete('conv-1')
+  out['delete'] = {
+    'wire_method' => 'delete',
+    'decoded' => { 'status' => deleted ? 'deleted' : '?', 'id' => 'conv-1' }
+  }
+
+  chat_log = client.log('conv-1')
+  out['log'] = {
+    'wire_method' => 'chat_log',
+    'decoded' => { 'chat_log' => chat_log.messages, 'call_timeline' => chat_log.call_timeline }
+  }
+
+  summary = client.summarize('conv-1')
+  out['summarize'] = { 'wire_method' => 'summarize', 'decoded' => { 'summary' => summary } }
+
+  # ── summarize one_of {error} branch: must SURFACE, not swallow ───────
+  begin
+    swallowed = client.summarize(SUMMARIZE_ERROR_ID)
+    out['summarize_failed'] = {
+      'wire_method' => 'summarize', 'raised' => false, 'decoded' => { 'summary' => swallowed }
+    }
+  rescue SignalWire::AIChat::SummaryError => e
+    out['summarize_failed'] = {
+      'wire_method' => 'summarize', 'raised' => true,
+      'error_type' => e.class.name.split('::').last, 'message' => e.server_message
+    }
+  end
+
+  # ── error-code steps (JSON-RPC error object) ─────────────────────────
+  ERROR_STEPS.each do |step, code|
+    client.chat(force_error_id(code), 'x')
+    out[step] = { 'raised' => false }
+  rescue SignalWire::AIChat::AIChatError => e
+    out[step] = { 'raised' => true, 'error_code' => e.code, 'error_type' => e.class.name.split('::').last }
+  end
+
+  out
+end
+
+url = ENV.fetch('MOCK_AI_CHAT_URL', nil)
+if url.nil? || url.empty?
+  warn 'MOCK_AI_CHAT_URL not set'
+  exit 2
+end
+
+output = run(url)
+REAL_STDOUT.puts(JSON.generate(output))

--- a/lib/signalwire/ai_chat.rb
+++ b/lib/signalwire/ai_chat.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2026 SignalWire
+#
+# This file is part of the SignalWire SDK.
+#
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+
+# Public entry point for the SignalWire AI Chat client:
+#
+#   require 'signalwire/ai_chat'
+#   client = SignalWire::AIChatClient.new(space: 'myspace')
+#
+# Loads the client, its typed error family (SignalWire::AIChat::AIChatError and
+# subclasses), and its response models (ConversationInfo/ChatResponse/ChatLog).
+require_relative 'ai_chat/client'

--- a/lib/signalwire/ai_chat/client.rb
+++ b/lib/signalwire/ai_chat/client.rb
@@ -191,6 +191,13 @@ module SignalWire
             'or provide space: / SIGNALWIRE_SPACE.'
     end
 
+    # Release any client-held resources. The reference closes its persistent
+    # aiohttp session here; Ruby's AIChatClient opens a fresh Net::HTTP
+    # connection per request and owns no long-lived session, so there is nothing
+    # to release — this is a well-defined no-op that completes the lifecycle
+    # contract (mirrors the reference #close). Safe to call any number of times.
+    def close; end
+
     # ── API methods ──────────────────────────────────────────────────
 
     # Create a conversation (or, with +reinit+, reinitialize an existing one) and

--- a/lib/signalwire/ai_chat/client.rb
+++ b/lib/signalwire/ai_chat/client.rb
@@ -1,0 +1,364 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2026 SignalWire
+#
+# This file is part of the SignalWire SDK.
+#
+# Licensed under the MIT License.
+# See LICENSE file in the project root for full license information.
+
+require 'net/http'
+require 'json'
+require 'uri'
+require 'base64'
+require_relative '../version'
+require_relative '../error'
+
+module SignalWire
+  # Namespace holding the AI Chat client's error family and response models.
+  #
+  # {SignalWire::AIChatClient} speaks the standard SignalWire front-door protocol:
+  # HTTP Basic +project:api_token+ with the space in the hostname —
+  # +POST https://{space}.signalwire.com/api/ai/chat+ — carrying a JSON-RPC 2.0
+  # body whose params are pure payload (identity NEVER appears in the body; it
+  # rides the Basic-auth header only).
+  #
+  # A +chat+ call awaits a full LLM round trip (seconds, not milliseconds). The
+  # service streams keepalive whitespace ahead of a slow response body (proxy
+  # read-timeout protection), so liveness is byte-driven rather than wall-clock:
+  # there is no total-request timeout an idle turn could trip — only a per-read
+  # idle timeout, mirroring the python reference's
+  # +aiohttp.ClientTimeout(total=None, connect=10, sock_read=60)+. Leading
+  # whitespace is valid JSON, so the buffered +JSON.parse+ is unaffected.
+  #
+  # Mirrors the python reference +signalwire.ai_chat.AIChatClient+.
+  #
+  #   require 'signalwire/ai_chat'
+  #
+  #   client = SignalWire::AIChatClient.new(space: 'myspace') # env supplies creds
+  #   client.create_conversation('conv-1', config_url: CONFIG_URL)
+  #   reply = client.chat('conv-1', 'hello')
+  #   puts reply.text
+  module AIChat
+    # Default endpoint path appended to a +space+-derived base URL.
+    DEFAULT_PATH = '/api/ai/chat'
+
+    # Connect timeout (seconds) — a bounded TCP/TLS handshake. Mirrors the python
+    # reference's +connect=10+.
+    DEFAULT_CONNECT_TIMEOUT_SECONDS = 10
+
+    # Idle read timeout (seconds) for a single request. The service streams
+    # keepalive whitespace roughly every 10s, so this bounds true byte-silence (a
+    # dead connection), NOT total turn length — mirroring the python reference's
+    # +sock_read=60+. Net::HTTP's +read_timeout+ is per-read (it resets on each
+    # received chunk), so the streaming proxy's heartbeat keeps a live-but-slow
+    # turn alive while a truly dead connection is severed after this many seconds
+    # of silence. A total wall-clock cap is deliberately absent — a slow-but-live
+    # turn must never be severed by the client.
+    DEFAULT_READ_IDLE_TIMEOUT_SECONDS = 60
+
+    # ── Errors ─────────────────────────────────────────────────────────
+
+    # Base error for AI Chat service failures. Every typed subclass carries the
+    # JSON-RPC error +code+ (or +nil+ when the failure rode the success envelope,
+    # as with {SummaryError}) and the server +message+.
+    #
+    # A member of the +SignalWire::Error+ family, so a caller can rescue the whole
+    # SDK with +rescue SignalWire::Error+; catch this one family
+    # (+rescue SignalWire::AIChat::AIChatError+) for every AI-Chat failure and
+    # branch on +#code+ or the subclass type.
+    class AIChatError < SignalWire::Error
+      # JSON-RPC error code, or +nil+ when the failure rode the success envelope.
+      attr_reader :code
+
+      # The server-provided error message (without the +[code]+ prefix).
+      attr_reader :server_message
+
+      def initialize(code, message)
+        @code = code
+        @server_message = message
+        super("[#{code}] #{message}")
+      end
+    end
+
+    # Missing/rejected identity (HTTP 401 / JSON-RPC -32009).
+    class AuthenticationError < AIChatError; end
+
+    # The conversation does not exist in this project (-32001).
+    class ConversationNotFoundError < AIChatError; end
+
+    # Project or conversation rate limit hit (-32005 / -32006).
+    class RateLimitError < AIChatError; end
+
+    # Another message is being processed for this conversation (-32007).
+    class ChatInProgressError < AIChatError; end
+
+    # Summary generation failed. +summarize+ returns EXACTLY ONE of +{summary}+
+    # (success) or +{error}+ (generation failed), and the failure rides the
+    # JSON-RPC *success* envelope — not an +error+ object — so it never reaches
+    # the error-code mapping. Surfaced here so a failed summary can't masquerade
+    # as an empty string. +code+ is +nil+ (no JSON-RPC code).
+    class SummaryError < AIChatError; end
+
+    # JSON-RPC error code → the typed error class it maps to. An unmapped code
+    # falls to the base {AIChatError}.
+    ERROR_BY_CODE = {
+      -32_001 => ConversationNotFoundError,
+      -32_005 => RateLimitError,
+      -32_006 => RateLimitError,
+      -32_007 => ChatInProgressError,
+      -32_009 => AuthenticationError
+    }.freeze
+
+    # ── Response models ────────────────────────────────────────────────
+
+    # Result of {AIChatClient#create_conversation}.
+    ConversationInfo = Struct.new(:id, :status, :initial_message, keyword_init: true)
+
+    # Result of {AIChatClient#chat}.
+    ChatResponse = Struct.new(:text, :conversation_id, :user_event, keyword_init: true)
+
+    # Result of {AIChatClient#log}.
+    ChatLog = Struct.new(:messages, :call_timeline, keyword_init: true)
+  end
+
+  # Client for the SignalWire AI Chat service. See {SignalWire::AIChat} for the
+  # protocol overview and the error family / response models.
+  class AIChatClient
+    include AIChat
+
+    # AI-Chat User-Agent. Product token stays stable at +signalwire-ruby+; the
+    # version segment is the real SDK version so it can never drift from a
+    # hardcoded literal (mirrors the REST client's USER_AGENT).
+    USER_AGENT = "signalwire-ruby/#{SignalWire::VERSION}".freeze
+
+    # Fully-qualified endpoint URL requests are POSTed to.
+    attr_reader :url
+
+    # +project+ / +token+ default to the +SIGNALWIRE_PROJECT_ID+ /
+    # +SIGNALWIRE_API_TOKEN+ environment variables. The target URL resolves in
+    # order:
+    #   1. an explicit +url:+ (used verbatim, highest precedence);
+    #   2. +RAILS_DEV_MODE+ when it holds a real URL (it doubles as the service's
+    #      persona switch, so a plain boolean like "true"/"1" means "on" WITHOUT
+    #      carrying a URL and does NOT override the target);
+    #   3. +https://{space}.signalwire.com/api/ai/chat+ from +space:+ (or
+    #      +SIGNALWIRE_SPACE+).
+    #
+    # +connect_timeout+ / +read_idle_timeout+ default to
+    # {AIChat::DEFAULT_CONNECT_TIMEOUT_SECONDS} /
+    # {AIChat::DEFAULT_READ_IDLE_TIMEOUT_SECONDS}; the read timeout is per-read
+    # byte-silence (see {AIChat::DEFAULT_READ_IDLE_TIMEOUT_SECONDS}), NOT a total
+    # turn cap. A +read_idle_timeout+ of +0+/+nil+ disables the read timeout.
+    def initialize(project: nil, token: nil, space: nil, url: nil,
+                   connect_timeout: DEFAULT_CONNECT_TIMEOUT_SECONDS,
+                   read_idle_timeout: DEFAULT_READ_IDLE_TIMEOUT_SECONDS)
+      @project = require_project(project)
+      @token   = token || ENV.fetch('SIGNALWIRE_API_TOKEN', '')
+      space    ||= ENV.fetch('SIGNALWIRE_SPACE', '')
+
+      @url = self.class.resolve_url(url, space)
+      @auth_header = "Basic #{Base64.strict_encode64("#{@project}:#{@token}")}"
+      @connect_timeout = connect_timeout
+      @read_idle_timeout = read_idle_timeout
+      @request_counter = 0
+    end
+
+    # Redacted inspect: NEVER print the raw API token or the derived Basic-auth
+    # header (which embeds the token) — the default #inspect dumps every ivar,
+    # leaking the token into logs / crash dumps / a REPL session.
+    def inspect
+      "#<#{self.class.name} url=#{@url.inspect} project=#{@project.inspect} token=[REDACTED]>"
+    end
+    alias to_s inspect
+
+    # Resolve the target URL (see #initialize). Public for testability; static —
+    # takes no client state.
+    def self.resolve_url(url, space)
+      return url if url && !url.empty?
+
+      dev_url = ENV.fetch('RAILS_DEV_MODE', '').strip
+      # RAILS_DEV_MODE doubles as the service's persona switch, so plain booleans
+      # mean "on" without carrying a URL — only a real URL-looking value overrides
+      # the target here.
+      booleans = %w[false 0 no off true 1 yes on]
+      return dev_url if !dev_url.empty? && !booleans.include?(dev_url.downcase)
+
+      return "https://#{space}.signalwire.com#{DEFAULT_PATH}" if space && !space.empty?
+
+      raise ArgumentError,
+            'No service URL: provide url:, set RAILS_DEV_MODE to a full URL, ' \
+            'or provide space: / SIGNALWIRE_SPACE.'
+    end
+
+    # ── API methods ──────────────────────────────────────────────────
+
+    # Create a conversation (or, with +reinit+, reinitialize an existing one) and
+    # optionally send its opening user message. Returns a {AIChat::ConversationInfo}.
+    def create_conversation(conversation_id, config_url:, user_message: nil,
+                            timeout: nil, user_metadata: nil, reinit: false)
+      params = { 'id' => conversation_id, 'config_url' => config_url }.merge(
+        optional('user_message' => user_message, 'conversation_timeout' => timeout,
+                 'user_meta_data' => user_metadata, 'reinit' => (true if reinit))
+      )
+      result = request('create_conversation', params)
+      ConversationInfo.new(
+        id: conversation_id,
+        status: result['status'].is_a?(String) ? result['status'] : 'created',
+        initial_message: result['initial_message']
+      )
+    end
+
+    # Send a message and await a full LLM round trip. Returns a
+    # {AIChat::ChatResponse}.
+    #
+    # Passing +config_url+ auto-creates the conversation if it doesn't exist yet;
+    # +timeout+ and +reinit+ apply to that auto-create, with the same meaning as
+    # on {#create_conversation}. Expect seconds — the turn awaits the model.
+    def chat(conversation_id, message, role: 'user', config_url: nil,
+             user_metadata: nil, timeout: nil, reinit: false)
+      params = { 'id' => conversation_id, 'message' => message, 'role' => role }.merge(
+        optional('config_url' => config_url, 'user_meta_data' => user_metadata,
+                 'conversation_timeout' => timeout, 'reinit' => (true if reinit))
+      )
+      result = request('chat', params)
+      ChatResponse.new(
+        text: result['response'].is_a?(String) ? result['response'] : '',
+        conversation_id: conversation_id,
+        user_event: result['user_event'].is_a?(Hash) ? result['user_event'] : nil
+      )
+    end
+
+    # End a conversation (triggers server-side post-processing / archival).
+    # Returns +true+ when the service reported the conversation ended.
+    def end(conversation_id)
+      result = request('end_conversation', { 'id' => conversation_id })
+      result['status'] == 'ended'
+    end
+
+    # Permanently delete a conversation and its data. Idempotent. Returns +true+
+    # when the service reported the conversation deleted.
+    def delete(conversation_id)
+      result = request('delete', { 'id' => conversation_id })
+      result['status'] == 'deleted'
+    end
+
+    # Return the full message history plus the call timeline as a
+    # {AIChat::ChatLog}.
+    def log(conversation_id)
+      result = request('chat_log', { 'id' => conversation_id })
+      ChatLog.new(
+        messages: result['chat_log'].is_a?(Array) ? result['chat_log'] : [],
+        call_timeline: result['call_timeline'].is_a?(Array) ? result['call_timeline'] : []
+      )
+    end
+
+    # Return an AI summary of the conversation (rate limited server-side).
+    #
+    # The service returns EXACTLY ONE of +{summary}+ or +{error}+ — BOTH on the
+    # success envelope — so a failed generation surfaces as a raised
+    # {AIChat::SummaryError}, NEVER as an empty string. Optional +summary_prompt+
+    # and sampling params (+temperature+/+top_p+/+frequency_penalty+/
+    # +presence_penalty+/+max_tokens+) ride on the wire when given.
+    def summarize(conversation_id, summary_prompt: nil, temperature: nil, top_p: nil,
+                  frequency_penalty: nil, presence_penalty: nil, max_tokens: nil)
+      params = { 'id' => conversation_id }.merge(
+        optional('summary_prompt' => summary_prompt, 'temperature' => temperature, 'top_p' => top_p,
+                 'frequency_penalty' => frequency_penalty, 'presence_penalty' => presence_penalty,
+                 'max_tokens' => max_tokens)
+      )
+      result = request('summarize', params)
+      raise SummaryError.new(nil, result['error'].to_s) if result.key?('error') && !result.key?('summary')
+
+      summary = result['summary']
+      summary.is_a?(String) ? summary : summary.to_s
+    end
+
+    private
+
+    # The project id from the argument or +SIGNALWIRE_PROJECT_ID+; raises when
+    # neither supplies one (project is the Basic-auth username, always required).
+    def require_project(project)
+      resolved = project || ENV.fetch('SIGNALWIRE_PROJECT_ID', '')
+      return resolved unless resolved.nil? || resolved.empty?
+
+      raise ArgumentError,
+            'project is required. Provide it as an argument or set the ' \
+            'SIGNALWIRE_PROJECT_ID environment variable.'
+    end
+
+    # Drop keys whose value is +nil+, so only the wire params the caller actually
+    # supplied ride on the request (the SDK never sends an unset optional param).
+    def optional(pairs)
+      pairs.compact
+    end
+
+    # POST one JSON-RPC call and return its decoded +result+ object (a Hash).
+    #
+    # Success/failure is decided by the JSON-RPC BODY, not the HTTP status: the
+    # service's keepalive heartbeat commits +200+ before the turn's outcome is
+    # known, so a slow error can arrive as +200 + {"error": …}+. Never gate on the
+    # HTTP status here (mirrors the python reference).
+    #
+    # Raises {AIChat::AIChatError} (or a typed subclass) when the body carries
+    # +error+.
+    def request(method, params)
+      @request_counter += 1
+      payload = { 'jsonrpc' => '2.0', 'method' => method, 'params' => params,
+                  'id' => "req-#{@request_counter}" }
+      response = perform(payload)
+      body = parse_body(response)
+
+      raise_for_error(body['error']) if body.is_a?(Hash) && !body['error'].nil?
+
+      result = body.is_a?(Hash) ? body['result'] : nil
+      result.is_a?(Hash) ? result : {}
+    end
+
+    # Buffer the whole body then parse. Leading keepalive whitespace is valid
+    # JSON, so a plain parse handles it — no need to strip.
+    def parse_body(response)
+      JSON.parse(response.body || '')
+    rescue JSON::ParserError
+      raise AIChatError.new(response.code.to_i, "non-JSON response (HTTP #{response.code})")
+    end
+
+    # Raise the typed error for a JSON-RPC +error+ object. An unmapped (or absent)
+    # code falls to the base {AIChat::AIChatError}.
+    def raise_for_error(error)
+      error = {} unless error.is_a?(Hash)
+      code = error['code'].is_a?(Integer) ? error['code'] : nil
+      klass = code ? (ERROR_BY_CODE[code] || AIChatError) : AIChatError
+      raise klass.new(code, error['message'] || '')
+    end
+
+    # Issue one HTTP POST to the endpoint.
+    def perform(payload)
+      uri = URI(@url)
+      req = build_request(uri, payload)
+      build_http(uri).request(req)
+    end
+
+    # Build the Net::HTTP transport. +read_timeout+ is per-read byte-silence
+    # (Net::HTTP resets it on each received chunk), NOT a total turn cap — a
+    # live-but-slow turn kept alive by the proxy heartbeat never trips it.
+    def build_http(uri)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == 'https'
+      http.open_timeout = @connect_timeout if @connect_timeout
+      http.read_timeout = @read_idle_timeout if @read_idle_timeout&.positive?
+      http.max_retries = 0
+      http
+    end
+
+    def build_request(uri, payload)
+      req = Net::HTTP::Post.new(uri)
+      req['Authorization'] = @auth_header
+      req['Content-Type']  = 'application/json'
+      req['Accept']        = 'application/json'
+      req['User-Agent']    = USER_AGENT
+      req.body = JSON.generate(payload)
+      req
+    end
+  end
+end

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -341,49 +341,49 @@
                 },
                 {
                   "name": "name",
-                  "type": "any",
+                  "type": "string",
                   "kind": "keyword",
                   "required": false,
                   "default": null
                 },
                 {
                   "name": "route",
-                  "type": "any",
+                  "type": "string",
                   "kind": "keyword",
                   "required": false,
                   "default": null
                 },
                 {
                   "name": "system_prompt",
-                  "type": "any",
+                  "type": "optional<string>",
                   "kind": "keyword",
                   "required": false,
                   "default": null
                 },
                 {
                   "name": "voice_id",
-                  "type": "any",
+                  "type": "string",
                   "kind": "keyword",
                   "required": false,
                   "default": null
                 },
                 {
                   "name": "temperature",
-                  "type": "any",
+                  "type": "float",
                   "kind": "keyword",
                   "required": false,
                   "default": null
                 },
                 {
                   "name": "top_p",
-                  "type": "any",
+                  "type": "float",
                   "kind": "keyword",
                   "required": false,
                   "default": null
                 },
                 {
                   "name": "max_tokens",
-                  "type": "any",
+                  "type": "int",
                   "kind": "keyword",
                   "required": false,
                   "default": null
@@ -415,21 +415,21 @@
                 },
                 {
                   "name": "temperature",
-                  "type": "any",
+                  "type": "optional<float>",
                   "kind": "keyword",
                   "required": false,
                   "default": null
                 },
                 {
                   "name": "top_p",
-                  "type": "any",
+                  "type": "optional<float>",
                   "kind": "keyword",
                   "required": false,
                   "default": null
                 },
                 {
                   "name": "max_tokens",
-                  "type": "any",
+                  "type": "optional<int>",
                   "kind": "keyword",
                   "required": false,
                   "default": null
@@ -445,7 +445,7 @@
                 },
                 {
                   "name": "model",
-                  "type": "any",
+                  "type": "string",
                   "required": true
                 }
               ],
@@ -459,7 +459,7 @@
                 },
                 {
                   "name": "temperature",
-                  "type": "any",
+                  "type": "float",
                   "required": true
                 }
               ],
@@ -505,7 +505,7 @@
                 },
                 {
                   "name": "voice_id",
-                  "type": "any",
+                  "type": "string",
                   "required": true
                 }
               ],
@@ -519,6 +519,410 @@
                 }
               ],
               "returns": "any"
+            }
+          }
+        }
+      }
+    },
+    "signalwire.ai_chat.client": {
+      "classes": {
+        "AIChatClient": {
+          "methods": {
+            "__init__": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "project",
+                  "type": "optional<string>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "token",
+                  "type": "optional<string>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "space",
+                  "type": "optional<string>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "url",
+                  "type": "optional<string>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "connect_timeout",
+                  "type": "any",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "read_idle_timeout",
+                  "type": "any",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                }
+              ],
+              "returns": "void"
+            },
+            "chat": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "conversation_id",
+                  "type": "string",
+                  "required": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": true
+                },
+                {
+                  "name": "role",
+                  "type": "string",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "config_url",
+                  "type": "optional<string>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "user_metadata",
+                  "type": "optional<dict<string,any>>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "timeout",
+                  "type": "any",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "reinit",
+                  "type": "any",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                }
+              ],
+              "returns": "any"
+            },
+            "create_conversation": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "conversation_id",
+                  "type": "string",
+                  "required": true
+                },
+                {
+                  "name": "config_url",
+                  "type": "string",
+                  "kind": "keyword",
+                  "required": true
+                },
+                {
+                  "name": "user_message",
+                  "type": "optional<string>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "timeout",
+                  "type": "optional<int>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "user_metadata",
+                  "type": "optional<dict<string,any>>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "reinit",
+                  "type": "bool",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                }
+              ],
+              "returns": "any"
+            },
+            "delete": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "conversation_id",
+                  "type": "string",
+                  "required": true
+                }
+              ],
+              "returns": "any"
+            },
+            "end": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "conversation_id",
+                  "type": "string",
+                  "required": true
+                }
+              ],
+              "returns": "any"
+            },
+            "inspect": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                }
+              ],
+              "returns": "any"
+            },
+            "log": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "conversation_id",
+                  "type": "string",
+                  "required": true
+                }
+              ],
+              "returns": "any"
+            },
+            "summarize": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "conversation_id",
+                  "type": "string",
+                  "required": true
+                },
+                {
+                  "name": "summary_prompt",
+                  "type": "optional<string>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "temperature",
+                  "type": "any",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "top_p",
+                  "type": "any",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "frequency_penalty",
+                  "type": "any",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "presence_penalty",
+                  "type": "any",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "max_tokens",
+                  "type": "any",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                }
+              ],
+              "returns": "any"
+            },
+            "to_s": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                }
+              ],
+              "returns": "any"
+            },
+            "url": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                }
+              ],
+              "returns": "any"
+            }
+          }
+        },
+        "AIChatError": {
+          "methods": {
+            "__init__": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "code",
+                  "type": "optional<int>",
+                  "required": true
+                },
+                {
+                  "name": "message",
+                  "type": "string",
+                  "required": true
+                }
+              ],
+              "returns": "void"
+            }
+          }
+        },
+        "ChatLog": {
+          "methods": {
+            "__init__": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "messages",
+                  "type": "list<dict<string,any>>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "call_timeline",
+                  "type": "list<dict<string,any>>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                }
+              ],
+              "returns": "void"
+            }
+          }
+        },
+        "ChatResponse": {
+          "methods": {
+            "__init__": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "text",
+                  "type": "string",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "conversation_id",
+                  "type": "string",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "user_event",
+                  "type": "optional<dict<string,any>>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                }
+              ],
+              "returns": "void"
+            }
+          }
+        },
+        "ConversationInfo": {
+          "methods": {
+            "__init__": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                },
+                {
+                  "name": "id",
+                  "type": "string",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "status",
+                  "type": "string",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                },
+                {
+                  "name": "initial_message",
+                  "type": "optional<string>",
+                  "kind": "keyword",
+                  "required": false,
+                  "default": null
+                }
+              ],
+              "returns": "void"
             }
           }
         }
@@ -36772,6 +37176,10 @@
             "serverless": {
               "params": [],
               "returns": "any"
+            },
+            "suppress_run": {
+              "params": [],
+              "returns": "any"
             }
           }
         }
@@ -39326,8 +39734,8 @@
                   "kind": "self"
                 },
                 {
-                  "name": "_document",
-                  "type": "any",
+                  "name": "document",
+                  "type": "dict<string,any>",
                   "required": true
                 }
               ],

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -633,6 +633,15 @@
               ],
               "returns": "any"
             },
+            "close": {
+              "params": [
+                {
+                  "name": "self",
+                  "kind": "self"
+                }
+              ],
+              "returns": "any"
+            },
             "create_conversation": {
               "params": [
                 {

--- a/port_signatures.json
+++ b/port_signatures.json
@@ -618,14 +618,14 @@
                 },
                 {
                   "name": "timeout",
-                  "type": "any",
+                  "type": "optional<integer>",
                   "kind": "keyword",
                   "required": false,
                   "default": null
                 },
                 {
                   "name": "reinit",
-                  "type": "any",
+                  "type": "boolean",
                   "kind": "keyword",
                   "required": false,
                   "default": null

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_from": "signalwire-ruby @ a882f7b12006e489def563b525ec09b3f0b7a172",
+  "generated_from": "signalwire-ruby @ 51b233a67e7ec2f255ae77a7e6fc1fd6661868d9",
   "modules": {
     "signalwire": {
       "classes": {},
@@ -47,6 +47,31 @@
           "set_voice",
           "to_s"
         ]
+      },
+      "functions": []
+    },
+    "signalwire.ai_chat.client": {
+      "classes": {
+        "AIChatClient": [
+          "__init__",
+          "chat",
+          "create_conversation",
+          "delete",
+          "end",
+          "log",
+          "summarize"
+        ],
+        "AIChatError": [
+          "__init__"
+        ],
+        "AuthenticationError": [],
+        "ChatInProgressError": [],
+        "ChatLog": [],
+        "ChatResponse": [],
+        "ConversationInfo": [],
+        "ConversationNotFoundError": [],
+        "RateLimitError": [],
+        "SummaryError": []
       },
       "functions": []
     },

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_from": "signalwire-ruby @ 51b233a67e7ec2f255ae77a7e6fc1fd6661868d9",
+  "generated_from": "signalwire-ruby @ 540083fb912f02fe4cc25ac09599d92b1c00192d",
   "modules": {
     "signalwire": {
       "classes": {},
@@ -55,6 +55,7 @@
         "AIChatClient": [
           "__init__",
           "chat",
+          "close",
           "create_conversation",
           "delete",
           "end",

--- a/port_surface.json
+++ b/port_surface.json
@@ -1,5 +1,5 @@
 {
-  "generated_from": "signalwire-ruby @ 540083fb912f02fe4cc25ac09599d92b1c00192d",
+  "generated_from": "signalwire-ruby @ faf7f643764b0ed79ef4ba074be627c927be2659",
   "modules": {
     "signalwire": {
       "classes": {},

--- a/scripts/enumerate_signatures.py
+++ b/scripts/enumerate_signatures.py
@@ -348,6 +348,75 @@ def apply_sig_free_function_projections(out_modules: dict) -> None:
                 target.setdefault(m, sig)
 
 
+# The AI-Chat response models are Ruby ``Struct.new(..., keyword_init: true)``
+# value types — the idiomatic analog of the reference's ``@dataclass``
+# ConversationInfo / ChatResponse / ChatLog. A Struct's constructor params are
+# invisible to Method#parameters reflection (the fields surface only as zero-arg
+# READERS), and it auto-generates machinery (``new`` / ``members`` /
+# ``keyword_init`` / ``inspect``) the reference dataclass doesn't have. Rebuild
+# each class's signature to the ONE method the reference records — a keyword
+# ``__init__`` whose params ARE the Struct fields — sourced from the reflected
+# field readers (so a real field drop/rename still surfaces as drift), and drop
+# the machinery. The reference-param-type projection (run next) attaches the
+# concrete field types by name. Keyed by (module, class) -> ordered field names
+# (Struct field order = the reference __init__ positional order).
+AI_CHAT_STRUCT_FIELDS: dict[tuple, list[str]] = {
+    ("signalwire.ai_chat.client", "ConversationInfo"): ["id", "status", "initial_message"],
+    ("signalwire.ai_chat.client", "ChatResponse"): ["text", "conversation_id", "user_event"],
+    ("signalwire.ai_chat.client", "ChatLog"): ["messages", "call_timeline"],
+}
+
+# Ruby-idiom accessors/methods on the AI-Chat client family the reference records
+# as plain instance ATTRIBUTES or a PRIVATE method — no reference surface member
+# to compare against, so drop them (mirrors enumerate_surface.rb's
+# SURFACE_MEMBER_DROPS). Keyed (module, class) -> method names to remove.
+AI_CHAT_METHOD_DROPS: dict[tuple, set[str]] = {
+    # resolve_url mirrors the reference's PRIVATE ``_resolve_url`` @staticmethod
+    # (dropped from the reference surface by its leading ``_``); Ruby exposes the
+    # same helper public for testability.
+    ("signalwire.ai_chat.client", "AIChatClient"): {"resolve_url"},
+    # #code / #server_message are attr_readers over the reference's
+    # ``self.code`` / message instance attributes set in ``__init__``.
+    ("signalwire.ai_chat.client", "AIChatError"): {"code", "server_message"},
+}
+
+
+def synth_ai_chat_struct_inits(out_modules: dict) -> None:
+    """Rebuild the AI-Chat Struct value models to a single keyword ``__init__``
+    (params = the reflected Struct field readers) and drop the Struct machinery;
+    also drop the client-family Ruby-idiom accessors the reference records as
+    attributes/private. In place."""
+    for (mod, cls), fields in AI_CHAT_STRUCT_FIELDS.items():
+        entry = out_modules.get(mod, {}).get("classes", {}).get(cls)
+        if not entry:
+            continue
+        methods = entry.get("methods", {})
+        # Verify each declared field is present as a reflected zero-arg reader —
+        # a real Struct field drop/rename then re-surfaces as drift here.
+        readers = [
+            f for f in fields
+            if f in methods and not _has_value_params(methods[f])
+        ]
+        params = [{"name": "self", "kind": "self"}] + [
+            {"name": f, "type": "any", "kind": "keyword", "required": False, "default": None}
+            for f in readers
+        ]
+        entry["methods"] = {"__init__": {"params": params, "returns": "void"}}
+
+    for (mod, cls), drops in AI_CHAT_METHOD_DROPS.items():
+        entry = out_modules.get(mod, {}).get("classes", {}).get(cls)
+        if not entry:
+            continue
+        for m in drops:
+            entry.get("methods", {}).pop(m, None)
+
+
+def _has_value_params(sig: dict) -> bool:
+    """True if the method takes any non-receiver param (i.e. it is not a plain
+    zero-arg reader)."""
+    return any(p.get("kind") not in ("self", "cls") for p in sig.get("params", []))
+
+
 def apply_hand_param_renames(out_modules: dict) -> None:
     """Rewrite Ruby-idiom hand-written param identifiers to the reference name so
     the projection + diff compare EQUAL (see HAND_PARAM_RENAMES). In place."""
@@ -574,6 +643,22 @@ RUBY_TO_PYTHON_MODULE_OVERRIDES = {
     "SignalWire::Relay::AIEvent": "signalwire.relay.event",
     "SignalWire::Relay::RelayEvent": "signalwire.relay.event",
     "SignalWire::Relay::Message": "signalwire.relay.message",
+    # AI Chat: the reference collapses the client, its typed error family, and
+    # the response models into one module signalwire.ai_chat.client. Ruby splits
+    # the client (top-level SignalWire::AIChatClient) from the error/model family
+    # (nested under SignalWire::AIChat::*); pin every one to the reference module
+    # so the surface + signature gates route them identically (mirrors
+    # enumerate_surface.rb's auto-resolve of these unique class names).
+    "SignalWire::AIChatClient": "signalwire.ai_chat.client",
+    "SignalWire::AIChat::AIChatError": "signalwire.ai_chat.client",
+    "SignalWire::AIChat::AuthenticationError": "signalwire.ai_chat.client",
+    "SignalWire::AIChat::ConversationNotFoundError": "signalwire.ai_chat.client",
+    "SignalWire::AIChat::RateLimitError": "signalwire.ai_chat.client",
+    "SignalWire::AIChat::ChatInProgressError": "signalwire.ai_chat.client",
+    "SignalWire::AIChat::SummaryError": "signalwire.ai_chat.client",
+    "SignalWire::AIChat::ConversationInfo": "signalwire.ai_chat.client",
+    "SignalWire::AIChat::ChatResponse": "signalwire.ai_chat.client",
+    "SignalWire::AIChat::ChatLog": "signalwire.ai_chat.client",
     # RequestOptions envelope (plan 4.2): route the value type to the
     # reference module signalwire.rest._request_options. Its helper classes
     # (EffectiveOptions/AbortSignal) mirror that module's PRIVATE
@@ -1057,6 +1142,7 @@ def collect(raw: dict) -> dict:
     apply_sig_method_aliases(out_modules)
     apply_sig_method_donors(out_modules)
     apply_sig_free_function_projections(out_modules)
+    synth_ai_chat_struct_inits(out_modules)
     apply_hand_param_renames(out_modules)
     project_reference_param_types(out_modules)
     normalize_request_options_param_kind(out_modules)

--- a/scripts/enumerate_surface.rb
+++ b/scripts/enumerate_surface.rb
@@ -720,6 +720,41 @@ def surface_module?(name, seen_classes)
   true
 end
 
+# The AI-Chat response models are Ruby `Struct.new(..., keyword_init: true)`
+# value types — the idiomatic Ruby analog of the reference's `@dataclass`
+# ConversationInfo / ChatResponse / ChatLog. griffe records a dataclass's fields
+# as ATTRIBUTES, so the reference surface for each is METHOD-LESS. A Ruby Struct,
+# by contrast, auto-generates a pile of machinery (`[]`, `new`, `members`,
+# `keyword_init?`, `inspect`, plus a reader per field). Surface these classes
+# method-less — exactly like the generated payload/type DTOs — so each compares
+# EQUAL to the reference's method-less dataclass (emission covers the Struct
+# idiom; no PORT_ADDITIONS entry per accessor). Scoped by FQN so no other class
+# is affected.
+AI_CHAT_METHODLESS_CLASSES = %w[
+  SignalWire::AIChat::ConversationInfo
+  SignalWire::AIChat::ChatResponse
+  SignalWire::AIChat::ChatLog
+].freeze
+
+# Per-[module, class] surface members to DROP: a Ruby-idiom accessor/method that
+# the reference records as a plain instance ATTRIBUTE (not a surface method), so
+# there is no reference member to compare against — the idiomatic-Ruby getter is
+# folded away rather than surfaced as an addition. Applied after the alias pass.
+#   * AIChatClient#url        → the reference's `self.url` instance attribute;
+#   * AIChatClient#inspect/to_s → token-redacting Ruby object hooks (the reference
+#                                 AIChatClient defines no `__repr__`/`__str__`);
+#   * AIChatClient#resolve_url → the reference's PRIVATE `_resolve_url`
+#                                 @staticmethod (excluded from the reference
+#                                 surface by the leading `_`); Ruby exposes the
+#                                 same helper public for testability, so drop it
+#                                 to match the reference's private form;
+#   * AIChatError#code/#server_message → the reference's `self.code` / message
+#                                 instance attributes set in `__init__`.
+SURFACE_MEMBER_DROPS = {
+  ['signalwire.ai_chat.client', 'AIChatClient'] => %w[url inspect to_s resolve_url],
+  ['signalwire.ai_chat.client', 'AIChatError'] => %w[code server_message]
+}.freeze
+
 # A generated wire-type / read-side-payload class surfaces METHOD-LESS: the
 # reference records these as method-less type definitions (griffe: dataclass
 # fields are attributes, not surface methods). The SWML-verbs / post-prompt /
@@ -729,6 +764,7 @@ end
 # Scoped to the generated-payload/type FQN prefixes so no SDK class is affected.
 def generated_methodless_class?(ruby_fqn)
   return true if ruby_fqn.start_with?(GENERATED_TYPES_PREFIX)
+  return true if AI_CHAT_METHODLESS_CLASSES.include?(ruby_fqn)
 
   GENERATED_PAYLOAD_PREFIXES.each_key { |prefix| return true if ruby_fqn.start_with?(prefix) }
   false
@@ -741,10 +777,21 @@ def process_module(mod, name, modules, python_index)
     methods = generated_methodless_class?(name) ? [] : enumerate_methods(mod)
     methods = project_free_functions(name, methods, modules)
     methods = apply_method_aliases(target_mod, cls, methods)
+    methods = drop_idiom_members(target_mod, cls, methods)
     modules[target_mod]['classes'][cls] = methods
   else
     process_namespace_module(mod, name, modules)
   end
+end
+
+# Drop the per-[module, class] Ruby-idiom accessors the reference records as
+# plain instance attributes (SURFACE_MEMBER_DROPS). Applied after aliasing so the
+# names being dropped are already in their reference spelling.
+def drop_idiom_members(target_mod, cls, methods)
+  drops = SURFACE_MEMBER_DROPS[[target_mod, cls]]
+  return methods unless drops
+
+  methods - drops
 end
 
 # Apply the per-[module, class] Ruby-idiom -> reference method-name aliases,

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -231,6 +231,16 @@ sched_gate DOC-SURFACE desc="public YARD doc-comment coverage holds the .doc_sur
 sched_gate WIRED-MODES desc="run-ci exports every load-bearing strict-mode line declared in WIRED_MODES.md" \
     -- python3 "$PORTING_SDK_DIR/scripts/check_wired_modes.py" --port ruby --repo "$PORT_ROOT"
 
+# AI-CHAT (task #22, COORDINATED pass ruby:ai-chat-client <-> porting-sdk:ai-chat-client):
+# wire-behavioral gate for the AIChatClient. Drives bin/ai-chat-dump through the shared
+# ai_chat_corpus against porting-sdk's in-process mock_ai_chat and asserts the client
+# speaks the AI Chat JSON-RPC protocol per the vendored spec (ai-chat-specs/ai-chat.yaml).
+# The gate script (diff_port_ai_chat.py) + mock live on the porting-sdk `ai-chat-client`
+# branch, so during the coordinated pass PORTING_SDK_REF pins that branch and the gate
+# runs; on plain main it skip-passes until the branch merges.
+sched_gate AI-CHAT desc="AIChatClient speaks the AI Chat protocol per the vendored spec (mock_ai_chat wire-behavioral)" \
+    -- bash -c 'if [ -f "$1/scripts/diff_port_ai_chat.py" ]; then python3 "$1/scripts/diff_port_ai_chat.py" --port ruby --dump-cmd "ruby $2/bin/ai-chat-dump"; else echo "[ai-chat] diff_port_ai_chat.py not on porting-sdk main yet — skip-pass (coordinated-branch dep: porting-sdk ai-chat-client)"; fi' _ "$PORTING_SDK_DIR" "$PORT_ROOT"
+
 # GATE-INVENTORY NOTE (§2.16): §1.11b (GATE-INVENTORY freshness) is intentionally
 # NOT wired here. gen_gate_inventory.py resolves its reference port as a SIBLING
 # checkout (DEFAULT_REFERENCE=signalwire-typescript), which does not exist in a

--- a/tests/ai_chat_test.rb
+++ b/tests/ai_chat_test.rb
@@ -1,0 +1,316 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'socket'
+require 'json'
+require 'base64'
+
+ENV['SIGNALWIRE_LOG_MODE'] = 'off'
+
+require_relative '../lib/signalwire/ai_chat'
+
+# A tiny in-process HTTP server mirroring porting-sdk's mock_ai_chat responder:
+# it records every JSON-RPC request (method, params, Authorization header) and
+# replies with the canned success result — or, for a "__err_<code>" / a
+# "__summarize_error" sentinel id, the matching error / one_of-{error} branch.
+#
+# Running the REAL Net::HTTP path (not a stubbed transport) proves the client's
+# wire encoding, Basic-auth header, and buffered JSON parse end-to-end.
+class MockAIChat
+  # A recorded request the client put on the wire. :method mirrors the wire
+  # method field name (as MockTest's JournalEntry does), overriding Struct#method.
+  # rubocop:disable Lint/StructNewOverride
+  Recorded = Struct.new(:method, :params, :authorization, keyword_init: true)
+  # rubocop:enable Lint/StructNewOverride
+
+  CANNED = {
+    'create_conversation' => { 'status' => 'created', 'id' => 'conv-1', 'initial_message' => 'hello' },
+    'chat' => { 'response' => 'hi there', 'user_event' => { 'event_type' => 'demo', 'n' => 1 } },
+    'end_conversation' => { 'status' => 'ended', 'id' => 'conv-1' },
+    'delete' => { 'status' => 'deleted', 'id' => 'conv-1' },
+    'chat_log' => { 'chat_log' => [{ 'role' => 'user', 'content' => 'm' }], 'call_timeline' => [{ 't' => 1 }] },
+    'summarize' => { 'summary' => 'a concise summary' }
+  }.freeze
+
+  attr_reader :requests
+
+  def initialize
+    @server = TCPServer.new('127.0.0.1', 0)
+    @requests = []
+    @thread = Thread.new { serve_loop }
+  end
+
+  def url
+    "http://127.0.0.1:#{@server.addr[1]}/api/ai/chat"
+  end
+
+  def stop
+    @server.close
+    @thread.kill
+  end
+
+  private
+
+  def serve_loop
+    loop do
+      conn = @server.accept
+      handle(conn)
+    rescue IOError, Errno::EBADF
+      break
+    end
+  end
+
+  def handle(conn)
+    request_line = conn.gets
+    return conn.close if request_line.nil?
+
+    headers = read_headers(conn)
+    body = read_body(conn, headers)
+    auth = headers['authorization']
+    reply(conn, envelope(body, auth))
+  ensure
+    conn.close
+  end
+
+  def read_headers(conn)
+    headers = {}
+    while (line = conn.gets) && line != "\r\n"
+      k, v = line.split(':', 2)
+      headers[k.strip.downcase] = v.strip if v
+    end
+    headers
+  end
+
+  def read_body(conn, headers)
+    length = headers['content-length'].to_i
+    length.positive? ? conn.read(length) : ''
+  end
+
+  def envelope(raw, auth)
+    payload = JSON.parse(raw.empty? ? '{}' : raw)
+    params = payload['params'] || {}
+    @requests << Recorded.new(method: payload['method'], params: params, authorization: auth)
+    { 'jsonrpc' => '2.0', 'id' => payload['id'] }.merge(outcome(payload['method'], params['id']))
+  end
+
+  # The JSON-RPC outcome (error vs result) for one method + conversation id.
+  def outcome(method, id)
+    if id.is_a?(String) && id.start_with?('__err_')
+      return { 'error' => { 'code' => id.sub('__err_', '').to_i, 'message' => 'forced error' } }
+    end
+    if method == 'summarize' && id == '__summarize_error'
+      return { 'result' => { 'error' => 'Failed to generate summary' } }
+    end
+
+    { 'result' => CANNED.fetch(method, {}) }
+  end
+
+  def reply(conn, obj)
+    body = JSON.generate(obj)
+    conn.write("HTTP/1.1 200 OK\r\n")
+    conn.write("Content-Type: application/json\r\n")
+    conn.write("Content-Length: #{body.bytesize}\r\n")
+    conn.write("Connection: close\r\n\r\n")
+    conn.write(body)
+  end
+end
+
+# Identity keys that must never ride in the JSON-RPC params.
+FORBIDDEN_IN_PARAMS = %w[project_id project token api_token space_id space].freeze
+
+module AIChatTestHelper
+  def setup
+    @mock = MockAIChat.new
+  end
+
+  def teardown
+    @mock&.stop
+  end
+
+  def client(**)
+    SignalWire::AIChatClient.new(project: 'proj-1', token: 'tok-1', url: @mock.url, **)
+  end
+end
+
+class AIChatClientConstructionTest < Minitest::Test
+  def test_requires_a_project
+    saved = ENV.fetch('SIGNALWIRE_PROJECT_ID', nil)
+    ENV.delete('SIGNALWIRE_PROJECT_ID')
+    err = assert_raises(ArgumentError) { SignalWire::AIChatClient.new(url: 'http://x') }
+    assert_match(/project is required/, err.message)
+  ensure
+    ENV['SIGNALWIRE_PROJECT_ID'] = saved if saved
+  end
+
+  def test_builds_space_url_when_no_explicit_url
+    c = SignalWire::AIChatClient.new(project: 'p', token: 't', space: 'myspace')
+
+    assert_equal 'https://myspace.signalwire.com/api/ai/chat', c.url
+  end
+
+  def test_uses_explicit_url_verbatim
+    c = SignalWire::AIChatClient.new(project: 'p', token: 't', url: 'http://local/api/ai/chat')
+
+    assert_equal 'http://local/api/ai/chat', c.url
+  end
+
+  def test_raises_when_neither_url_nor_space_resolves
+    saved = ENV.fetch('SIGNALWIRE_SPACE', nil)
+    ENV.delete('SIGNALWIRE_SPACE')
+    err = assert_raises(ArgumentError) { SignalWire::AIChatClient.new(project: 'p', token: 't') }
+    assert_match(/No service URL/, err.message)
+  ensure
+    ENV['SIGNALWIRE_SPACE'] = saved if saved
+  end
+
+  def test_rails_dev_mode_boolean_does_not_override_target
+    # A plain boolean RAILS_DEV_MODE is the persona switch, not a URL — the target
+    # still comes from space.
+    saved = ENV.fetch('RAILS_DEV_MODE', nil)
+    ENV['RAILS_DEV_MODE'] = 'true'
+    c = SignalWire::AIChatClient.new(project: 'p', token: 't', space: 'myspace')
+
+    assert_equal 'https://myspace.signalwire.com/api/ai/chat', c.url
+  ensure
+    saved ? ENV['RAILS_DEV_MODE'] = saved : ENV.delete('RAILS_DEV_MODE')
+  end
+
+  def test_rails_dev_mode_url_overrides_target
+    saved = ENV.fetch('RAILS_DEV_MODE', nil)
+    ENV['RAILS_DEV_MODE'] = 'http://localhost:8080/'
+    c = SignalWire::AIChatClient.new(project: 'p', token: 't', space: 'myspace')
+
+    assert_equal 'http://localhost:8080/', c.url
+  ensure
+    saved ? ENV['RAILS_DEV_MODE'] = saved : ENV.delete('RAILS_DEV_MODE')
+  end
+
+  def test_inspect_redacts_token
+    c = SignalWire::AIChatClient.new(project: 'p', token: 'super-secret', url: 'http://x')
+
+    refute_match(/super-secret/, c.inspect)
+    assert_match(/\[REDACTED\]/, c.inspect)
+  end
+end
+
+class AIChatClientWireTest < Minitest::Test
+  include AIChatTestHelper
+
+  def test_basic_auth_username_is_project_identity_never_in_params
+    client.create_conversation('conv-1', config_url: 'http://cfg', timeout: 30, reinit: true)
+    req = @mock.requests.first
+
+    assert_match(/\ABasic /, req.authorization)
+    decoded = Base64.decode64(req.authorization.sub('Basic ', ''))
+
+    assert_equal 'proj-1:tok-1', decoded
+    FORBIDDEN_IN_PARAMS.each { |k| refute req.params.key?(k), "identity key #{k} leaked into params" }
+  end
+
+  def test_create_conversation_maps_timeout_and_decodes
+    info = client.create_conversation('conv-1', config_url: 'http://cfg', timeout: 30, reinit: true)
+    req = @mock.requests.first
+
+    assert_equal 'create_conversation', req.method
+    # timeout -> conversation_timeout on the wire; the whole param shape:
+    expected_params = { 'id' => 'conv-1', 'config_url' => 'http://cfg',
+                        'conversation_timeout' => 30, 'reinit' => true }
+    expected_info = SignalWire::AIChat::ConversationInfo.new(
+      id: 'conv-1', status: 'created', initial_message: 'hello'
+    )
+
+    assert_equal expected_params, req.params
+    assert_equal expected_info, info
+  end
+
+  def test_chat_sends_role_user_by_default_and_decodes
+    reply = client.chat('conv-1', 'hello', timeout: 30, reinit: true)
+    req = @mock.requests.first
+
+    assert_equal 'chat', req.method
+    expected_params = { 'id' => 'conv-1', 'message' => 'hello', 'role' => 'user',
+                        'conversation_timeout' => 30, 'reinit' => true }
+    expected_reply = SignalWire::AIChat::ChatResponse.new(
+      text: 'hi there', conversation_id: 'conv-1', user_event: { 'event_type' => 'demo', 'n' => 1 }
+    )
+
+    assert_equal expected_params, req.params
+    assert_equal expected_reply, reply
+  end
+
+  def test_end_returns_true_on_status_ended
+    assert_equal true, client.end('conv-1')
+    assert_equal 'end_conversation', @mock.requests.first.method
+  end
+
+  def test_delete_returns_true_on_status_deleted
+    assert_equal true, client.delete('conv-1')
+    assert_equal 'delete', @mock.requests.first.method
+  end
+
+  def test_log_decodes_messages_and_call_timeline
+    chat_log = client.log('conv-1')
+
+    assert_equal 'chat_log', @mock.requests.first.method
+    assert_equal [{ 'role' => 'user', 'content' => 'm' }], chat_log.messages
+    assert_equal [{ 't' => 1 }], chat_log.call_timeline
+  end
+
+  def test_summarize_returns_summary_on_summary_branch
+    assert_equal 'a concise summary', client.summarize('conv-1')
+  end
+
+  def test_summarize_passes_sampling_params_on_the_wire
+    client.summarize('conv-1', summary_prompt: 'be brief', temperature: 0.2, max_tokens: 64)
+    params = @mock.requests.first.params
+
+    assert_equal 'be brief', params['summary_prompt']
+    assert_in_delta 0.2, params['temperature']
+    assert_equal 64, params['max_tokens']
+  end
+end
+
+class AIChatSummarizeErrorBranchTest < Minitest::Test
+  include AIChatTestHelper
+
+  def test_raises_summary_error_never_returns_empty_string
+    assert_raises(SignalWire::AIChat::SummaryError) { client.summarize('__summarize_error') }
+  end
+
+  def test_raised_summary_error_carries_server_message_and_nil_code
+    err = assert_raises(SignalWire::AIChat::SummaryError) { client.summarize('__summarize_error') }
+    assert_nil err.code
+    assert_equal 'Failed to generate summary', err.server_message
+  end
+end
+
+class AIChatErrorMappingTest < Minitest::Test
+  include AIChatTestHelper
+
+  MAPPED = {
+    -32_001 => SignalWire::AIChat::ConversationNotFoundError,
+    -32_005 => SignalWire::AIChat::RateLimitError,
+    -32_006 => SignalWire::AIChat::RateLimitError,
+    -32_007 => SignalWire::AIChat::ChatInProgressError,
+    -32_009 => SignalWire::AIChat::AuthenticationError
+  }.freeze
+
+  def test_maps_each_code_to_its_typed_error_carrying_the_code
+    MAPPED.each do |code, klass|
+      err = assert_raises(klass) { client.chat("__err_#{code}", 'x') }
+      assert_kind_of SignalWire::AIChat::AIChatError, err
+      assert_equal code, err.code
+    end
+  end
+
+  def test_maps_an_unmapped_code_to_the_base_error
+    err = assert_raises(SignalWire::AIChat::AIChatError) { client.chat('__err_-32602', 'x') }
+    assert_instance_of SignalWire::AIChat::AIChatError, err
+    assert_equal(-32_602, err.code)
+  end
+
+  def test_ai_chat_error_is_part_of_the_signalwire_error_family
+    err = assert_raises(SignalWire::AIChat::ConversationNotFoundError) { client.chat('__err_-32001', 'x') }
+    assert_kind_of SignalWire::Error, err
+  end
+end

--- a/tests/ai_chat_test.rb
+++ b/tests/ai_chat_test.rb
@@ -191,6 +191,16 @@ class AIChatClientConstructionTest < Minitest::Test
     refute_match(/super-secret/, c.inspect)
     assert_match(/\[REDACTED\]/, c.inspect)
   end
+
+  def test_close_is_a_no_op_lifecycle_member
+    c = SignalWire::AIChatClient.new(project: 'p', token: 't', url: 'http://x')
+
+    # No persistent session/connection to release (Net::HTTP is per-request), so
+    # #close completes the lifecycle contract as a no-op and is safe to call
+    # repeatedly. Mirrors the reference AIChatClient.close.
+    assert_nil c.close
+    assert_nil c.close
+  end
 end
 
 class AIChatClientWireTest < Minitest::Test


### PR DESCRIPTION
## What

Idiomatic Ruby port of the SignalWire AI Chat client, proven GREEN against the shared cross-port wire-behavioral gate. Mirrors the python reference `signalwire.ai_chat.AIChatClient` exactly on the wire; expressed in Ruby idioms.

## Files

- **`lib/signalwire/ai_chat/client.rb`** + **`lib/signalwire/ai_chat.rb`** — `SignalWire::AIChatClient` (`require 'signalwire/ai_chat'`). Six methods (`create_conversation` / `chat` / `end` / `delete` / `log` / `summarize`) over JSON-RPC 2.0 to `POST /api/ai/chat`, HTTP Basic identity (project = username; identity NEVER in params). `Net::HTTP` transport with a bounded connect timeout + a per-read idle timeout (no total wall-clock cap a keepalive heartbeat can't reset), mirroring python's `connect=10` / `sock_read=60`. Typed error family under `SignalWire::Error`: `AIChatError` base (`#code` + `#server_message`) with `AuthenticationError` (-32009) / `ConversationNotFoundError` (-32001) / `RateLimitError` (-32005/-32006) / `ChatInProgressError` (-32007) / `SummaryError`. `summarize` **raises** `SummaryError` on the `{error}` one_of branch (which rides the success envelope, no JSON-RPC code) — never a silent empty string. Struct response models; token-redacted `#inspect`.
- **`bin/ai-chat-dump`** — the Ruby AI-CHAT dump program: reads `MOCK_AI_CHAT_URL`, drives every corpus step, emits one JSON object to stdout (stdout-only).
- **`tests/ai_chat_test.rb`** — 20 minitest cases against an in-process HTTP mock over the real `Net::HTTP` path, including the `summarize {error}` → `SummaryError` branch, the full error-code mapping + unmapped-code → base error, Basic-auth username = project, and identity-never-in-params.
- **`scripts/run-ci.sh`** — wires the `AI-CHAT` sched_gate (skip-passes until the gate lands on porting-sdk main), mirroring the TypeScript idiom.
- **`.rubocop.yml`** — registers `bin/ai-chat-dump` as a Layer-D dump program and `client.rb` as a 1:1 parity surface unit (same rationale as the REST `http_client.rb` entries).

## Verification (all RUN)

- **AI-CHAT gate GREEN** — `python3 scripts/diff_port_ai_chat.py --port ruby --dump-cmd 'ruby <repo>/bin/ai-chat-dump'` →
  `✓ AI-CHAT — ruby: client speaks the AI Chat protocol per the vendored spec.` (exit 0)
- **RED-proof** — making `summarize` swallow the `{error}` branch reds the gate on `summarize_failed` (`one_of 'error' branch was swallowed …`, exit 1); reverted → GREEN again.
- **Dump alone** — valid JSON-only stdout, exit 0, against a live `mock_ai_chat`.
- **Lint / format** — `rubocop` clean tree-wide: `run-lint.sh` and `run-format.sh --check` both report `1368 files inspected, no offenses detected`.
- **Tests** — new suite 20/20 green; `error_root_test` still green (no regression).

## Coordination

This is a COORDINATED pass: the gate + mock + corpus live on porting-sdk's `ai-chat-client` branch (unmerged). The `AI-CHAT` run-ci gate skip-passes on plain porting-sdk main and runs once that branch is pinned via `PORTING_SDK_REF`.

Coordinated-With: porting-sdk@ai-chat-client

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqhUoqrbptHNS3cypq9s6t
